### PR TITLE
Require NextAuth session before extension UI

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,12 +12,14 @@
   ],
 
   "host_permissions": [
+    "https://app.example.com/*",
     "http://localhost:3000/*",
     "https://www.netflix.com/*"  
   ],
 
   "background": {
-    "service_worker": "src/background/background.js"
+    "service_worker": "src/background/background.js",
+    "type": "module"
   },
 
   "content_scripts": [

--- a/src/auth/authClient.js
+++ b/src/auth/authClient.js
@@ -1,0 +1,25 @@
+export const BASE_ORIGIN = 'https://app.example.com';
+export const SESSION_URL = `${BASE_ORIGIN}/api/auth/session`;
+export const DONE_URL = `${BASE_ORIGIN}/ext-auth/done`;
+
+export function getLoginUrl() {
+  const callbackUrl = encodeURIComponent(DONE_URL);
+  return `${BASE_ORIGIN}/api/auth/signin/google?callbackUrl=${callbackUrl}`;
+}
+
+export async function fetchSession() {
+  const response = await fetch(SESSION_URL, {
+    method: 'GET',
+    credentials: 'include'
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  return response.json();
+}
+
+export function isLoggedIn(session) {
+  return Boolean(session?.user?.id);
+}

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -1,12 +1,57 @@
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-    if (message.type === 'HISTORY_CHANGE') {
-      console.log('URLが変更されました:', message.data.url);
+import { DONE_URL, getLoginUrl } from '../auth/authClient.js';
+
+let authTabId = null;
+
+async function ensureAuthTab() {
+  const loginUrl = getLoginUrl();
+
+  if (authTabId) {
+    try {
+      await chrome.tabs.update(authTabId, { active: true });
+      return;
+    } catch (error) {
+      console.warn('[Auth] Existing auth tab missing, reopening.', error);
+      authTabId = null;
     }
-  });
+  }
+
+  const tab = await chrome.tabs.create({ url: loginUrl });
+  authTabId = tab.id;
+}
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (message?.type === 'AUTH_START') {
+    console.log('[Auth] AUTH_START received');
+    void ensureAuthTab();
+  }
+});
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
+  if (!authTabId || tabId !== authTabId) return;
+  if (!changeInfo.url) return;
+
+  if (changeInfo.url.startsWith(DONE_URL)) {
+    console.log('[Auth] Login done detected, closing tab.');
+    chrome.tabs.remove(tabId);
+    authTabId = null;
+    chrome.runtime.sendMessage({ type: 'AUTH_DONE' });
+  }
+});
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+  if (authTabId === tabId) {
+    authTabId = null;
+  }
+});
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'HISTORY_CHANGE') {
+    console.log('URLが変更されました:', message.data.url);
+  }
+});
 
 //再生と録画を切り替える値
-  let playClipSystemKey = "initialValue";
-
+let playClipSystemKey = "initialValue";
 
 //netflix用ブリッジ注入
 // background.js — content から {type:"seek", sec:数字} を受け取ってシーク
@@ -56,6 +101,3 @@ chrome.runtime.onMessage.addListener(async (msg, sender, sendResponse) => {
   sendResponse({ ok: true });
   return true; // async sendResponse のため
 });
-
-
-

--- a/src/content/content.js
+++ b/src/content/content.js
@@ -75,7 +75,6 @@ import {
 
     showAuthMessage('ログインが必要です。ログインタブを開きます...');
     chrome.runtime.sendMessage({ type: 'AUTH_START' });
-    authInProgress = false;
     return false;
   }
 
@@ -273,6 +272,7 @@ import {
 
   chrome.runtime.onMessage.addListener((message) => {
     if (message?.type === 'AUTH_DONE') {
+      authInProgress = false;
       ensureAuthAndBootstrap();
     }
   });

--- a/src/content/content.js
+++ b/src/content/content.js
@@ -4,10 +4,15 @@ import "../image/recordSVG.js";
 import "../image/LoopButtonSVG.js";
 import "./playClipNetflix.js";
 import { detectService, openMemoSidebar, sendData } from './common.js';
+import {
+  fetchSession,
+  isLoggedIn
+} from '../auth/authClient.js'; // NOTE: authClient path is relative to src/content
 
 (function() {
   const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
   const BUTTON_ID = 'record-button';
+  const AUTH_MESSAGE_ID = 'mc-auth-message';
 
   const SELECTORS = {
     videoPlayer: 'video',
@@ -17,9 +22,79 @@ import { detectService, openMemoSidebar, sendData } from './common.js';
     controlForward10: '[data-uia="control-forward10"]',
   };
 
+  let hasBootstrapped = false;
+  let authInProgress = false;
 
+  function showAuthMessage(message) {
+    let container = document.getElementById(AUTH_MESSAGE_ID);
 
-  window.addEventListener('load', () => {
+    if (!container) {
+      container = document.createElement('div');
+      container.id = AUTH_MESSAGE_ID;
+      container.style.cssText = [
+        'position: fixed',
+        'top: 16px',
+        'right: 16px',
+        'z-index: 2147483647',
+        'background: rgba(0, 0, 0, 0.85)',
+        'color: #fff',
+        'padding: 10px 14px',
+        'border-radius: 6px',
+        'font-size: 12px',
+        'font-family: sans-serif'
+      ].join(';');
+      document.body.appendChild(container);
+    }
+
+    container.textContent = message;
+  }
+
+  function clearAuthMessage() {
+    const container = document.getElementById(AUTH_MESSAGE_ID);
+    if (container) {
+      container.remove();
+    }
+  }
+
+  async function requireAuthOrShowLogin() {
+    if (authInProgress) return false;
+    authInProgress = true;
+
+    try {
+      const session = await fetchSession();
+      if (isLoggedIn(session)) {
+        clearAuthMessage();
+        authInProgress = false;
+        return true;
+      }
+    } catch (error) {
+      showAuthMessage(`Session check failed: ${error.message}`);
+      authInProgress = false;
+      return false;
+    }
+
+    showAuthMessage('ログインが必要です。ログインタブを開きます...');
+    chrome.runtime.sendMessage({ type: 'AUTH_START' });
+    authInProgress = false;
+    return false;
+  }
+
+  async function ensureAuthAndBootstrap() {
+    const ok = await requireAuthOrShowLogin();
+    if (!ok) return;
+
+    if (!hasBootstrapped) {
+      bootstrapApp();
+      hasBootstrapped = true;
+      return;
+    }
+
+    if (typeof window.mcResetState === 'function') {
+      window.mcResetState();
+    }
+  }
+
+  function bootstrapApp() {
     // 履歴変更フック用スクリプトをページワールドへ注入
     injectScript('src/util/history_change.js');
 
@@ -84,6 +159,7 @@ import { detectService, openMemoSidebar, sendData } from './common.js';
       button.setAttribute('aria-label', '録画ボタン');
       return button;
     }
+
     function createSVGElement(type, attributes) {
       const elem = document.createElementNS(SVG_NAMESPACE, type);
       for (const [key, value] of Object.entries(attributes)) {
@@ -176,7 +252,6 @@ import { detectService, openMemoSidebar, sendData } from './common.js';
     }
 
     function mutationCallback(mutationsList) {
-
       const controlsForward10Element = document.querySelector(SELECTORS.controlForward10);
       if (controlsForward10Element && !document.getElementById(BUTTON_ID)) {
         addElements();
@@ -192,5 +267,19 @@ import { detectService, openMemoSidebar, sendData } from './common.js';
       endTime = null;
       svgElement.setAttribute('color', window.COLOR_DEFAULT);
     }
+
+    window.mcResetState = init;
+  }
+
+  chrome.runtime.onMessage.addListener((message) => {
+    if (message?.type === 'AUTH_DONE') {
+      ensureAuthAndBootstrap();
+    }
   });
+
+  if (document.readyState === 'loading') {
+    window.addEventListener('load', ensureAuthAndBootstrap, { once: true });
+  } else {
+    ensureAuthAndBootstrap();
+  }
 })();

--- a/src/content/content.js
+++ b/src/content/content.js
@@ -63,6 +63,7 @@ import {
     try {
       const session = await fetchSession();
       if (isLoggedIn(session)) {
+        console.log('[Auth] Session OK:', session);
         clearAuthMessage();
         authInProgress = false;
         return true;

--- a/src/content/content_disney.js
+++ b/src/content/content_disney.js
@@ -67,7 +67,6 @@ import { fetchSession, isLoggedIn } from '../auth/authClient.js'; // NOTE: authC
 
     showAuthMessage('ログインが必要です。ログインタブを開きます...');
     chrome.runtime.sendMessage({ type: 'AUTH_START' });
-    authInProgress = false;
     return false;
   }
 
@@ -1111,6 +1110,7 @@ async function startPlaylistMode() {
 
   chrome.runtime.onMessage.addListener((message) => {
     if (message?.type === 'AUTH_DONE') {
+      authInProgress = false;
       ensureAuthAndBootstrap();
     }
   });

--- a/src/content/content_disney.js
+++ b/src/content/content_disney.js
@@ -55,6 +55,7 @@ import { fetchSession, isLoggedIn } from '../auth/authClient.js'; // NOTE: authC
     try {
       const session = await fetchSession();
       if (isLoggedIn(session)) {
+        console.log('[Auth] Session OK:', session);
         clearAuthMessage();
         authInProgress = false;
         return true;

--- a/src/content/content_disney.js
+++ b/src/content/content_disney.js
@@ -7,11 +7,79 @@ import {
   requestSeek,
   sendData
 } from './common.js';
+import { fetchSession, isLoggedIn } from '../auth/authClient.js'; // NOTE: authClient path is relative to src/content
 
 (() => {
   const AUTO_NAV_STORAGE_KEY = 'autoNav';
   const AUTO_NAV_TTL_MS = 15000;
+  const AUTH_MESSAGE_ID = 'mc-auth-message';
   let autoNavCache = null;
+  let hasBootstrapped = false;
+  let authInProgress = false;
+
+  function showAuthMessage(message) {
+    let container = document.getElementById(AUTH_MESSAGE_ID);
+
+    if (!container) {
+      container = document.createElement('div');
+      container.id = AUTH_MESSAGE_ID;
+      container.style.cssText = [
+        'position: fixed',
+        'top: 16px',
+        'right: 16px',
+        'z-index: 2147483647',
+        'background: rgba(0, 0, 0, 0.85)',
+        'color: #fff',
+        'padding: 10px 14px',
+        'border-radius: 6px',
+        'font-size: 12px',
+        'font-family: sans-serif'
+      ].join(';');
+      document.body.appendChild(container);
+    }
+
+    container.textContent = message;
+  }
+
+  function clearAuthMessage() {
+    const container = document.getElementById(AUTH_MESSAGE_ID);
+    if (container) {
+      container.remove();
+    }
+  }
+
+  async function requireAuthOrShowLogin() {
+    if (authInProgress) return false;
+    authInProgress = true;
+
+    try {
+      const session = await fetchSession();
+      if (isLoggedIn(session)) {
+        clearAuthMessage();
+        authInProgress = false;
+        return true;
+      }
+    } catch (error) {
+      showAuthMessage(`Session check failed: ${error.message}`);
+      authInProgress = false;
+      return false;
+    }
+
+    showAuthMessage('ログインが必要です。ログインタブを開きます...');
+    chrome.runtime.sendMessage({ type: 'AUTH_START' });
+    authInProgress = false;
+    return false;
+  }
+
+  async function ensureAuthAndBootstrap() {
+    const ok = await requireAuthOrShowLogin();
+    if (!ok) return;
+
+    if (!hasBootstrapped) {
+      startApp();
+      hasBootstrapped = true;
+    }
+  }
 
   function isAutoNavValid(autoNav) {
     if (!autoNav || typeof autoNav !== 'object') return false;
@@ -1008,34 +1076,48 @@ async function startPlaylistMode() {
     };
   })();
 
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', UI.bootstrap, { once: true });
-  } else {
-    UI.bootstrap();
-  }
-
-  Mode.bootstrap();
-
-  window.addEventListener('locationchange', () => UI.scheduleInjection());
-  window.addEventListener('load', () => UI.scheduleInjection(), { once: true });
-
-  window.addEventListener('beforeunload', () => {
-    const autoFlag = isAutoNavigation();
-    const autoStored = isAutoNavActive();
-
-    if (autoFlag || autoStored) {
-      console.log(`▶️ 自動遷移検知：beforeunloadでのリセットをスキップ (flag=${autoFlag}, storage=${autoStored})`);
-      return;
+  function startApp() {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', UI.bootstrap, { once: true });
+    } else {
+      UI.bootstrap();
     }
 
-    console.log("ユーザー操作（手動リロード or ページ遷移）検知");
-    chrome.storage.local.set({
-      playClipSystemKey: 0,
-      playlistSystemKey: 0,
-      currentClipOrder: 0,
-      playmode: null
-    }, () => {
-      console.log("systemKey を 0 に設定しました（両モード）");
+    Mode.bootstrap();
+
+    window.addEventListener('locationchange', () => UI.scheduleInjection());
+    window.addEventListener('load', () => UI.scheduleInjection(), { once: true });
+
+    window.addEventListener('beforeunload', () => {
+      const autoFlag = isAutoNavigation();
+      const autoStored = isAutoNavActive();
+
+      if (autoFlag || autoStored) {
+        console.log(`▶️ 自動遷移検知：beforeunloadでのリセットをスキップ (flag=${autoFlag}, storage=${autoStored})`);
+        return;
+      }
+
+      console.log("ユーザー操作（手動リロード or ページ遷移）検知");
+      chrome.storage.local.set({
+        playClipSystemKey: 0,
+        playlistSystemKey: 0,
+        currentClipOrder: 0,
+        playmode: null
+      }, () => {
+        console.log("systemKey を 0 に設定しました（両モード）");
+      });
     });
+  }
+
+  chrome.runtime.onMessage.addListener((message) => {
+    if (message?.type === 'AUTH_DONE') {
+      ensureAuthAndBootstrap();
+    }
   });
+
+  if (document.readyState === 'loading') {
+    window.addEventListener('load', ensureAuthAndBootstrap, { once: true });
+  } else {
+    ensureAuthAndBootstrap();
+  }
 })();


### PR DESCRIPTION
### Motivation
- Ensure the extension UI only initializes when the user is authenticated via NextAuth session cookie to avoid unauthenticated API calls and to require login up-front.
- Open a login tab from the background service worker and automatically close it when the Next.js login flow reaches the provided done URL so the extension can resume work.

### Description
- Add a shared auth helper `src/auth/authClient.js` that defines `BASE_ORIGIN`, `SESSION_URL`, `DONE_URL` and exports `getLoginUrl()`, `fetchSession()` (uses `credentials: 'include'`) and `isLoggedIn()`.
- Gate content initialization by inserting `requireAuthOrShowLogin()` / `ensureAuthAndBootstrap()` into `src/content/content.js` so the UI shows an auth message on failure and sends `AUTH_START`, and re-initializes on `AUTH_DONE`.
- Apply the same auth gating to `src/content/content_disney.js` by adding session checks, UI messaging, and `AUTH_DONE` handling; extract the existing start logic into `startApp()` so it can be invoked after auth.
- Implement background auth flow in `src/background/background.js` to handle `AUTH_START` by opening the Google signin URL, monitor the auth tab for navigation to the `DONE_URL`, close the tab on detection, and broadcast `AUTH_DONE`, with `console.log` traces for `AUTH_START` and login-done detection.
- Update `manifest.json` to add `https://app.example.com/*` to `host_permissions` and set the service worker to module mode (`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698129cd9c8c832eb01fc5959cef39b5)