### PR TITLE
Add playQueue-based playlist support to Disney content script

### DIFF
--- a/src/content/content_disney.js
+++ b/src/content/content_disney.js
@@ -518,6 +518,28 @@ import { detectService, openMemoSidebar, sendData } from './common.js';
     return { play, stop };
   })();
 
+  function normalizeClipData(clip) {
+    if (!clip) return null;
+    return {
+      startTime: Number(clip.startTime ?? clip.starttime),
+      endTime: Number(clip.endTime ?? clip.endtime),
+      title: String(clip.clipname ?? clip.title ?? ''),
+      url: clip.url ?? clip.URL ?? clip.Url ?? ''
+    };
+  }
+
+  function normalizeClipUrl(clip) {
+    return clip?.url ?? clip?.URL ?? clip?.Url ?? '';
+  }
+
+  function buildClipUrl(url, startTime) {
+    if (!url) return '';
+    const base = url.startsWith('http') ? url : new URL(url, location.origin).toString();
+    const target = new URL(base);
+    target.searchParams.set('t', Math.floor(startTime || 0).toString());
+    return target.toString();
+  }
+
   // === Playlist ===
   const Playlist = (() => {
     const state = {
@@ -646,10 +668,102 @@ import { detectService, openMemoSidebar, sendData } from './common.js';
     }
 
     async function startPlaylistMode() {
-      const clipData = await loadClipData();
+      stopActiveMode();
+      await chrome.storage.local.set({ playClipSystemKey: 0, playlistSystemKey: 1 });
+      const { playQueue, currentClipOrder } = await chrome.storage.local.get([
+        'playQueue',
+        'currentClipOrder'
+      ]);
+
+      if (!Array.isArray(playQueue) || playQueue.length === 0) {
+        console.warn('[Playlist] playQueue が存在しません');
+        return;
+      }
+
+      const sortedQueue = [...playQueue].sort((a, b) => a.order - b.order);
+      const fallbackOrder = sortedQueue[0]?.order ?? 0;
+      const order = Number.isInteger(currentClipOrder) ? currentClipOrder : fallbackOrder;
+      const currentClip = sortedQueue.find((clip) => clip.order === order) || sortedQueue[0];
+
+      if (!currentClip) {
+        console.warn('[Playlist] 該当clipが見つかりません:', order);
+        return;
+      }
+
+      if (currentClipOrder !== currentClip.order) {
+        await chrome.storage.local.set({ currentClipOrder: currentClip.order });
+      }
+
+      await chrome.storage.local.set({ currentClipId: currentClip.id });
+
+      const clipData = normalizeClipData(currentClip);
       if (!clipData) return;
 
-      stopCurrent = Playlist.play([clipData]);
+      playPlaylistClip(clipData);
+    }
+
+    function playPlaylistClip(clipData) {
+      stopCurrent = Clip.play(clipData, {
+        onEnd: handlePlaylistEnd
+      });
+    }
+
+    function handlePlaylistEnd() {
+      chrome.storage.local.get(['playQueue', 'currentClipOrder'], (res) => {
+        const { playQueue, currentClipOrder } = res;
+        if (Array.isArray(playQueue)) {
+          playlistNextClip(playQueue, currentClipOrder ?? 0);
+        } else {
+          console.warn('[Playlist] playQueue が無効。playlist終了');
+          chrome.storage.local.set({ playlistSystemKey: 0 });
+        }
+      });
+    }
+
+    async function playlistNextClip(playQueue, currentOrder) {
+      console.log('[Playlist] playlistNextClip: 現在のorder =', currentOrder);
+
+      const sortedQueue = [...playQueue].sort((a, b) => a.order - b.order);
+      const currentIndex = sortedQueue.findIndex((clip) => clip.order === currentOrder);
+      if (currentIndex === -1) {
+        console.warn('[Playlist] 現在のclipが見つかりません:', currentOrder);
+        return;
+      }
+
+      const current = sortedQueue[currentIndex];
+      const isLast = currentIndex === sortedQueue.length - 1;
+      const next = isLast ? sortedQueue[0] : sortedQueue[currentIndex + 1];
+
+      if (isLast) {
+        console.log('[Playlist] 最終clip → order 0 のclipへループ再生します');
+      }
+
+      await chrome.storage.local.set({
+        currentClipOrder: next.order,
+        currentClipId: next.id
+      });
+
+      const nextClipData = normalizeClipData(next);
+      if (!nextClipData) {
+        console.warn('[Playlist] 次クリップのデータが不正です:', next);
+        return;
+      }
+
+      const currentUrl = normalizeClipUrl(current);
+      const nextUrl = normalizeClipUrl(next);
+
+      if (currentUrl && nextUrl && currentUrl !== nextUrl) {
+        const url = buildClipUrl(nextUrl, nextClipData.startTime);
+        console.log('[Playlist] 異なるURL → ページ遷移:', url);
+        if (!url) return;
+        setTimeout(() => {
+          chrome.storage.local.set({ playClipSystemKey: 0, playlistSystemKey: 1 });
+          window.location.href = url;
+        }, 150);
+        return;
+      }
+
+      playPlaylistClip(nextClipData);
     }
 
     async function startPreferredMode() {


### PR DESCRIPTION
### Motivation
- Align Disney playlist behavior with Netflix by adding `playQueue`-driven playback and external order control.
- Ensure playlist state (`currentClipOrder` / `currentClipId`) is updated and persisted during playback and navigation.
- Support advancing to the next clip automatically when a clip ends, including looping behavior.
- Handle same-page seeks versus cross-URL navigations to continue playlist playback reliably.

### Description
- Added helpers `normalizeClipData`, `normalizeClipUrl`, and `buildClipUrl` to normalize clip objects and construct target URLs.
- Reworked `Mode.startPlaylistMode` to read `playQueue` and `currentClipOrder` from `chrome.storage.local`, set mode flags, and select the correct starting clip.
- Implemented `playPlaylistClip`, `handlePlaylistEnd`, and `playlistNextClip` to advance order, update `currentClipOrder`/`currentClipId` in storage, and either continue playback or navigate to a new URL.
- Persisted storage changes before navigation and preserved loop behavior for the last clip when advancing.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b44caf114832e9234c9a80a517b75)