### PR TITLE
fix: トークンリフレッシュ失敗時に指数バックオフを入れリトライ暴走を防止

### DIFF
--- a/src/background/tokenRefresh.js
+++ b/src/background/tokenRefresh.js
@@ -140,6 +140,14 @@ async function performCheckAndRefreshToken() {
   }
 
   if (response.status === 401) {
+    // fetch 中に再連携が起きていた場合、この 401 は旧トークンに対するもの(サイト側 CAS の
+    // 競合負け)であり、保存済みの新トークンを消すと連携直後の無言解除になる。
+    const current = await storageGet([STORAGE_KEYS.extensionAuthToken]);
+    if (current[STORAGE_KEYS.extensionAuthToken] !== token) {
+      console.log('[extension-sync] stale 401 for replaced token; keeping current token');
+      return { ok: false, reason: 'stale_unauthorized' };
+    }
+
     // 失効・解除・ローテーション競合負け。トークンを破棄し、次のユーザー操作時の
     // 再ログイン導線(sync の missing_token 経路)に任せる。
     // バックオフ状態は clearExtensionAuthState() が併せて削除する。

--- a/src/background/tokenRefresh.js
+++ b/src/background/tokenRefresh.js
@@ -3,6 +3,7 @@ import {
   STORAGE_KEYS,
   storageGet,
   storageSet,
+  storageRemove,
   clearExtensionAuthState,
 } from './../shared/storage.js';
 import { runExclusive } from './sync.js';
@@ -10,6 +11,45 @@ import { runExclusive } from './sync.js';
 // トークンはサーバ発行の不透明トークン(JWT ではない)。期限はサーバが link/refresh 応答の
 // expiresAt で通知し、拡張は storage に保存した値だけを見て更新時期を判断する。
 const RENEWAL_THRESHOLD_MS = 15 * 24 * 60 * 60 * 1000;
+
+// expiresAt が未保存だと下の not_due 判定を素通りするため、失敗が続くと SW 起動毎
+// (実効15分間隔)にリフレッシュを撃ち続ける。連続失敗を storage に記録して抑制する。
+const BACKOFF_BASE_MS = 15 * 60 * 1000;
+const BACKOFF_MAX_MS = 24 * 60 * 60 * 1000;
+// 404 はサイト側がこのエンドポイントを未実装であることを意味し、短間隔で試す意味がない。
+const BACKOFF_NOT_IMPLEMENTED_MS = 6 * 60 * 60 * 1000;
+
+function computeBackoffMs(failureCount, status) {
+  if (status === 404) {
+    return Math.max(BACKOFF_NOT_IMPLEMENTED_MS, BACKOFF_BASE_MS * 2 ** (failureCount - 1));
+  }
+  return Math.min(BACKOFF_BASE_MS * 2 ** (failureCount - 1), BACKOFF_MAX_MS);
+}
+
+async function recordRefreshFailure(previousBackoff, status) {
+  const failureCount = Number(previousBackoff?.failureCount) > 0
+    ? Number(previousBackoff.failureCount) + 1
+    : 1;
+  const delayMs = Math.min(computeBackoffMs(failureCount, status), BACKOFF_MAX_MS);
+
+  await storageSet({
+    [STORAGE_KEYS.extensionTokenRefreshBackoff]: {
+      failureCount,
+      nextAttemptAt: new Date(Date.now() + delayMs).toISOString(),
+      lastStatus: status ?? null,
+    },
+  });
+
+  console.warn('[extension-sync] refresh backoff scheduled', {
+    failureCount,
+    delayMinutes: Math.round(delayMs / 60000),
+    status: status ?? null,
+  });
+}
+
+function clearRefreshBackoff() {
+  return storageRemove([STORAGE_KEYS.extensionTokenRefreshBackoff]);
+}
 
 export function checkAndRefreshToken() {
   return runExclusive(performCheckAndRefreshToken);
@@ -20,12 +60,25 @@ async function performCheckAndRefreshToken() {
     STORAGE_KEYS.extensionAuthToken,
     STORAGE_KEYS.extensionInstanceId,
     STORAGE_KEYS.extensionTokenExpiresAt,
+    STORAGE_KEYS.extensionTokenRefreshBackoff,
   ]);
   const token = stored[STORAGE_KEYS.extensionAuthToken];
   const extensionInstanceId = stored[STORAGE_KEYS.extensionInstanceId];
 
   if (!token || !extensionInstanceId) {
     return { ok: true, skipped: true, reason: 'not_linked' };
+  }
+
+  const backoff = stored[STORAGE_KEYS.extensionTokenRefreshBackoff] || null;
+  const nextAttemptAtMs = Date.parse(backoff?.nextAttemptAt || '');
+  if (Number.isFinite(nextAttemptAtMs) && nextAttemptAtMs > Date.now()) {
+    return {
+      ok: true,
+      skipped: true,
+      reason: 'backoff',
+      nextAttemptAt: backoff.nextAttemptAt,
+      failureCount: backoff.failureCount ?? null,
+    };
   }
 
   const expiresAtMs = Date.parse(stored[STORAGE_KEYS.extensionTokenExpiresAt] || '');
@@ -53,6 +106,7 @@ async function performCheckAndRefreshToken() {
     console.warn('[extension-sync] token refresh failed; keeping current token', {
       message: error?.message,
     });
+    await recordRefreshFailure(backoff, null);
     return { ok: false, reason: 'network_error' };
   }
 
@@ -62,6 +116,7 @@ async function performCheckAndRefreshToken() {
       [STORAGE_KEYS.extensionTokenExpiresAt]: data.expiresAt || null,
       [STORAGE_KEYS.extensionLinked]: true,
     });
+    await clearRefreshBackoff();
     console.log('[extension-sync] token refreshed', { expiresAt: data.expiresAt });
     return { ok: true, refreshed: true };
   }
@@ -69,6 +124,7 @@ async function performCheckAndRefreshToken() {
   if (response.status === 401) {
     // 失効・解除・ローテーション競合負け。トークンを破棄し、次のユーザー操作時の
     // 再ログイン導線(sync の missing_token 経路)に任せる。
+    // バックオフ状態は clearExtensionAuthState() が併せて削除する。
     await clearExtensionAuthState();
     console.warn('[extension-sync] token refresh unauthorized; cleared token');
     return { ok: false, reason: 'unauthorized' };
@@ -77,5 +133,6 @@ async function performCheckAndRefreshToken() {
   console.warn('[extension-sync] token refresh failed; keeping current token', {
     status: response.status,
   });
+  await recordRefreshFailure(backoff, response.status);
   return { ok: false, reason: 'refresh_failed' };
 }

--- a/src/background/tokenRefresh.js
+++ b/src/background/tokenRefresh.js
@@ -26,32 +26,33 @@ function computeBackoffMs(failureCount, status) {
   return Math.min(BACKOFF_BASE_MS * 2 ** (failureCount - 1), BACKOFF_MAX_MS);
 }
 
-// 失敗を書き戻す直前に storage を読み直し、試行したトークンが今も保存されているか確認する。
-// fetch 中にユーザーが再連携すると saveExtensionAuthToken() が新トークンを保存しつつ
-// バックオフを削除するが、その保存は content 側で行われ runExclusive の外にあるため
-// 直列化されない。読み込み時点のスナップショットをそのまま書くと、削除済みのバックオフが
-// 復活して新しいトークンを最大24時間抑制してしまう。
+// バックオフは「どのトークンで失敗したか」に紐づけて保存する。
+// content 側の saveExtensionAuthToken() は runExclusive の外で storage を書き換えるため、
+// 「保存済みトークンを確認してから書く」形にしても確認と書き込みの間に再連携が割り込む
+// 余地が残る(TOCTOU)。書き込み側の原子性に頼らず、読み出し側で現在のトークンと照合し、
+// 一致しない記録は無効として扱う。これなら古い試行が後から書き戻しても影響しない。
+async function tokenFingerprint(token) {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(token));
+  return Array.from(new Uint8Array(digest).slice(0, 8))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
 async function recordRefreshFailure(attemptedToken, status) {
-  const current = await storageGet([
-    STORAGE_KEYS.extensionAuthToken,
-    STORAGE_KEYS.extensionTokenRefreshBackoff,
-  ]);
-
-  if (current[STORAGE_KEYS.extensionAuthToken] !== attemptedToken) {
-    console.log('[extension-sync] token replaced during refresh; skipping backoff record', {
-      status: status ?? null,
-    });
-    return;
-  }
-
+  const current = await storageGet([STORAGE_KEYS.extensionTokenRefreshBackoff]);
   const previousBackoff = current[STORAGE_KEYS.extensionTokenRefreshBackoff] || null;
-  const failureCount = Number(previousBackoff?.failureCount) > 0
+  const fingerprint = await tokenFingerprint(attemptedToken);
+
+  // 直前の記録が別トークンのものなら連番を引き継がず 1 から数え直す。
+  const failureCount = previousBackoff?.tokenFingerprint === fingerprint
+    && Number(previousBackoff.failureCount) > 0
     ? Number(previousBackoff.failureCount) + 1
     : 1;
   const delayMs = Math.min(computeBackoffMs(failureCount, status), BACKOFF_MAX_MS);
 
   await storageSet({
     [STORAGE_KEYS.extensionTokenRefreshBackoff]: {
+      tokenFingerprint: fingerprint,
       failureCount,
       nextAttemptAt: new Date(Date.now() + delayMs).toISOString(),
       lastStatus: status ?? null,
@@ -90,13 +91,20 @@ async function performCheckAndRefreshToken() {
   const backoff = stored[STORAGE_KEYS.extensionTokenRefreshBackoff] || null;
   const nextAttemptAtMs = Date.parse(backoff?.nextAttemptAt || '');
   if (Number.isFinite(nextAttemptAtMs) && nextAttemptAtMs > Date.now()) {
-    return {
-      ok: true,
-      skipped: true,
-      reason: 'backoff',
-      nextAttemptAt: backoff.nextAttemptAt,
-      failureCount: backoff.failureCount ?? null,
-    };
+    // 現在のトークンに紐づく記録のときだけ抑制する。再連携で差し替わっていれば旧トークンの
+    // 記録なので、古い試行が競合で書き戻したものも含めて破棄し、通常どおり続行する。
+    if (backoff.tokenFingerprint === (await tokenFingerprint(token))) {
+      return {
+        ok: true,
+        skipped: true,
+        reason: 'backoff',
+        nextAttemptAt: backoff.nextAttemptAt,
+        failureCount: backoff.failureCount ?? null,
+      };
+    }
+
+    console.log('[extension-sync] discarding backoff recorded for a superseded token');
+    await clearRefreshBackoff();
   }
 
   const expiresAtMs = Date.parse(stored[STORAGE_KEYS.extensionTokenExpiresAt] || '');

--- a/src/background/tokenRefresh.js
+++ b/src/background/tokenRefresh.js
@@ -26,7 +26,25 @@ function computeBackoffMs(failureCount, status) {
   return Math.min(BACKOFF_BASE_MS * 2 ** (failureCount - 1), BACKOFF_MAX_MS);
 }
 
-async function recordRefreshFailure(previousBackoff, status) {
+// 失敗を書き戻す直前に storage を読み直し、試行したトークンが今も保存されているか確認する。
+// fetch 中にユーザーが再連携すると saveExtensionAuthToken() が新トークンを保存しつつ
+// バックオフを削除するが、その保存は content 側で行われ runExclusive の外にあるため
+// 直列化されない。読み込み時点のスナップショットをそのまま書くと、削除済みのバックオフが
+// 復活して新しいトークンを最大24時間抑制してしまう。
+async function recordRefreshFailure(attemptedToken, status) {
+  const current = await storageGet([
+    STORAGE_KEYS.extensionAuthToken,
+    STORAGE_KEYS.extensionTokenRefreshBackoff,
+  ]);
+
+  if (current[STORAGE_KEYS.extensionAuthToken] !== attemptedToken) {
+    console.log('[extension-sync] token replaced during refresh; skipping backoff record', {
+      status: status ?? null,
+    });
+    return;
+  }
+
+  const previousBackoff = current[STORAGE_KEYS.extensionTokenRefreshBackoff] || null;
   const failureCount = Number(previousBackoff?.failureCount) > 0
     ? Number(previousBackoff.failureCount) + 1
     : 1;
@@ -106,7 +124,7 @@ async function performCheckAndRefreshToken() {
     console.warn('[extension-sync] token refresh failed; keeping current token', {
       message: error?.message,
     });
-    await recordRefreshFailure(backoff, null);
+    await recordRefreshFailure(token, null);
     return { ok: false, reason: 'network_error' };
   }
 
@@ -133,6 +151,6 @@ async function performCheckAndRefreshToken() {
   console.warn('[extension-sync] token refresh failed; keeping current token', {
     status: response.status,
   });
-  await recordRefreshFailure(backoff, response.status);
+  await recordRefreshFailure(token, response.status);
   return { ok: false, reason: 'refresh_failed' };
 }

--- a/src/content/extensionSync.js
+++ b/src/content/extensionSync.js
@@ -2,6 +2,7 @@ import {
   STORAGE_KEYS,
   storageGet,
   storageSet,
+  storageRemove,
   normalizePendingClips,
   clearExtensionAuthState,
 } from './../shared/storage.js';
@@ -120,6 +121,9 @@ export async function saveExtensionAuthToken(extensionInstanceId, extensionAuthT
       : null,
     [STORAGE_KEYS.extensionLinked]: true,
   });
+  // 新しいトークンを受けた時点で旧トークン時代の失敗回数は無効。抑制を持ち越すと
+  // 再連携直後のリフレッシュが不要に待たされる。
+  await storageRemove([STORAGE_KEYS.extensionTokenRefreshBackoff]);
   return true;
 }
 

--- a/src/shared/storage.js
+++ b/src/shared/storage.js
@@ -5,6 +5,7 @@ export const STORAGE_KEYS = {
   extensionInstanceId: 'extensionInstanceId',
   extensionAuthToken: 'extensionAuthToken',
   extensionTokenExpiresAt: 'extensionTokenExpiresAt',
+  extensionTokenRefreshBackoff: 'extensionTokenRefreshBackoff',
   extensionLinked: 'extensionLinked',
   lastSyncAt: 'lastSyncAt',
   pendingClips: 'pendingClips',
@@ -55,6 +56,8 @@ export async function clearExtensionAuthState() {
   await storageRemove([
     STORAGE_KEYS.extensionAuthToken,
     STORAGE_KEYS.extensionTokenExpiresAt,
+    // トークンを捨てる以上、旧トークンで積み上がったリフレッシュ抑制も持ち越さない。
+    STORAGE_KEYS.extensionTokenRefreshBackoff,
   ]);
   await storageSet({ [STORAGE_KEYS.extensionLinked]: false });
 }


### PR DESCRIPTION
Closes #117

## 問題

`checkAndRefreshToken()` は 401 以外のすべての失敗を握りつぶしてトークンを保持するが、バックオフも試行上限も持たない。そのため特定条件下で失敗リクエストを撃ち続ける。

`src/background/tokenRefresh.js` の `not_due` ゲートは `Number.isFinite(expiresAtMs)` が false のとき素通しになる。`expiresAt` が `null` のままリフレッシュが失敗し続けると `expiresAt` は更新されないため、**この状態から自力で抜けられない**。

頻度は想定より高い。リフレッシュの発火点が 2 つあるため。

- `TOKEN_REFRESH_ALARM` — 6 時間周期
- モジュールのトップレベル `checkAndRefreshToken()` — **SW のコールドスタート毎**（`src/background/background.js`）

MV3 の SW は ~30 秒アイドルで停止し `SYNC_RETRY_ALARM`（15 分周期）で起こされる。その度にモジュールが再評価されるため、実効的には**最低 15 分間隔**でリフレッシュが走る。

該当するのは主に次のケース。

- トークン期限の導入より前に連携したプロファイル → `expiresAt` は `null`
- サイトを react--site `d82de45` より前のリビジョンで動かしている → 404

## 変更内容

`src/background/sync.js` の `LOGIN_PROMPT_COOLDOWN_MS`（storage に時刻を持ってクールダウン）と同じパターンに揃えた。

| ファイル | 変更 |
|---|---|
| `src/shared/storage.js` | `extensionTokenRefreshBackoff` を `STORAGE_KEYS` に追加し、`clearExtensionAuthState()` の remove 対象に含めた |
| `src/background/tokenRefresh.js` | `{ failureCount, nextAttemptAt, lastStatus }` を保持。`not_linked` 判定の直後にゲートを置き、未到達なら `reason: 'backoff'` で早期 return |
| `src/content/extensionSync.js` | `saveExtensionAuthToken()` でバックオフを削除（再連携直後に古い抑制を持ち越さない） |

バックオフの間隔:

- 通常: `15分 × 2^(n-1)`、上限 24 時間
- **404 のみ初回から 6 時間**。サイト側がエンドポイントを未実装であることを意味し、短間隔で試す意味がないため
- `network_error` も失敗として計上
- 200 成功時にリセット。401 は `clearExtensionAuthState()` が併せて削除する

## サイト側 API 契約の状況

この PR はサイト側の新規実装を必要としない。依存する契約はすべて react--site `develop` で実装済み。

| 依存先 | 実装 |
|---|---|
| `POST /api/extension/token/refresh` | `src/app/api/extension/token/refresh/route.ts`（レスポンス `{ ok, extensionAuthToken, expiresAt }`、TTL 90 日） |
| `POST /api/extension/link` が `expiresAt` を返す | `src/app/api/extension/link/route.ts:29` |
| `EXT_LINK_WITH_AUTH_TOKEN` に `expiresAt` が載る | `src/lib/extension/client.ts:57` |

出典は react--site `d82de45`（**PR #59 で `develop` にマージ済み**、`git branch -r --contains d82de45` で `origin/develop` を確認）。

本 PR は既存プロファイルの移行時とサイトが古いリビジョンで動いている場合の**フォールバック挙動の改善**であり、契約の前倒しではない。

## 検証

- `npm run build` — 成功
- `npm run lint` — 変更 3 ファイルに指摘なし（既存 7 warnings は `history_change.js` 等の無関係箇所）
- `npm test` — 実行したが **tests 0**（`test/` が空でテストファイルが存在しないため）

## レビュー観点

- バックオフ間隔（通常 15 分開始 / 404 は 6 時間）が妥当か
- 404 を特別扱いする設計に異論がないか
- 再連携時のリセットを content 側（`saveExtensionAuthToken`）に置いた点