### PR TITLE
Persist auto-navigation flag to protect playlist transitions

### DIFF
--- a/src/content/common.js
+++ b/src/content/common.js
@@ -165,12 +165,17 @@ export function openMemoSidebar({
 
 export function markAutoNavigation(reason = 'auto') {
   sessionStorage.setItem(AUTO_NAVIGATION_KEY, reason);
+  localStorage.setItem(AUTO_NAVIGATION_KEY, reason);
 }
 
 export function isAutoNavigation() {
-  return Boolean(sessionStorage.getItem(AUTO_NAVIGATION_KEY));
+  return Boolean(
+    sessionStorage.getItem(AUTO_NAVIGATION_KEY) ||
+      localStorage.getItem(AUTO_NAVIGATION_KEY)
+  );
 }
 
 export function clearAutoNavigation() {
   sessionStorage.removeItem(AUTO_NAVIGATION_KEY);
+  localStorage.removeItem(AUTO_NAVIGATION_KEY);
 }


### PR DESCRIPTION
### Motivation
- The `beforeunload` handler was clearing playback state on navigation and interrupting playlist continuation.
- The auto-navigation marker needs to survive reloads/navigation so the unload handler can skip reset during automated transitions.
- Persisting the marker to a storage area that survives script reloads avoids false-positive manual-unload detection.

### Description
- `markAutoNavigation` now writes the marker to both `sessionStorage` and `localStorage` to persist across reloads.
- `isAutoNavigation` checks both `sessionStorage` and `localStorage` when determining auto-navigation state.
- `clearAutoNavigation` removes the marker from both storages.
- Changes applied in `src/content/common.js`.

### Testing
- No automated tests were run as part of this change.
- Please run integration/manual validation to confirm playlist transitions are no longer interrupted by `beforeunload`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b73517338832ea152ff514d6a37c5)