### PR TITLE
Enable shared playlist state and auto-navigation handling

### DIFF
--- a/src/content/common.js
+++ b/src/content/common.js
@@ -1,6 +1,7 @@
 import { getApiEndpoint } from './../api.js';
 
 export const MEMO_SIDEBAR_ID = 'nf-memo-sidebar';
+export const AUTO_NAVIGATION_KEY = 'extAutoNavigation';
 
 export function detectService(host = window.location.hostname) {
   if (host.includes('netflix.com')) return 'Netflix';
@@ -123,4 +124,16 @@ export function openMemoSidebar({
 
   document.body.appendChild(sb);
   return sb;
+}
+
+export function markAutoNavigation(reason = 'auto') {
+  sessionStorage.setItem(AUTO_NAVIGATION_KEY, reason);
+}
+
+export function isAutoNavigation() {
+  return Boolean(sessionStorage.getItem(AUTO_NAVIGATION_KEY));
+}
+
+export function clearAutoNavigation() {
+  sessionStorage.removeItem(AUTO_NAVIGATION_KEY);
 }

--- a/src/content/content_disney.js
+++ b/src/content/content_disney.js
@@ -1,5 +1,6 @@
-import { detectService, openMemoSidebar, sendData } from './common.js';
+import { clearAutoNavigation, detectService, isAutoNavigation, openMemoSidebar, sendData } from './common.js';
 (() => {
+  clearAutoNavigation();
   // === UI ===
   const UI = (() => {
     const PLAYER_CONTROLS_SELECTOR = '.controls__footer__wrapper';
@@ -642,24 +643,65 @@ import { detectService, openMemoSidebar, sendData } from './common.js';
       const clipData = await loadClipData();
       if (!clipData) return;
 
+      await chrome.storage.local.set({ playClipSystemKey: 1, playlistSystemKey: 0, playmode: "clip" });
       stopCurrent = Playlist.play([clipData], { loop: loopEnabled });
     }
 
+    async function loadPlaylistClip() {
+      const { playQueue, currentClipOrder } = await chrome.storage.local.get([
+        'playQueue',
+        'currentClipOrder'
+      ]);
+
+      if (!Array.isArray(playQueue) || playQueue.length === 0) {
+        console.warn('⚠️ playQueue が存在しません');
+        return null;
+      }
+
+      const order = Number.isInteger(currentClipOrder) ? currentClipOrder : 0;
+      const currentClip = playQueue.find((clip) => clip.order === order) ?? playQueue[0];
+
+      if (!currentClip) {
+        console.warn('⚠️ 該当clipが見つかりません:', order);
+        return null;
+      }
+
+      return {
+        startTime: Number(currentClip.startTime ?? currentClip.starttime),
+        endTime:   Number(currentClip.endTime   ?? currentClip.endtime),
+        title:     String(currentClip.clipname || currentClip.title || '')
+      };
+    }
+
     async function startPlaylistMode() {
-      const clipData = await loadClipData();
+      const clipData = await loadPlaylistClip();
       if (!clipData) return;
 
+      await chrome.storage.local.set({ playClipSystemKey: 0, playlistSystemKey: 1, playmode: "playlist" });
       stopCurrent = Playlist.play([clipData]);
     }
 
     async function startPreferredMode() {
-      const { playClipSystemKey, playlistSystemKey } = await chrome.storage.local.get([
+      const { playClipSystemKey, playlistSystemKey, playmode } = await chrome.storage.local.get([
         'playClipSystemKey',
-        'playlistSystemKey'
+        'playlistSystemKey',
+        'playmode'
       ]);
 
       console.log("再生機能の起動キー:", playClipSystemKey);
       console.log("プレイリスト再生機能の起動キー:", playlistSystemKey);
+
+      if (playmode === "playlist") {
+        await chrome.storage.local.set({ playClipSystemKey: 0, playlistSystemKey: 1 });
+        await startPlaylistMode();
+        return;
+      }
+
+      if (playmode === "clip") {
+        await chrome.storage.local.set({ playClipSystemKey: 1, playlistSystemKey: 0 });
+        await startClipMode();
+        return;
+      }
 
       if (playClipSystemKey === 1 && playlistSystemKey === 1) {
         // どちらもONは異常。Clip優先で矯正。
@@ -726,4 +768,21 @@ import { detectService, openMemoSidebar, sendData } from './common.js';
 
   window.addEventListener('locationchange', () => UI.scheduleInjection());
   window.addEventListener('load', () => UI.scheduleInjection(), { once: true });
+
+  window.addEventListener('beforeunload', () => {
+    if (isAutoNavigation()) {
+      console.log("▶️ 自動遷移検知：beforeunloadでのリセットをスキップ");
+      return;
+    }
+
+    console.log("ユーザー操作（手動リロード or ページ遷移）検知");
+    chrome.storage.local.set({
+      playClipSystemKey: 0,
+      playlistSystemKey: 0,
+      currentClipOrder: 0,
+      playmode: null
+    }, () => {
+      console.log("systemKey を 0 に設定しました（両モード）");
+    });
+  });
 })();

--- a/src/content/getClipData.js
+++ b/src/content/getClipData.js
@@ -22,6 +22,7 @@ window.addEventListener("clipSelected", () => {
 
   chrome.storage.local.set({ clip: playClipData });
   chrome.storage.local.set({ playClipSystemKey: 1 });
+  safeSetStorage({ playmode: "clip" });
 
   chrome.storage.local.get(["playClipSystemKey"], (result) => {
     console.log("🔑 再生機能の起動キー:", result.playClipSystemKey);
@@ -59,6 +60,7 @@ window.addEventListener("message", async (event) => {
   if (msg.type === "SET_CLIP_DATA") {
     const { clip, playClipSystemKey } = msg.payload;
     await chrome.storage.local.set({ clip});
+    await safeSetStorage({ playmode: "clip" });
     // clip再生開始時に
     chrome.storage.local.set({playClipSystemKey: 1,playlistSystemKey: 0});
     console.log("🎞️ clipデータを保存:", clip, playClipSystemKey);
@@ -80,7 +82,7 @@ window.addEventListener("message", async (event) => {
     console.log("🧩 プレイキュー全体:", queue);
 
     // 🎯 playQueue 全体を拡張ストレージに保存（別ドメインからも参照可能に）
-    await chrome.storage.local.set({ playQueue: queue });
+    await safeSetStorage({ playQueue: queue, currentClipOrder: 0, playmode: "playlist" });
     console.log("💾 playQueue 全体を chrome.storage.local に保存しました");
 
     playQueue(queue);

--- a/src/content/playClipNetflix.js
+++ b/src/content/playClipNetflix.js
@@ -1,5 +1,5 @@
 import { getApiEndpoint } from './../api.js';
-import { MEMO_SIDEBAR_ID } from './common.js';
+import { clearAutoNavigation, isAutoNavigation, markAutoNavigation, MEMO_SIDEBAR_ID } from './common.js';
 
 (() => {
   'use strict';
@@ -8,15 +8,17 @@ import { MEMO_SIDEBAR_ID } from './common.js';
 // 🔰 起動時初期化ガード（モードが有効でなければリセット）
 // --------------------------------------------------
 if (!sessionStorage.getItem("nfClipInitialized")) {
-  chrome.storage.local.get(["playClipSystemKey", "playlistSystemKey"], (res) => {
+  chrome.storage.local.get(["playClipSystemKey", "playlistSystemKey", "playmode"], (res) => {
     const clipModeActive = res.playClipSystemKey === 1;
     const playlistActive = res.playlistSystemKey === 1;
+    const playmodeActive = res.playmode === "clip" || res.playmode === "playlist";
 
-    if (!clipModeActive && !playlistActive) {
+    if (!clipModeActive && !playlistActive && !playmodeActive) {
       chrome.storage.local.set({
         playClipSystemKey: 0,
         playlistSystemKey: 0,
         currentClipOrder: 0,
+        playmode: null,
         clip: null
       }, () => {
         console.log("🧹 初期化ガード: 不要データをクリーンアップしました");
@@ -35,8 +37,6 @@ if (!sessionStorage.getItem("nfClipInitialized")) {
   // ---------------------------------------------------------------------------
   let videoPlayer = null;            // <video> element
   let clipData    = null;            // { startTime, endTime, title, ... }
-  let isScriptReloading = false;     // スクリプト起因のリロード検知
-
   const EPSILON = 0.05;
   let countdownIntervalId = null;
 
@@ -57,8 +57,7 @@ if (!sessionStorage.getItem("nfClipInitialized")) {
 
   let uiWarmerInterval = null;
 
-  // グローバル
-  let isPlaylistNavigating = false;
+  clearAutoNavigation();
 
   // storage.set を await できるユーティリティ
   function setStorageAsync(data) {
@@ -356,7 +355,7 @@ if (!sessionStorage.getItem("nfClipInitialized")) {
 
   async function init() {
     // Clipモードの明示（相互排他）
-    chrome.storage.local.set({ playClipSystemKey: 1, playlistSystemKey: 0 });
+    chrome.storage.local.set({ playClipSystemKey: 1, playlistSystemKey: 0, playmode: "clip" });
 
     //ensureClipTagInURL(); 不要コード
     try {
@@ -374,7 +373,7 @@ if (!sessionStorage.getItem("nfClipInitialized")) {
   // ---------------------------------------------------------------------------
   async function startPlaylistMode() {
     // Playlistモードの明示（相互排他）
-    chrome.storage.local.set({ playClipSystemKey: 0, playlistSystemKey: 1 });
+    chrome.storage.local.set({ playClipSystemKey: 0, playlistSystemKey: 1, playmode: "playlist" });
 
     console.log("▶️ プレイリスト再生モードを起動します");
     chrome.storage.local.get(["playQueue", "currentClipOrder"], async ({ playQueue, currentClipOrder }) => {
@@ -491,7 +490,7 @@ async function playlistNextClip(playQueue, currentOrder) {
     // --------------------------------------------------
     
     // playlist継続中であることを通知
-    isScriptReloading = true;
+    markAutoNavigation("playlist");
     
     console.log("🌐 異なるURL → ページ遷移を実行");
     const url = `https://www.netflix.com${next.url}?t=${Math.floor(next.startTime)}`;
@@ -618,9 +617,21 @@ function stopUIWarmer() {
   // ページロード時のモード起動（排他保証）
   // ---------------------------------------------------------------------------
   window.addEventListener("load", async () => {
-    chrome.storage.local.get(["playClipSystemKey", "playlistSystemKey"], async ({ playClipSystemKey, playlistSystemKey }) => {
+    chrome.storage.local.get(["playClipSystemKey", "playlistSystemKey", "playmode"], async ({ playClipSystemKey, playlistSystemKey, playmode }) => {
       console.log("再生機能の起動キー:", playClipSystemKey);
       console.log("プレイリスト再生機能の起動キー:", playlistSystemKey);
+
+      if (playmode === "playlist") {
+        await chrome.storage.local.set({ playClipSystemKey: 0, playlistSystemKey: 1 });
+        await startPlaylistMode();
+        return;
+      }
+
+      if (playmode === "clip") {
+        await chrome.storage.local.set({ playClipSystemKey: 1, playlistSystemKey: 0 });
+        await init();
+        return;
+      }
 
       if (playClipSystemKey === 1 && playlistSystemKey === 1) {
         // どちらもONは異常。Clip優先で矯正。
@@ -645,33 +656,26 @@ function stopUIWarmer() {
   // ---------------------------------------------------------------------------
   window.addEventListener("beforeunload", () => {
 
-    if (isPlaylistNavigating) {
-      console.log("▶️ playlist ナビ中：beforeunloadでのリセットをスキップ");
+    if (isAutoNavigation()) {
+      console.log("▶️ 自動遷移検知：beforeunloadでのリセットをスキップ");
       return;
     }
 
-    if (!isScriptReloading) {
-      console.log("ユーザー操作（手動リロード or ページ遷移）検知");
-      // ★ 重要：両方のキーを落とす（残留防止）
-      chrome.storage.local.set({ playClipSystemKey: 0, playlistSystemKey: 0 }, () => {
-        console.log("systemKey を 0 に設定しました（両モード）");
-      });
-      chrome.storage.local.get(["playlistSystemKey"], ({ playlistSystemKey }) => {
-      if (playlistSystemKey == 1) {
-        chrome.storage.local.set({ currentClipOrder: 0 }, () => {
-          console.log("🧭 currentClipOrder 初期化完了");
-        });
-      }
+    console.log("ユーザー操作（手動リロード or ページ遷移）検知");
+    // ★ 重要：両方のキーを落とす（残留防止）
+    chrome.storage.local.set({
+      playClipSystemKey: 0,
+      playlistSystemKey: 0,
+      currentClipOrder: 0,
+      playmode: null
+    }, () => {
+      console.log("systemKey を 0 に設定しました（両モード）");
     });
-    } else {
-      console.log("スクリプトによる再読み込み");
-      isScriptReloading = false;
-    }
   });
 
   // （必要なら）スクリプト側から明示リロードする場合のラッパ
   function reloadPageFromScript() {
-    isScriptReloading = true;
+    markAutoNavigation("script-reload");
     location.reload();
   }
 


### PR DESCRIPTION
### Motivation
- Persist shared playback state so playlist/clip flows can be resumed across domains by storing `playmode`, `playQueue`, and `currentClipOrder` in extension storage.
- Ensure content scripts automatically start the appropriate playback flow when they see `playmode === "playlist"` on load.
- Distinguish user-driven unloads from automatic navigations so unload handlers only reset state for real user exits.
- Centralize auto-navigation flags to avoid leaving stale playback state after scripted redirects.

### Description
- Added `AUTO_NAVIGATION_KEY` and helper APIs (`markAutoNavigation`, `isAutoNavigation`, `clearAutoNavigation`) to `src/content/common.js` to mark and query automatic navigations via `sessionStorage`.
- Use `safeSetStorage` in `src/content/getClipData.js` to persist `playQueue`, `currentClipOrder`, and `playmode` when starting playlist flows and set `playmode: "clip"` for clip starts.
- Updated Netflix (`src/content/playClipNetflix.js`) and Disney (`src/content/content_disney.js`) content scripts to read `playmode` at startup and to start `playlist` playback when `playmode === "playlist"` or `clip` when `playmode === "clip"`.
- Mark auto-navigation before scripted redirects (`markAutoNavigation`) and unified `beforeunload` logic to skip resets when `isAutoNavigation()` is true and otherwise clear `playClipSystemKey`, `playlistSystemKey`, `currentClipOrder`, and `playmode`.

### Testing
- No automated tests were run for this change.
- Changes were committed locally and the modified files are `src/content/common.js`, `src/content/getClipData.js`, `src/content/playClipNetflix.js`, and `src/content/content_disney.js`.
- Manual runtime behavior was considered in code (sessionStorage guards and safe storage fallbacks) but not executed as automated tests.
- Recommend running content-script integration/manual smoke tests on Netflix/Disney flows to validate playlist resume and unload semantics.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b5fe168b0832e9354bff0c945818e)