### PR TITLE
Add shared content helpers and Disney sidebar

### DIFF
--- a/src/content/common.js
+++ b/src/content/common.js
@@ -1,0 +1,124 @@
+import { getApiEndpoint } from './../api.js';
+
+export const MEMO_SIDEBAR_ID = 'nf-memo-sidebar';
+
+export function detectService(host = window.location.hostname) {
+  if (host.includes('netflix.com')) return 'Netflix';
+  if (host.includes('primevideo.com')) return 'Prime Video';
+  if (host.includes('youtube.com')) return 'YouTube';
+  if (host.includes('disneyplus.com')) return 'Disney+';
+  if (host.includes('hulu.jp') || host.includes('hulu.com')) return 'Hulu';
+  return 'Unknown';
+}
+
+export function formatSeconds(seconds = 0) {
+  const sec = Math.max(0, Math.floor(seconds));
+  return `${Math.floor(sec / 60)}:${String(sec % 60).padStart(2, '0')}`;
+}
+
+export function sendData(dataToSend) {
+  return fetch(getApiEndpoint('receive'), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(dataToSend),
+  })
+    .then((response) => response.json())
+    .then((data) => {
+      console.log('Success:', data);
+      return data;
+    })
+    .catch((error) => {
+      console.error('Error:', error);
+      throw error;
+    });
+}
+
+export function openMemoSidebar({
+  data = {},
+  videoPlayer,
+  sidebarPct = 20,
+  sidebarTitle = '録画メモ',
+  onSave,
+  onClose,
+}) {
+  const player =
+    videoPlayer ||
+    document.querySelector('.watch-video--player-view') ||
+    document.querySelector('video')?.parentElement;
+  if (!player) return null;
+
+  document.getElementById(MEMO_SIDEBAR_ID)?.remove();
+
+  const originalWidth = player.style.width;
+  player.style.transition = 'width .3s';
+  player.style.width = `calc(100% - ${sidebarPct}%)`;
+
+  const sb = document.createElement('div');
+  sb.id = MEMO_SIDEBAR_ID;
+  sb.style.cssText = `
+    position:fixed;top:0;right:0;width:${sidebarPct}%;
+    height:100%;background:rgba(0,0,0,.85);padding:10px;
+    box-sizing:border-box;z-index:9999;display:flex;flex-direction:column;gap:8px;`;
+
+  const header = document.createElement('div');
+  header.style.cssText = 'display:flex;justify-content:space-between;align-items:center;';
+  const title = document.createElement('strong');
+  title.textContent = sidebarTitle;
+  const closeBtn = document.createElement('button');
+  closeBtn.textContent = '×';
+  closeBtn.style.cssText = 'background:red;color:#fff;border:none;cursor:pointer;';
+  const closeSidebar = () => {
+    player.style.width = originalWidth || '100%';
+    sb.remove();
+    onClose?.();
+  };
+  closeBtn.onclick = closeSidebar;
+  header.append(title, closeBtn);
+  sb.appendChild(header);
+
+  const infoBox = document.createElement('div');
+  infoBox.style.fontSize = '12px';
+  const start = Math.floor(data?.StartTime || 0);
+  const end = Math.floor(data?.EndTime || 0);
+  infoBox.innerHTML = `
+    <div><b>タイトル:</b> ${data?.title || '(不明)'}</div>
+    <div><b>エピソード:</b> ${data?.epnumber || '-'}</div>
+    <div><b>サービス:</b> ${data?.service || '-'}</div>
+    <div><b>開始:</b> ${formatSeconds(start)}</div>
+    <div><b>終了:</b> ${formatSeconds(end)}</div>
+    <div><b>URL:</b> ${data?.URL || location.href}</div>`;
+  sb.appendChild(infoBox);
+
+  const nameLabel = document.createElement('label');
+  nameLabel.style.cssText = 'font-size:12px;color:#000;';
+  nameLabel.textContent = '名前:';
+  const nameInput = document.createElement('input');
+  nameInput.style.cssText = 'width:100%;margin-top:4px;';
+  nameInput.value = data?.clipName || '';
+  nameLabel.appendChild(nameInput);
+  sb.appendChild(nameLabel);
+
+  const saveBtn = document.createElement('button');
+  saveBtn.textContent = '保存';
+  saveBtn.style.cssText = 'background:#00c853;border:none;color:#fff;padding:6px;cursor:pointer;';
+
+  saveBtn.onclick = () => {
+    const enriched = {
+      ...data,
+      clipName: nameInput.value.trim(),
+    };
+    const result = onSave ? onSave(enriched) : sendData(enriched);
+    Promise.resolve(result)
+      .catch((error) => console.error('保存エラー:', error))
+      .finally(() => {
+        videoPlayer?.play?.();
+        closeSidebar();
+      });
+  };
+  sb.appendChild(saveBtn);
+
+  document.body.appendChild(sb);
+  return sb;
+}

--- a/src/content/content.js
+++ b/src/content/content.js
@@ -3,7 +3,7 @@ import "../image/moreDetailSVG.js";
 import "../image/recordSVG.js";
 import "../image/LoopButtonSVG.js";
 import "./playClipNetflix.js";
-import { getApiEndpoint } from './../api.js';
+import { detectService, openMemoSidebar, sendData } from './common.js';
 
 (function() {
   const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
@@ -140,7 +140,11 @@ import { getApiEndpoint } from './../api.js';
           console.log("録画データ:", data);
           //動画を一時停止
           videoPlayer.pause();
-          openSidebar(data, videoPlayer); // サイドバーを開く
+          openMemoSidebar({
+            data,
+            videoPlayer,
+            onSave: (payload) => sendData(payload),
+          }); // サイドバーを開く
           init();
         } else {
           svgElement.setAttribute('color', window.COLOR_RECORDING);
@@ -188,115 +192,4 @@ import { getApiEndpoint } from './../api.js';
       svgElement.setAttribute('color', window.COLOR_DEFAULT);
     }
   });
-  /**
-   * 今いる動画サービスをホスト名から判定
-   * @returns {string} サービス名
-   */
-    function detectService() {
-      const host = window.location.hostname;
-      if (host.includes('netflix.com')) return 'Netflix';
-      if (host.includes('primevideo.com')) return 'Prime Video';
-      if (host.includes('youtube.com')) return 'YouTube';
-      if (host.includes('disneyplus.com')) return 'Disney+';
-      if (host.includes('hulu.jp') || host.includes('hulu.com')) return 'Hulu';
-      return 'Unknown';
-    }
-    function openSidebar(data, videoPlayer) {
-      const SIDEBAR_ID = "nf-memo-sidebar";
-      const SIDEBAR_PCT = 20;
-
-      const player = document.querySelector(".watch-video--player-view") || videoPlayer?.parentElement;
-      if (!player) return;
-
-      document.getElementById(SIDEBAR_ID)?.remove();
-
-      player.style.transition = "width .3s";
-      player.style.width = `calc(100% - ${SIDEBAR_PCT}%)`;
-
-      const sb = document.createElement("div");
-      sb.id = SIDEBAR_ID;
-      sb.style.cssText = `
-        position:fixed;top:0;right:0;width:${SIDEBAR_PCT}%;
-        height:100%;background:rgba(0,0,0,.85);padding:10px;
-        box-sizing:border-box;z-index:9999;display:flex;flex-direction:column;gap:8px;`;
-
-      const header = document.createElement("div");
-      header.style.cssText = "display:flex;justify-content:space-between;align-items:center;";
-      const title = document.createElement("strong");
-      title.textContent = "録画メモ";
-      const closeBtn = document.createElement("button");
-      closeBtn.textContent = "×";
-      closeBtn.style.cssText = "background:red;color:#fff;border:none;cursor:pointer;";
-      closeBtn.onclick = () => {
-        player.style.width = "100%";
-        sb.remove();
-      };
-      header.append(title, closeBtn);
-      sb.appendChild(header);
-
-      const infoBox = document.createElement("div");
-      infoBox.style.fontSize = "12px";
-      const start = Math.floor(data?.StartTime || 0);
-      const end = Math.floor(data?.EndTime || 0);
-      const formatTime = sec => `${Math.floor(sec / 60)}:${String(sec % 60).padStart(2, "0")}`;
-      infoBox.innerHTML = `
-        <div><b>タイトル:</b> ${data?.title || '(不明)'}</div>
-        <div><b>エピソード:</b> ${data?.epnumber || '-'}</div>
-        <div><b>サービス:</b> ${data?.service || '-'}</div>
-        <div><b>開始:</b> ${formatTime(start)}</div>
-        <div><b>終了:</b> ${formatTime(end)}</div>
-        <div><b>URL:</b> ${data?.URL || location.href}</div>`;
-      sb.appendChild(infoBox);
-
-      const nameLabel = document.createElement("label");
-      nameLabel.style.cssText = "font-size:12px;color:#000;";
-      nameLabel.textContent = "名前:";
-      const nameInput = document.createElement("input");
-      nameInput.style.cssText = "width:100%;margin-top:4px;";
-      nameLabel.appendChild(nameInput);
-      sb.appendChild(nameLabel);
-
-      const saveBtn = document.createElement("button");
-      saveBtn.textContent = "保存";
-      saveBtn.style.cssText = "background:#00c853;border:none;color:#fff;padding:6px;cursor:pointer;";
-
-      saveBtn.onclick = () => {
-        const enriched = {
-          ...data,
-          clipName: nameInput.value.trim(),
-        };
-        console.log("保存データ:", enriched);
-        sendData(enriched);
-        //alert("送信しました！");
-        videoPlayer.play(); // ← ここで再生
-        closeBtn.click();
-      };
-      sb.appendChild(saveBtn);
-
-      document.body.appendChild(sb);
-    }
-
-
-      /**
-   * データをサーバーに送信する関数
-   * @param {Object} dataToSend - 送信するデータ
-   */
-  function sendData(dataToSend) {
-    fetch(getApiEndpoint('receive'), {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(dataToSend),
-    })
-    .then((response) => response.json())
-    .then((data) => {
-      console.log('Success:', data);
-      // ユーザーに成功を通知するUIを追加可能
-    })
-    .catch((error) => {
-      console.error('Error:', error);
-      // ユーザーにエラーを通知するUIを追加可能
-    });
-  }
 })();

--- a/src/content/content.js
+++ b/src/content/content.js
@@ -144,6 +144,7 @@ import { detectService, openMemoSidebar, sendData } from './common.js';
             data,
             videoPlayer,
             onSave: (payload) => sendData(payload),
+            sidebarTitle: "Clipを追加 - Netflix",
           }); // サイドバーを開く
           init();
         } else {

--- a/src/content/content_disney.js
+++ b/src/content/content_disney.js
@@ -290,7 +290,7 @@ import { detectService, openMemoSidebar, sendData } from './common.js';
         data: payload,
         videoPlayer,
         onSave: (data) => sendData(data),
-        sidebarTitle: "録画メモ",
+        sidebarTitle: "Clipを追加 - Disney+",
       });
 
 

--- a/src/content/content_disney.js
+++ b/src/content/content_disney.js
@@ -1,4 +1,4 @@
-import { getApiEndpoint } from './../api.js';
+import { detectService, openMemoSidebar, sendData } from './common.js';
 (() => {
   const PLAYER_CONTROLS_SELECTOR = '.controls__footer__wrapper';
   const LEFT_CONTROLS_SELECTORS = [
@@ -261,6 +261,9 @@ import { getApiEndpoint } from './../api.js';
       const t = DPlusTime.get();
       const endtime = t?.currentSeconds;
 
+      const videoPlayer = document.querySelector('video');
+      videoPlayer?.pause();
+
       console.log("【2回目】終了時間:", endtime);
 
       const urldata = location.href;
@@ -272,15 +275,22 @@ import { getApiEndpoint } from './../api.js';
       console.log("start:", starttime, "end:", endtime);
       console.log("url:", urldata);
 
-      sendData({
+      const payload = {
         clipName: clipName,
         user: "testUser",
-        service: "disneyplus",
+        service: detectService(),
         StartTime: starttime,   // Netflix 形式に合わせる
         EndTime: endtime,       // Netflix 形式に合わせる
         URL: urldata,               // Netflix 形式に合わせる
         title: title,
         epnumber: subtitle,
+      };
+
+      openMemoSidebar({
+        data: payload,
+        videoPlayer,
+        onSave: (data) => sendData(data),
+        sidebarTitle: "録画メモ",
       });
 
 
@@ -373,25 +383,6 @@ import { getApiEndpoint } from './../api.js';
 
     window.addEventListener('popstate', dispatch);
   }
-
-  function sendData(dataToSend) {
-      fetch(getApiEndpoint("receive"), {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(dataToSend),
-      })
-        .then((response) => response.json())
-        .then((data) => {
-          console.log("Success:", data);
-          // ユーザーに成功を通知するUIを追加可能
-        })
-        .catch((error) => {
-          console.error("Error:", error);
-          // ユーザーにエラーを通知するUIを追加可能
-        });
-    }
 
   function bootstrap() {
     hookHistory();

--- a/src/content/playClipNetflix.js
+++ b/src/content/playClipNetflix.js
@@ -1,4 +1,5 @@
 import { getApiEndpoint } from './../api.js';
+import { MEMO_SIDEBAR_ID } from './common.js';
 
 (() => {
   'use strict';
@@ -41,7 +42,7 @@ if (!sessionStorage.getItem("nfClipInitialized")) {
 
   const BUTTON_ID = "nf-loop-toggle-btn";
   const NEXT_BUTTON_ID = "nf-next-clip-btn";
-  const SIDEBAR_ID = "nf-memo-sidebar";
+  const SIDEBAR_ID = MEMO_SIDEBAR_ID;
   const SIDEBAR_PCT = 30;
 
   const SELECTOR_STANDARD  = '[data-uia="controls-standard"]';


### PR DESCRIPTION
## Summary
- add shared content helpers for detecting services, saving clips, and opening the memo sidebar
- update Netflix and Disney content scripts to use the shared sidebar flow and data sender
- reuse the common memo sidebar identifier within the Netflix playback script

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d43754a40832eb843d217c8aaca73)