### PR TITLE
Add start-time URL handling for Prime, Disney+, and YouTube; alert on unsupported services

### DIFF
--- a/src/content/getClipData.js
+++ b/src/content/getClipData.js
@@ -126,6 +126,23 @@ async function playQueue(queue) {
   const service = nextClip.service?.toLowerCase();
   const startTime = Math.floor(nextClip.startTime) || 0;
 
+  function appendStartTimeParam(baseUrl, paramKey) {
+    try {
+      const urlObj = new URL(baseUrl);
+      urlObj.searchParams.set(paramKey, String(startTime));
+      return urlObj.toString();
+    } catch (error) {
+      console.warn("⚠️ URL 解析に失敗しました:", baseUrl, error);
+      return baseUrl;
+    }
+  }
+
+  function notifyUnsupportedService(targetService) {
+    const message = `未対応のサービスです: ${targetService || "unknown"}`;
+    console.warn("⚠️", message);
+    window.alert(`⚠️ ${message}`);
+  }
+
   let url = "";
   switch (service) {
     case "netflix": {
@@ -133,14 +150,47 @@ async function playQueue(queue) {
       const base = nextClip.url.startsWith("http")
         ? nextClip.url
         : `https://www.netflix.com${nextClip.url}`;
-      url = `${base}?t=${startTime}`;
+      url = appendStartTimeParam(base, "t");
       break;
     }
-    case "prime":
-      console.log("📺 Prime は現在未対応です");
-      return;
+    case "prime": {
+      console.log("📺 Prime のクリップを再生します");
+      const base = nextClip.url.startsWith("http")
+        ? nextClip.url
+        : `https://www.primevideo.com${nextClip.url}`;
+      url = appendStartTimeParam(base, "t");
+      break;
+    }
+    case "disney": {
+      console.log("📺 Disney+ のクリップを再生します");
+      const base = nextClip.url.startsWith("http")
+        ? nextClip.url
+        : `https://www.disneyplus.com${nextClip.url}`;
+      url = appendStartTimeParam(base, "t");
+      break;
+    }
+    case "youtube": {
+      console.log("📺 YouTube のクリップを再生します");
+      let base = "";
+      if (nextClip.url.startsWith("http")) {
+        base = nextClip.url;
+      } else if (
+        nextClip.url.startsWith("youtu.be") ||
+        nextClip.url.startsWith("www.youtube.com") ||
+        nextClip.url.startsWith("youtube.com")
+      ) {
+        base = `https://${nextClip.url}`;
+      } else {
+        const normalized = nextClip.url.startsWith("/")
+          ? nextClip.url
+          : `/${nextClip.url}`;
+        base = `https://www.youtube.com${normalized}`;
+      }
+      url = appendStartTimeParam(base, "t");
+      break;
+    }
     default:
-      console.warn("⚠️ 未対応のサービス:", service);
+      notifyUnsupportedService(service);
       return;
   }
 


### PR DESCRIPTION
### Motivation
- Extend `playQueue` URL generation to support additional services (Prime Video, Disney+, YouTube) so playlist playback can navigate to the correct service pages with start-times.
- Use a safe helper to append start-time query parameters instead of manual string concatenation to avoid malformed URLs.
- Provide a clear UI notification for unsupported services rather than only logging to the console.

### Description
- Added `appendStartTimeParam(baseUrl, paramKey)` to safely append the start time using the `URL` API.
- Added `notifyUnsupportedService(service)` which logs and shows a `window.alert` to inform the user of unsupported services.
- Implemented service branches for `prime`, `disney`, and `youtube`, and updated the `netflix` branch to use the new helper; included YouTube URL normalization logic.
- Left existing storage writes (`safeSetStorage`) and the navigation flow intact while reusing the new helpers.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a5ce9b2bc832e86626d14c91507f5)