### PR TITLE
Unify clip seek and transition handling across services

### DIFF
--- a/src/content/common.js
+++ b/src/content/common.js
@@ -16,6 +16,43 @@ export function formatSeconds(seconds = 0) {
   return `${Math.floor(sec / 60)}:${String(sec % 60).padStart(2, '0')}`;
 }
 
+export function decideClipTransition(currentUrl, nextUrl) {
+  return currentUrl === nextUrl ? 'seek' : 'navigate';
+}
+
+export async function handleClipTransition({ currentUrl, nextUrl, onSameUrl, onDifferentUrl }) {
+  const action = decideClipTransition(currentUrl, nextUrl);
+  if (action === 'seek') {
+    return onSameUrl?.();
+  }
+  return onDifferentUrl?.();
+}
+
+export async function requestSeek({ service = detectService(), seconds, adapter, videoElement }) {
+  const targetSeconds = Number(seconds);
+  if (!Number.isFinite(targetSeconds)) {
+    throw new Error(`Invalid seek seconds: ${seconds}`);
+  }
+
+  if (service === 'Netflix') {
+    return chrome.runtime.sendMessage({ type: 'seek', sec: targetSeconds });
+  }
+
+  if (adapter?.seek) {
+    adapter.seek(targetSeconds);
+    return { ok: true };
+  }
+
+  if (videoElement) {
+    videoElement.currentTime = targetSeconds;
+    videoElement.play?.();
+    return { ok: true };
+  }
+
+  console.warn(`[Seek] No handler for service: ${service}`);
+  return { ok: false };
+}
+
 export function sendData(dataToSend) {
   return fetch(getApiEndpoint('receive'), {
     method: 'POST',

--- a/src/content/content_disney.js
+++ b/src/content/content_disney.js
@@ -1,4 +1,4 @@
-import { detectService, openMemoSidebar, sendData } from './common.js';
+import { detectService, openMemoSidebar, requestSeek, sendData } from './common.js';
 (() => {
   // === UI ===
   const UI = (() => {
@@ -395,8 +395,9 @@ import { detectService, openMemoSidebar, sendData } from './common.js';
 
     })();
 
-    function seekDisney(seconds) {
+    function seek(seconds) {
       const t = DPlusTime.get();
+      if (!t) return console.warn("再生時間が取得できません");
       const bar = document.querySelector("progress-bar");
       const root = bar?.shadowRoot;
       const seekable = root?.querySelector(".progress-bar__seekable-range");
@@ -423,8 +424,13 @@ import { detectService, openMemoSidebar, sendData } from './common.js';
       );
     }
 
-    return { DPlusTime, seekDisney };
+    return { DPlusTime, seek };
   })();
+
+  const playerAdapter = {
+    getTime: () => Service.DPlusTime.get(),
+    seek: (seconds) => Service.seek(seconds)
+  };
 
   // === Clip ===
   const Clip = (() => {
@@ -455,14 +461,18 @@ import { detectService, openMemoSidebar, sendData } from './common.js';
       const timers = { startTimer: null, endTimer: null };
 
       timers.startTimer = setInterval(() => {
-        const t = Service.DPlusTime.get();
+        const t = playerAdapter.getTime();
         if (!t) {
           console.log("再生時間を再チェックします...");
           return;
         }
 
         console.log("再生時間を取得:", t);
-        Service.seekDisney(clipData.startTime);
+        requestSeek({
+          service: detectService(),
+          seconds: clipData.startTime,
+          adapter: playerAdapter
+        });
 
         clearInterval(timers.startTimer);
         timers.startTimer = null;
@@ -485,7 +495,7 @@ import { detectService, openMemoSidebar, sendData } from './common.js';
      */
     function startEndMonitor(clipData, onEnd) {
       const endTimer = setInterval(() => {
-        const t = Service.DPlusTime.get();
+        const t = playerAdapter.getTime();
         if (!t) return;
 
         if (t.currentSeconds >= clipData.endTime) {

--- a/src/content/playClipNetflix.js
+++ b/src/content/playClipNetflix.js
@@ -1,5 +1,5 @@
 import { getApiEndpoint } from './../api.js';
-import { MEMO_SIDEBAR_ID } from './common.js';
+import { MEMO_SIDEBAR_ID, handleClipTransition, requestSeek } from './common.js';
 
 (() => {
   'use strict';
@@ -456,52 +456,56 @@ async function playlistNextClip(playQueue, currentOrder) {
   // --------------------------------------------------
   // 🎯 分岐：同じURL内ならseek、異なるURLならページ遷移
   // --------------------------------------------------
-  if (current.url === next.url) {
-    console.log("🔁 同じURL内のclipに移動 → ui seek使用（無限リトライ）");
-    startUIWarmer();//seek成功までUIクリックブースト開始
-    const targetTime = Math.floor(next.startTime);
+  await handleClipTransition({
+    currentUrl: current.url,
+    nextUrl: next.url,
+    onSameUrl: async () => {
+      console.log("🔁 同じURL内のclipに移動 → ui seek使用（無限リトライ）");
+      startUIWarmer();//seek成功までUIクリックブースト開始
+      const targetTime = Math.floor(next.startTime);
 
-    for (;;) {
-      try {
-        await chrome.runtime.sendMessage({ type: "seek", sec: targetTime });
-        stopUIWarmer();
-      } catch (err) {
-        console.warn("⚠️ seekメッセージ送信失敗:", err);
+      for (;;) {
+        try {
+          await requestSeek({ service: 'Netflix', seconds: targetTime });
+          stopUIWarmer();
+        } catch (err) {
+          console.warn("⚠️ seekメッセージ送信失敗:", err);
+        }
+
+        // Netflix側が反映するまで待機（0.3秒間隔）
+        await new Promise(r => setTimeout(r, 300));
+
+        const currentSec = Math.floor(videoPlayer?.currentTime ?? 0);
+        if (Math.abs(currentSec - targetTime) <= 1) {
+          console.log(`✅ seek成功: ${currentSec}s に到達`);
+          break;
+        } else {
+          console.log(`🔁 seek再送: current=${currentSec}s / target=${targetTime}s`);
+        }
       }
 
-      // Netflix側が反映するまで待機（0.3秒間隔）
-      await new Promise(r => setTimeout(r, 300));
+      // 成功後、再監視をセット
+      monitorClipEnd(clipData.endTime, clipData.startTime, "playlist");
+      startCountdownLogger(clipData.endTime);
+    },
+    onDifferentUrl: () => {
+      // --------------------------------------------------
+      // 異なるURL → ページ遷移（最初のorder更新後）
+      // --------------------------------------------------
 
-      const currentSec = Math.floor(videoPlayer?.currentTime ?? 0);
-      if (Math.abs(currentSec - targetTime) <= 1) {
-        console.log(`✅ seek成功: ${currentSec}s に到達`);
-        break;
-      } else {
-        console.log(`🔁 seek再送: current=${currentSec}s / target=${targetTime}s`);
-      }
+      // playlist継続中であることを通知
+      isScriptReloading = true;
+
+      console.log("🌐 異なるURL → ページ遷移を実行");
+      const url = `https://www.netflix.com${next.url}?t=${Math.floor(next.startTime)}`;
+      console.log("➡️ 次clipへ移動:", url);
+
+      // storage.set完了を確実にしてから移行（少し遅延）
+      setTimeout(() => {
+        window.location.href = url;
+      }, 150);
     }
-
-    // 成功後、再監視をセット
-    monitorClipEnd(clipData.endTime, clipData.startTime, "playlist");
-    startCountdownLogger(clipData.endTime);
-
-  } else {
-    // --------------------------------------------------
-    // 異なるURL → ページ遷移（最初のorder更新後）
-    // --------------------------------------------------
-    
-    // playlist継続中であることを通知
-    isScriptReloading = true;
-    
-    console.log("🌐 異なるURL → ページ遷移を実行");
-    const url = `https://www.netflix.com${next.url}?t=${Math.floor(next.startTime)}`;
-    console.log("➡️ 次clipへ移動:", url);
-
-    // storage.set完了を確実にしてから移行（少し遅延）
-    setTimeout(() => {
-      window.location.href = url;
-    }, 150);
-  }
+  });
 }
 
   // ---------------------------------------------------------------------------
@@ -554,7 +558,7 @@ async function playlistNextClip(playQueue, currentOrder) {
         } else {
           // 単体Clipモード：init()再帰はしない。seekのみでループ。
           try {
-            chrome.runtime.sendMessage({ type: "seek", sec: start });
+            requestSeek({ service: 'Netflix', seconds: start, videoElement: videoPlayer });
           } catch(e) {
             // 念のため、失敗時はvideo直操作のフォールバック
             try { videoPlayer.currentTime = start; videoPlayer.play?.(); } catch(_) {}


### PR DESCRIPTION
### Motivation
- Provide a reusable mechanism equivalent to Netflix's `chrome.runtime.sendMessage({ type: "seek" })` so other services can perform seeks consistently.
- Encapsulate service-specific seek logic (e.g. `seekDisney` / Disney+ time getter) behind an adapter/shared interface for reuse.
- Centralize the decision of "same URL -> seek" vs "different URL -> navigate" so different content scripts can share the logic.
- Add a request-level fallback to directly control the `<video>` element when platform adapters are not available.

### Description
- Added `decideClipTransition`, `handleClipTransition` and `requestSeek` helpers to `src/content/common.js` to centralize transition and seek behavior and to route Netflix seeks through the background bridge.
- Updated `src/content/playClipNetflix.js` to use `handleClipTransition` and `requestSeek` instead of calling `chrome.runtime.sendMessage` inline, and reused the same URL vs navigation decision path.
- Refactored `src/content/content_disney.js` to expose a small `playerAdapter` and renamed `seekDisney` to `seek`, then route seeks through the shared `requestSeek` helper so Disney+ uses the common path.
- Kept platform fallbacks: `requestSeek` will call a provided `adapter.seek`, or operate on a passed `videoElement`, and preserves the Netflix background-bridge behavior for `service === 'Netflix'`.

### Testing
- No automated tests were executed for these changes in this rollout.
- The changes were committed and basic runtime integration points were updated, but no unit or integration test suite was run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b5fed214c832eaf3eb8c89c592e2e)