### PR TITLE
fix: コメント機能と再生handoffの統合を堅牢化

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm run build   # 一回ビルド
 npm run dev     # webpack --watch
 ```
 
-`manifest.json` は `dist/` のバンドル（`background.js` / `content.js` / `content_disney.js` / `extension_link.js`）を参照するため、**ビルドせずに読み込むと拡張は動作しない**（`dist/` は git 管理外）。
+`manifest.json` は `dist/` のバンドル（`background.js` / `content.js` / `content_disney.js` / `extension_link.js` / `getClipData.js`）を参照するため、**ビルドせずに読み込むと拡張は動作しない**（`dist/` は git 管理外）。
 
 ### 3. Load as a Chrome Extension
 

--- a/biome.json
+++ b/biome.json
@@ -14,7 +14,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "preset": "recommended"
     }
   },
   "javascript": {

--- a/documentation/comment-feature-review-fixes-2026-08-21.md
+++ b/documentation/comment-feature-review-fixes-2026-08-21.md
@@ -1,0 +1,428 @@
+# コメント機能ブランチ コードレビュー修正記録
+
+- 作成日: 2026-08-21
+- 修正ブランチ: `codex/fix-comment-feature-review`
+- 比較元: `codex/comment-feature-integration` (`29ceb47`)
+- 対象: コメント機能、認証・通信、Netflix / Disney+ 統合、再生状態管理
+
+## 1. 目的
+
+`codex/comment-feature-integration` のコードレビューで見つかった、誤ったクリップへのコメント投稿、複数タブ間の状態混線、認証競合、無期限の通信待ち、パネルのライフサイクル不備、Disney+ のDOM更新ループなどを修正する。
+
+今回の変更では、特に次の3点を設計上の軸とした。
+
+1. コメント対象は共有storageではなく、タブ固有の再生コンテキストを正とする。
+2. 共有再生状態の書き込みはbackgroundへ集約し、tab IDとnonceで所有権を検証する。
+3. 認証・コメント・同期処理は、応答順序とタイムアウトを明示して競合や永久待機を防ぐ。
+
+## 2. 対応結果の概要
+
+| レビュー指摘 | 主な問題 | 対応 | 状態 |
+|---|---|---|---|
+| コメント対象が全タブ共通 | 別タブで再生を始めると、開いているパネルの表示・投稿先が別クリップへ変わる | `sessionStorage` ベースのタブ固有コンテキストとbackground ownershipを導入 | ロジック・単体テストで対応済み |
+| Netflixのクリップ選択が不完全 | 選択したclipを保存せず、古いclipやplaylistへコメントする可能性 | 完全なsnapshotを登録してからcookie設定・新規タブ表示を行う | 対応済み |
+| 古い401が新トークンを削除 | コメント通信中の再連携と401処理が競合 | auth書き込みをbackgroundの共通mutexへ集約し、使用トークンを再照合 | 対応済み |
+| 成功レスポンスの検証不足 | 壊れたJSONを成功扱いし、空表示や重複投稿につながる | GET 200 / POST 201とAPIレスポンスschemaを厳密検証 | 対応済み |
+| background通信が無期限 | 1件の停止でコメント・同期・token refresh・再連携が詰まる | ヘッダー・JSON本文を含む15秒タイムアウトを追加 | 対応済み |
+| ログインタブが多重に開く | 連打で複数タブ生成、失敗後の再試行もcooldownで阻害 | in-flight共有、成功後のみcooldown記録 | 対応済み |
+| 投稿中の次の下書きが消える | 遅いPOST中に入力した文章を成功応答が消去 | 送信時の本文と現在値が一致する場合だけクリア | 対応済み |
+| 曖昧なPOST失敗で重複投稿 | server commit後のtimeout等で再投稿を促す | 一覧を再取得し、下書きを保持してユーザーに確認を促す | 対応済み |
+| パネル再注入・切断時の状態不整合 | 新ボタンのARIA表示が残る、listenerがリークする | trigger再登録、open-state通知、切断Observer、一括teardown | 対応済み |
+| コメント・メモ・一覧が重なる | プレイヤー幅とsidebar状態が競合 | 3種類のパネルを相互排他化し、元の幅を保存・復元 | 対応済み |
+| 入力中も動画shortcutが動く | Space・矢印などがpause/seekを発火 | window capture guard、light-DOM textarea、`stopImmediatePropagation` | 実装済み、実機確認が必要 |
+| Disney+のDOM更新が自己再発火 | 同じlabelを書き続け、MutationObserverとrAFがループ | 値が変わった場合だけ`textContent`を更新 | 対応済み |
+| SPA遷移・reload・tab closeの混同 | reloadで状態消失、手動遷移で古い状態が残る | route照合、`PREPARE_PLAYBACK_NAVIGATION`、tab lifecycle管理 | ロジック・単体テストで対応済み |
+
+## 3. 認証・コメント通信
+
+### 3.1 認証更新の直列化
+
+認証トークンの保存・解除をcontent scriptから直接storageへ書く方式から、backgroundメッセージ経由へ変更した。
+
+- [authState.js](../src/background/authState.js): token保存・unlinkを`runExclusive`内で処理
+- [background.js](../src/background/background.js): `SAVE_EXTENSION_AUTH_TOKEN` / `UNLINK_EXTENSION`を受付
+- [extensionSync.js](../src/content/extensionSync.js): site bridgeからbackgroundへ転送
+- [comments.js](../src/background/comments.js): 401時に、リクエストで使用したtokenと現在tokenを再照合
+
+これにより、旧tokenで開始したコメントリクエストが401になった直前・直後に再連携しても、新tokenを誤って削除しない。
+
+`extensionInstanceId` の生成もbackground側のin-flight Promiseへ集約し、同時要求で異なるIDが生成される競合を防いだ。
+
+### 3.2 APIレスポンスの検証
+
+[comments.js](../src/background/comments.js) では、HTTP成功だけではなく次の契約をすべて満たした場合だけ成功とする。
+
+- GETはHTTP 200、POSTはHTTP 201
+- top-level `ok === true`
+- GETの`clipId`が要求したclip IDと一致
+- commentの`id`、`clipId`、`userId`が正のsafe integer
+- `username`がstringまたはnull
+- `body`が1〜500文字
+- `createdAt`が正規化可能なISO日時
+- GETの`hasNext`と`nextCursor`が整合
+
+HTTP 200 / 201でも契約違反なら`invalid_response`を返し、UIが空一覧や投稿成功として誤処理しないようにした。
+
+### 3.3 タイムアウトとログインタブ
+
+[request.js](../src/background/request.js) に共通の15秒timeoutを追加した。`fetch()`のレスポンスヘッダー待ちだけでなく、`response.json()`の本文読み込みもAbort対象に含む。
+
+適用先:
+
+- コメントGET / POST
+- クリップ同期
+- token refresh
+
+コメントは`runExclusive`の待機時間も15秒の期限に含める。タイムアウトした要求が後からmutexを取得しても、新たなfetchは開始しない。
+
+ログインタブは全callerで1つのin-flight処理を共有する。タブ作成に成功した後だけcooldownを保存するため、Chrome側で作成に失敗した場合はすぐ再試行できる。
+
+## 4. タブ別再生コンテキストとownership
+
+### 4.1 タブ固有のコメント対象
+
+[playbackContext.js](../src/content/playbackContext.js) は、現在の`mode`と`clipId`をタブ単位の`sessionStorage`へ保存する。
+
+- 未初期化と「初期化済みだが再生対象なし」を区別
+- 初期化済みのnull状態では共有storageへフォールバックしない
+- `sessionStorage`が拒否・失敗した場合は、モジュール内メモリを正としてタブ分離を維持
+- context変更を同一タブ内イベントでコメントパネルへ通知
+
+[commentPanel.js](../src/content/commentPanel.js) はこのcontextを優先してclip IDを解決する。これにより、Tab Aでコメントを開いたままTab Bで別クリップを再生しても、Tab Aの投稿先は変わらない。
+
+### 4.2 backgroundを共有再生状態の単一writerにする
+
+[playbackOwnership.js](../src/background/playbackOwnership.js) は、`chrome.storage.session`に次のregistryを保持する。
+
+- `pending`: 再生開始前のnonce別handoff。TTLは30秒
+- `active`: tab IDごとの所有者、context、snapshot、route
+- `revision`: 同時刻の操作でも最新snapshotを決定できる単調増加番号
+
+共有`chrome.storage.local`へ再生状態を書けるのは、このmanagerの直列化された処理だけとした。
+
+```mermaid
+flowchart LR
+  A[BEGIN<br/>nonce + context + snapshot] --> B[pendingへ登録<br/>globalへsnapshot反映]
+  B --> C{CLAIM検証}
+  C -->|tab / opener / target<br/>nonce / route一致| D[activeへ移行<br/>snapshotを返却]
+  C -->|不一致・複数候補| X[fail-safeで再生しない]
+  D --> E[タブ内contextを設定]
+  E --> F[UPDATE<br/>playlist遷移]
+  F --> D
+  D --> G[PREPARE<br/>次routeを登録]
+  G --> H[自動navigation]
+  D --> I[RELEASE / tab close / 手動route変更]
+  I --> J{残ownerあり?}
+  J -->|あり| K[最新revisionのsnapshotを復元]
+  J -->|なし| L[global再生flagをreset]
+```
+
+### 4.3 claimとnavigationのルール
+
+- URLの`dextPlaybackOwner` nonceを最優先する
+- 明示nonceは送信元tab、opener、事前bind済みtargetのいずれかと一致した場合だけclaim可能
+- 旧サイト互換のnonceなし経路は、openerに紐づくpendingが厳密に1件の場合だけ許可
+- pendingが複数なら`ambiguous_handoff`として安全側で拒否
+- legacy BEGINが遅れる場合に備え、nonceなしclaimは最大約1秒再試行
+- staleなtab-local nonceは`handoff_not_found`または`route_mismatch`で破棄し、legacy handoffへ再試行
+- reloadは同じtab・同じrouteとしてownershipを維持
+- 自動playlist遷移は先に次routeを`PREPARE`する
+- 手動route変更、明示release、tab終了ではownershipを解除
+- owner解除・pending失効後は、残っている最新revisionのsnapshotを復元。何も残らなければ再生flagをreset
+
+## 5. コメントパネルとsidebar
+
+### 5.1 読み込みと投稿
+
+[commentPanel.js](../src/content/commentPanel.js) では、初回GETを共有する`baseLoadPromise`と、context更新中のrefresh queueを追加した。古いレスポンスは`contextVersion` / `requestVersion`で破棄する。
+
+投稿時は送信時のtextarea値を保存し、成功時点の現在値が同じ場合だけクリアする。投稿後に入力した次の下書きは残る。
+
+次のreasonは「serverへ保存された可能性がある曖昧な失敗」として扱う。
+
+- `invalid_response`
+- `network_error`
+- `timeout`
+- `background_unavailable`
+- `request_failed`
+
+この場合は本文を保持したまま一覧を再取得し、即時の再投稿を促さない。
+
+### 5.2 ライフサイクル
+
+- 再生成されたtriggerをactive controllerへ登録し直す
+- すべてのコメントボタンへ`aria-expanded`を同期
+- パネルhostがSPAのDOM差し替えで切断された場合はObserverでclose
+- storage、visibility、keyboard、beforeunload、custom event、MutationObserverをclose時に解除
+- ログインボタンとrefreshをin-flight中は再入不可にする
+
+### 5.3 keyboardと相互排他
+
+UI本体はShadow DOMに残し、textareaだけをlight DOMに置いてslot表示する。配信サイト側からも実際の`textarea`がイベントtargetとして見えるため、通常の入力欄除外ロジックが働きやすくなる。
+
+コメントパネルとメモはwindow captureでキーイベントを止める。メモ側も`stopImmediatePropagation()`へ統一した。
+
+コメント、録画メモ、Netflixのクリップ一覧は同時に開かない。別sidebarを開く前に現在のsidebarを正式に閉じ、プレイヤー幅は最初の値へ戻す。
+
+## 6. Netflix / Disney+統合
+
+### 6.1 Netflix
+
+- [netflixClipSelection.js](../src/content/netflixClipSelection.js) で、clip・clip ID・mode・owner nonceを1つのsnapshotとして登録
+- handoff完了後にcookie設定と`window.open`を実行
+- 起動時は共有storageではなくclaim結果のsnapshotから単体・playlistを開始
+- playlist遷移はowner確認付きUPDATEを完了してからseekまたはURL遷移
+- generationと終了監視解除処理により、古いseek loopや`timeupdate` listenerを停止
+- controls再生成時もコメントボタンのopen状態とARIAを同期
+- 手動SPA遷移ではcontext、コメント、監視処理を解除
+
+### 6.2 Disney+
+
+- Netflixと同じclaim / update / prepare navigation方式へ統一
+- 起動時に古い共有modeをそのまま再生せず、claim結果のsnapshotを使用
+- 同一URL・別URLのplaylist遷移をownership管理下へ移行
+- button labelは値が変わった場合だけ更新し、MutationObserverの自己再発火を防止
+- documentがすでにload済みの場合にもmode起動処理を実行
+
+### 6.3 localhost再生ブリッジ
+
+[getClipData.js](../src/content/getClipData.js) の`clipSelected`、`SET_CLIP_DATA`、`PLAY_PLAYLIST_START`は、共有storageへ直接モードを書かず、nonce付きの`BEGIN_PLAYBACK_HANDOFF`をbackgroundへ送るよう変更した。
+
+拡張自身が遷移先を作る経路では、URLへ`dextPlaybackOwner`を付与する。既存サイトがnonceを付けない経路は、openerと一意なpendingを使う互換claimで処理する。
+
+## 7. 変更ファイル
+
+### 新規コード
+
+| ファイル | 役割 |
+|---|---|
+| [authState.js](../src/background/authState.js) | 認証保存・解除のbackground直列化 |
+| [request.js](../src/background/request.js) | background fetchの15秒timeout |
+| [playbackOwnership.js](../src/background/playbackOwnership.js) | tab / nonce / route単位のownership manager |
+| [playbackContext.js](../src/content/playbackContext.js) | タブ固有のコメント対象context |
+| [playbackOwnership.js](../src/content/playbackOwnership.js) | content側ownership client |
+| [domUpdates.js](../src/content/domUpdates.js) | 同値DOM更新の抑制 |
+| [netflixClipSelection.js](../src/content/netflixClipSelection.js) | Netflix選択clipの原子的commit |
+
+### 主な変更コード
+
+- [background.js](../src/background/background.js)
+- [comments.js](../src/background/comments.js)
+- [sync.js](../src/background/sync.js)
+- [tokenRefresh.js](../src/background/tokenRefresh.js)
+- [commentPanel.js](../src/content/commentPanel.js)
+- [common.js](../src/content/common.js)
+- [content_netflix.js](../src/content/content_netflix.js)
+- [content_disney.js](../src/content/content_disney.js)
+- [extensionSync.js](../src/content/extensionSync.js)
+- [getClipData.js](../src/content/getClipData.js)
+
+### 新規テスト
+
+- [backgroundAuth.test.js](../test/backgroundAuth.test.js)
+- [backgroundRequest.test.js](../test/backgroundRequest.test.js)
+- [integrationHelpers.test.mjs](../test/content/integrationHelpers.test.mjs)
+- [playbackContext.test.js](../test/playbackContext.test.js)
+- [playbackOwnership.test.js](../test/playbackOwnership.test.js)
+- [playbackOwnershipClient.test.js](../test/playbackOwnershipClient.test.js)
+
+既存の`comments.test.js`、`commentPanel.test.js`、`content/common.test.mjs`も拡張した。追加テストは52件、全体は75件となった。
+
+## 8. 自動検証結果
+
+2026-08-21時点の結果。
+
+| コマンド | 結果 |
+|---|---|
+| `npm test` | 75 / 75 pass |
+| `npm run lint` | exit 0、error 0、warning 6、info 3 |
+| `npm run build` | webpack production build成功 |
+| `git diff --check` | 空白エラーなし |
+
+テスト時に`package.json`へ`type: module`がないことによる`MODULE_TYPELESS_PACKAGE_JSON`警告が出るが、テスト失敗ではない。Biomeには既存コード・設定由来を含むwarning / infoが残る。
+
+自動テストで主に確認している内容:
+
+- auth保存・unlink・401・再連携の順序
+- login tabの多重作成防止と失敗後再試行
+- response schema、status、cursor、clip ID整合
+- fetch header / JSON body / mutex待ちのtimeout
+- 下書き保持と曖昧POST判定
+- sidebar teardown、相互排他、元幅復元
+- Disney+同値label更新の抑制
+- Netflix snapshot登録後に画面を開く順序
+- tab-local contextとstorage failure fallback
+- rapid handoff、2 owner間のsnapshot復元、reload、手動route、自動route、期限切れ
+- 明示URL nonce、stale session nonce、legacy retry、曖昧handoff拒否
+
+## 9. 実ブラウザでの確認項目
+
+このリポジトリにはPlaywright / Cypress / Selenium等のE2E環境がない。次はChromeへextensionを読み込んだ実機smoke testが必要。
+
+1. Netflix / Disney+でサイト起点の単体clipを開き、正しいclipのコメントが表示・投稿される。
+2. playlistの同一URL遷移と別URL遷移で、コメント対象と再生区間が次clipへ変わる。
+3. Tab AとTab Bで別clipを再生し、片方の再生・投稿・closeが他方へ影響しない。
+4. 再生タブをreloadしてownershipが維持され、通常の別作品へ移動すると解除される。
+5. URLのquery削除やservice側redirect後もhandoffが成立する。
+6. controlsを表示・非表示してボタンが再生成されても、色と`aria-expanded`が一致する。
+7. コメント・メモ入力中にSpace、矢印、Enter、Escape、IME変換を操作し、意図しないpause / seekが起きない。
+8. site CSSの影響でtextareaの色、サイズ、pointer操作が崩れない。
+9. ログインボタンを連打してもタブが1枚だけ開き、タブ作成失敗後は再試行できる。
+10. API応答遅延・401・再連携時に、下書きと新tokenが保持される。
+
+実機確認前には`npm run build`を実行し、manifestが参照する`dist/content.js`、`dist/content_disney.js`、`dist/background.js`、`dist/extension_link.js`を更新する。
+
+## 10. 既知の未対応・残リスク
+
+### 10.1 localhost bridgeの入力境界
+
+[getClipData.js](../src/content/getClipData.js) には、今回の差分でも次が残っている。
+
+- `clipSelected`でlocalhostの非HttpOnly cookieを全件`clip`へ取り込む
+- 不正なpercent encodingで`decodeURIComponent`が例外になる可能性
+- `SET_CLIP_DATA`の`payload`欠落で例外になる
+- `SET_CLIP_DATA`のclip shapeを検証していない
+- playlist itemのID、URL、service、開始・終了時刻、件数・総サイズを検証していない
+
+backgroundのownership managerはtop-levelの許可キーとclip ID整合を検証するが、nested `clip` / `playQueue`の全schemaまでは検証しない。cookie whitelist、受信時の正規化、queue上限を別途実装する必要がある。
+
+ownership終了時のglobal resetはmode flag、`currentClipId`、owner nonce等を戻すが、`clip`、`playQueue`、`nextClip`本体は削除しない。このため、取り込まれた不要cookieや不正なqueueデータが`chrome.storage.local`へ残留するデータ最小化上の問題もある。
+
+入力検証では、少なくとも次を境界で確認する必要がある。
+
+- clip IDが正のsafe integer
+- `order`が重複しない非負整数
+- 対応serviceと妥当なURL
+- `0 <= startTime < endTime`となる有限数
+- queueの最大件数とシリアライズ後の最大サイズ
+
+未検証queueでは、ownershipとコメント対象だけが次clipへ更新された後に再生データの正規化が失敗し、「コメント対象は進んだが再生は進まない」「ownerが残る」といった不整合も起こり得る。
+
+### 10.2 Disney+のSPAイベント境界
+
+Disney+の`history.pushState` / `replaceState` hookはisolated world内にある。ページ本体のMAIN worldで行われるhistory変更を捕捉できない場合、backgroundはownershipを解除してもcontent側のModeやUI teardownが遅れる可能性がある。
+
+Netflixと同様にMAIN world hookへ統一するか、backgroundからcontentへownership解除を通知する改善を検討する。まず実サイトでの手動SPA遷移確認が必要。
+
+また、Disney+の補助的な`autoNav`は`chrome.storage.local`に置かれ、owner / tab単位ではない。複数のDisney+タブが同時に動くと、別タブがmarkerを先に読み取って削除し、遷移元タブの`sessionStorage` markerが残る可能性がある。後続の手動遷移を自動遷移と誤認しないか、2タブ実機試験とtab-scoped化が必要。
+
+### 10.3 ブラウザ固有の順序とサイト干渉
+
+- redirectでURL nonceが消え、opener / target bindingも取得できない場合は、安全側で再生開始を拒否する。この場合、誤ったclipは再生しないが、正しい再生も始まらない。
+- legacy retryは最大約1秒であり、service workerのcold startを含む実時間は未検証。
+- `tabs.onUpdated`、`tabs.onRemoved`、beforeunload、content reinjectionの順序はmockテストのみ。
+- slotted textareaはlight DOMのため、ページCSS / JSの影響を受ける。
+- 先に登録済みのsite側window-capture listenerは、後から登録したguardで遡って停止できない。
+
+これらは「ロジック上の誤ったclipへのフォールバックを禁止する」ところまでは実装済みだが、配信サイトとChromeの実イベント境界は実機smokeで確認する必要がある。
+
+## 11. マージ前の完了条件
+
+- [x] unit test 75件成功
+- [x] lint error 0
+- [x] production build成功
+- [x] `git diff --check`成功
+- [ ] Netflix実機smoke
+- [ ] Disney+実機smoke
+- [ ] localhost siteとのAPI・auth・handoff結合確認
+- [ ] localhost bridge入力検証を実装し、回帰テストを追加
+
+## 12. Mergeまでの作業リスト
+
+### Phase 1: bridge契約を確定する
+
+- [x] cookieから受け付けるキーのwhitelistを確定する
+  - `title`, `user`, `url`, `service`, `clipId`, `username`
+  - legacyの`starttime` / `endtime`は`startTime` / `endTime`へ正規化
+- [x] 単体clipとplaylist itemの正準schemaを決める
+- [x] playlistの最大件数とシリアライズ後の最大サイズを決める
+- [x] 不正データは一部採用せず、handoff全体を拒否する方針に統一する
+- [x] 拒否時のconsole warningとユーザー通知方針を決める
+
+完了条件: localhost site側の実データ例と矛盾しない入力契約が文章化されている。  
+完了資料: [Localhost playback bridge input contract v1](./localhost-playback-bridge-contract-v1.md)
+
+### Phase 2: localhost bridgeを修正する
+
+- [ ] cookieをwhitelistで抽出し、未知のcookieを保存しない
+- [ ] cookie decodeをtry/catchし、不正なpercent encodingでlistenerを落とさない
+- [ ] `clipSelected`のdetailとcookieから正準clipを生成する
+- [ ] `SET_CLIP_DATA`で`payload` / `clip`の存在と型を確認する
+- [ ] clip IDを正のsafe integerへ正規化する
+- [ ] `service`とURLを検証する
+- [ ] `startTime` / `endTime`を有限数へ正規化し、`0 <= startTime < endTime`を検証する
+- [ ] playlistの各itemを正規化する
+- [ ] `order`を非負整数へ統一し、重複を拒否する
+- [ ] queue件数・サイズが上限を超えた場合はhandoffを開始しない
+- [ ] `BEGIN_PLAYBACK_HANDOFF`失敗時に後続navigationを開始しない経路を確認する
+- [ ] owner / pendingがないglobal resetで、不要な`clip` / `playQueue` / `nextClip`も消去する
+- [ ] background側でもnested clip / queueを最低限再検証し、多層防御にする
+
+完了条件: 不正入力が`chrome.storage.local`、ownership registry、再生contextのどこにも保存されない。
+
+### Phase 3: 自動テストを追加する
+
+- [ ] 許可cookieだけがclipへ入るテスト
+- [ ] legacyの小文字時刻が正準化されるテスト
+- [ ] 不正percent encodingで例外にならないテスト
+- [ ] `SET_CLIP_DATA`のpayload欠落・clip欠落を拒否するテスト
+- [ ] 0、負数、unsafe integer、非数値clip IDを拒否するテスト
+- [ ] 不正URL・未対応serviceを拒否するテスト
+- [ ] NaN、Infinity、負の開始時刻、終了 <= 開始を拒否するテスト
+- [ ] playlistの空配列、不正item、order重複、上限超過を拒否するテスト
+- [ ] 不正queueでglobal snapshotやownerが更新されないテスト
+- [ ] ownerなしresetで機微なclip / queueデータが残らないテスト
+- [ ] `npm test`を全件成功させる
+- [ ] `npm run lint`でerror 0を確認する
+- [ ] `npm run build`を成功させる
+- [ ] `git diff --check`を成功させる
+
+完了条件: bridgeの正常系・異常系が自動テストされ、全検証コマンドが成功する。
+
+### Phase 4: localhost siteとの結合確認
+
+- [ ] Chromeで最新`dist`を読み込む
+- [ ] 未連携状態からlogin tabを開き、siteと連携できる
+- [ ] unlink後にtokenが消え、再連携で新tokenが保存される
+- [ ] コメントGET / POSTがBearer tokenと正しい`extensionInstanceId`で成功する
+- [ ] 古いtokenの401と再連携が重なっても新tokenが消えない
+- [ ] localhost起点の単体clipをNetflixで開始できる
+- [ ] localhost起点の単体clipをDisney+で開始できる
+- [ ] nonce付きhandoffが正しいclipへclaimされる
+- [ ] 既存のnonceなしhandoffが一意なopener pendingへclaimされる
+- [ ] query削除・redirect後の挙動を確認する
+- [ ] playlistの同一URL遷移を確認する
+- [ ] playlistの別URL・別service遷移を確認する
+
+完了条件: site、extension、background、配信サービスを通る主要な正常系が実Chromeで成立する。
+
+### Phase 5: 複数タブとUIの実機smoke
+
+- [ ] Tab A / Tab Bで別clipを再生し、コメント対象が混線しない
+- [ ] Tab Bを閉じてもTab Aの再生・コメントが維持される
+- [ ] reload後も同じclipのownershipが復元される
+- [ ] 手動で別作品へ移動すると再生contextとコメントパネルが解除される
+- [ ] Disney+の手動SPA遷移をcontent側が検知できる
+- [ ] Disney+の2タブ同時自動遷移で`autoNav` markerが混線しない
+- [ ] controls再生成後もコメントボタンの色とARIAが一致する
+- [ ] コメント・メモ入力中のSpace、矢印、Enter、Escape、IMEを確認する
+- [ ] site CSSでtextareaの表示・操作が崩れない
+
+失敗時の対応:
+
+- Disney+のSPA変更を検知できなければ、Netflixと同様のMAIN-world history hookへ移行する
+- `autoNav`が混線する場合は、owner nonceまたはtab IDに紐づく状態へ変更する
+- redirectでclaimできない場合は、URL nonceとtarget bindingの引き継ぎ方法を見直す
+
+完了条件: 誤ったclipへ再生・コメント投稿しないことと、入力UIが配信サイトの操作と競合しないことを確認する。
+
+### Phase 6: Merge準備
+
+- [ ] 実機確認日、Chrome version、site revision、API revisionを記録する
+- [ ] 成功・失敗したsmoke結果を本資料へ追記する
+- [ ] 未解決項目があればissue化し、merge blockerかfollow-upかを明記する
+- [ ] 最終diffを再レビューする
+- [ ] commitを作成する
+- [ ] draft PRを通常PRへ切り替える
+
+最終完了条件: Phase 1〜5が完了し、残課題と検証証跡をレビュー可能な状態でmergeする。

--- a/documentation/comment-feature-review-fixes-2026-08-21.md
+++ b/documentation/comment-feature-review-fixes-2026-08-21.md
@@ -29,7 +29,7 @@
 | 曖昧なPOST失敗で重複投稿 | server commit後のtimeout等で再投稿を促す | 一覧を再取得し、下書きを保持してユーザーに確認を促す | 対応済み |
 | パネル再注入・切断時の状態不整合 | 新ボタンのARIA表示が残る、listenerがリークする | trigger再登録、open-state通知、切断Observer、一括teardown | 対応済み |
 | コメント・メモ・一覧が重なる | プレイヤー幅とsidebar状態が競合 | 3種類のパネルを相互排他化し、元の幅を保存・復元 | 対応済み |
-| 入力中も動画shortcutが動く | Space・矢印などがpause/seekを発火 | window capture guard、light-DOM textarea、`stopImmediatePropagation` | 実装済み、実機確認が必要 |
+| 入力中も動画shortcutが動く | Space・矢印などがpause/seekを発火 | window capture guard、light-DOM textarea、`stopImmediatePropagation` | 実装済み、Phase 5実機確認済み |
 | Disney+のDOM更新が自己再発火 | 同じlabelを書き続け、MutationObserverとrAFがループ | 値が変わった場合だけ`textContent`を更新 | 対応済み |
 | SPA遷移・reload・tab closeの混同 | reloadで状態消失、手動遷移で古い状態が残る | route照合、`PREPARE_PLAYBACK_NAVIGATION`、tab lifecycle管理 | ロジック・単体テストで対応済み |
 
@@ -55,7 +55,7 @@
 - GETはHTTP 200、POSTはHTTP 201
 - top-level `ok === true`
 - GETの`clipId`が要求したclip IDと一致
-- commentの`id`、`clipId`、`userId`が正のsafe integer
+- commentの`id`、`clipId`が正のsafe integerで、`userId`は正のsafe integerまたは退会ユーザー匿名化時の`null`
 - `username`がstringまたはnull
 - `body`が1〜500文字
 - `createdAt`が正規化可能なISO日時
@@ -226,7 +226,7 @@ UI本体はShadow DOMに残し、textareaだけをlight DOMに置いてslot表�
 - [playbackOwnership.test.js](../test/playbackOwnership.test.js)
 - [playbackOwnershipClient.test.js](../test/playbackOwnershipClient.test.js)
 
-既存の`comments.test.js`、`commentPanel.test.js`、`content/common.test.mjs`も拡張した。追加テストは52件、全体は75件となった。
+既存の`comments.test.js`、`commentPanel.test.js`、`content/common.test.mjs`も拡張した。初回レビュー修正時点では追加52件・全体75件で、Phase 2〜4のbridge / ownership回帰テスト追加後は全体95件となった。
 
 ## 8. 自動検証結果
 
@@ -234,12 +234,12 @@ UI本体はShadow DOMに残し、textareaだけをlight DOMに置いてslot表�
 
 | コマンド | 結果 |
 |---|---|
-| `npm test` | 75 / 75 pass |
-| `npm run lint` | exit 0、error 0、warning 6、info 3 |
+| `npm test` | 95 / 95 pass |
+| `npm run lint` | exit 0、error 0、warning 0、info 0 |
 | `npm run build` | webpack production build成功 |
 | `git diff --check` | 空白エラーなし |
 
-テスト時に`package.json`へ`type: module`がないことによる`MODULE_TYPELESS_PACKAGE_JSON`警告が出るが、テスト失敗ではない。Biomeには既存コード・設定由来を含むwarning / infoが残る。
+テスト時に`package.json`へ`type: module`がないことによる`MODULE_TYPELESS_PACKAGE_JSON`警告が出るが、テスト失敗ではない。Biomeのlint diagnosticsは0件。
 
 自動テストで主に確認している内容:
 
@@ -270,41 +270,35 @@ UI本体はShadow DOMに残し、textareaだけをlight DOMに置いてslot表�
 9. ログインボタンを連打してもタブが1枚だけ開き、タブ作成失敗後は再試行できる。
 10. API応答遅延・401・再連携時に、下書きと新tokenが保持される。
 
-実機確認前には`npm run build`を実行し、manifestが参照する`dist/content.js`、`dist/content_disney.js`、`dist/background.js`、`dist/extension_link.js`を更新する。
+実機確認前には`npm run build`を実行し、manifestが参照する`dist/content.js`、`dist/content_disney.js`、`dist/background.js`、`dist/extension_link.js`、`dist/getClipData.js`を更新する。
 
 ## 10. 既知の未対応・残リスク
 
 ### 10.1 localhost bridgeの入力境界
 
-[getClipData.js](../src/content/getClipData.js) には、今回の差分でも次が残っている。
+Phase 2で[playbackBridgeValidation.js](../src/shared/playbackBridgeValidation.js)を追加し、`clipSelected`、`SET_CLIP_DATA`、`PLAY_PLAYLIST_START`を同じ正準schemaへ統一した。[getClipData.js](../src/content/getClipData.js)はwebpack entry化し、manifestは`dist/getClipData.js`を参照する。
 
-- `clipSelected`でlocalhostの非HttpOnly cookieを全件`clip`へ取り込む
-- 不正なpercent encodingで`decodeURIComponent`が例外になる可能性
-- `SET_CLIP_DATA`の`payload`欠落で例外になる
-- `SET_CLIP_DATA`のclip shapeを検証していない
-- playlist itemのID、URL、service、開始・終了時刻、件数・総サイズを検証していない
+実装済み:
 
-backgroundのownership managerはtop-levelの許可キーとclip ID整合を検証するが、nested `clip` / `playQueue`の全schemaまでは検証しない。cookie whitelist、受信時の正規化、queue上限を別途実装する必要がある。
+- cookie whitelistとcookie単位の安全なdecode
+- detailを正本とするclip ID整合確認
+- 正のsafe integer ID、Netflix / Disney+ service、HTTPS hostname、時刻範囲の検証
+- playlist itemの正規化、欠落orderのindex補完、明示的不正値・重複の拒否
+- 最大100件、raw / 正規化後とも512 KiBの上限
+- 不正入力時のall-or-nothing拒否と安全なresult message
+- background ownership managerでのnested clip / queue再検証
+- owner / pending消滅時の`clip`、`playQueue`、`nextClip`消去
+- canonical absolute URLに合わせたNetflixのservice-aware遷移
 
-ownership終了時のglobal resetはmode flag、`currentClipId`、owner nonce等を戻すが、`clip`、`playQueue`、`nextClip`本体は削除しない。このため、取り込まれた不要cookieや不正なqueueデータが`chrome.storage.local`へ残留するデータ最小化上の問題もある。
-
-入力検証では、少なくとも次を境界で確認する必要がある。
-
-- clip IDが正のsafe integer
-- `order`が重複しない非負整数
-- 対応serviceと妥当なURL
-- `0 <= startTime < endTime`となる有限数
-- queueの最大件数とシリアライズ後の最大サイズ
-
-未検証queueでは、ownershipとコメント対象だけが次clipへ更新された後に再生データの正規化が失敗し、「コメント対象は進んだが再生は進まない」「ownerが残る」といった不整合も起こり得る。
+Phase 4ではlocalhost site（`C:\dev\react--site`）の実装も確認し、`clipSelected.detail.clipId`送信、handoff結果の同一origin通知、ユーザー向け成功・失敗表示まで結合した。site側のroot layoutには認証bridgeとhandoff結果表示を常設し、content scriptの起動が遅い場合は認証状態確認を最大3回再試行する。
 
 ### 10.2 Disney+のSPAイベント境界
 
-Disney+の`history.pushState` / `replaceState` hookはisolated world内にある。ページ本体のMAIN worldで行われるhistory変更を捕捉できない場合、backgroundはownershipを解除してもcontent側のModeやUI teardownが遅れる可能性がある。
+Phase 5の実Chrome試験で、isolated world内のhookではページ本体の`history.pushState`を捕捉できず、backgroundがownershipを解除した後もcontent側にclip contextとコメントパネルが残ることを再現した。
 
-Netflixと同様にMAIN world hookへ統一するか、backgroundからcontentへownership解除を通知する改善を検討する。まず実サイトでの手動SPA遷移確認が必要。
+Disney+でも`src/util/history_change.js`を`document_start`のMAIN world content scriptとして実行し、content側は`historyChange`イベントを監視する構成へ変更した。手動SPA遷移後にcontext、owner nonce、コメントパネルが解除され、global playback stateもresetされることを再確認済みである。
 
-また、Disney+の補助的な`autoNav`は`chrome.storage.local`に置かれ、owner / tab単位ではない。複数のDisney+タブが同時に動くと、別タブがmarkerを先に読み取って削除し、遷移元タブの`sessionStorage` markerが残る可能性がある。後続の手動遷移を自動遷移と誤認しないか、2タブ実機試験とtab-scoped化が必要。
+全タブ共有だった`chrome.storage.local.autoNav`はPhase 4後の再監査で既に廃止し、background ownershipのprepared routeをtab / owner nonce単位でclaim結果へ引き継ぐ方式へ変更した。Phase 5では異なるowner・次clip・次URLを持つDisney+の2タブを同時に遷移させ、各タブがそれぞれのnonceとclip IDを維持することを実Chromeで確認した。
 
 ### 10.3 ブラウザ固有の順序とサイト干渉
 
@@ -318,14 +312,14 @@ Netflixと同様にMAIN world hookへ統一するか、backgroundからcontent�
 
 ## 11. マージ前の完了条件
 
-- [x] unit test 75件成功
-- [x] lint error 0
+- [x] unit test 98件成功
+- [x] lint error / warning / info 0
 - [x] production build成功
 - [x] `git diff --check`成功
-- [ ] Netflix実機smoke
-- [ ] Disney+実機smoke
-- [ ] localhost siteとのAPI・auth・handoff結合確認
-- [ ] localhost bridge入力検証を実装し、回帰テストを追加
+- [x] Netflix実機smoke
+- [x] Disney+実機smoke
+- [x] localhost siteとのAPI・auth・handoff結合確認
+- [x] localhost bridge入力検証を実装し、回帰テストを追加
 
 ## 12. Mergeまでの作業リスト
 
@@ -344,69 +338,109 @@ Netflixと同様にMAIN world hookへ統一するか、backgroundからcontent�
 
 ### Phase 2: localhost bridgeを修正する
 
-- [ ] cookieをwhitelistで抽出し、未知のcookieを保存しない
-- [ ] cookie decodeをtry/catchし、不正なpercent encodingでlistenerを落とさない
-- [ ] `clipSelected`のdetailとcookieから正準clipを生成する
-- [ ] `SET_CLIP_DATA`で`payload` / `clip`の存在と型を確認する
-- [ ] clip IDを正のsafe integerへ正規化する
-- [ ] `service`とURLを検証する
-- [ ] `startTime` / `endTime`を有限数へ正規化し、`0 <= startTime < endTime`を検証する
-- [ ] playlistの各itemを正規化する
-- [ ] `order`を非負整数へ統一し、重複を拒否する
-- [ ] queue件数・サイズが上限を超えた場合はhandoffを開始しない
-- [ ] `BEGIN_PLAYBACK_HANDOFF`失敗時に後続navigationを開始しない経路を確認する
-- [ ] owner / pendingがないglobal resetで、不要な`clip` / `playQueue` / `nextClip`も消去する
-- [ ] background側でもnested clip / queueを最低限再検証し、多層防御にする
+- [x] cookieをwhitelistで抽出し、未知のcookieを保存しない
+- [x] cookie decodeをtry/catchし、不正なpercent encodingでlistenerを落とさない
+- [x] `clipSelected`のdetailとcookieから正準clipを生成する
+- [x] `SET_CLIP_DATA`で`payload` / `clip`の存在と型を確認する
+- [x] clip IDを正のsafe integerへ正規化する
+- [x] `service`とURLを検証する
+- [x] `startTime` / `endTime`を有限数へ正規化し、`0 <= startTime < endTime`を検証する
+- [x] playlistの各itemを正規化する
+- [x] `order`を非負整数へ統一し、重複を拒否する
+- [x] queue件数・サイズが上限を超えた場合はhandoffを開始しない
+- [x] `BEGIN_PLAYBACK_HANDOFF`失敗時に後続navigationを開始しない経路を確認する
+- [x] owner / pendingがないglobal resetで、不要な`clip` / `playQueue` / `nextClip`も消去する
+- [x] background側でもnested clip / queueを最低限再検証し、多層防御にする
 
 完了条件: 不正入力が`chrome.storage.local`、ownership registry、再生contextのどこにも保存されない。
 
 ### Phase 3: 自動テストを追加する
 
-- [ ] 許可cookieだけがclipへ入るテスト
-- [ ] legacyの小文字時刻が正準化されるテスト
-- [ ] 不正percent encodingで例外にならないテスト
-- [ ] `SET_CLIP_DATA`のpayload欠落・clip欠落を拒否するテスト
-- [ ] 0、負数、unsafe integer、非数値clip IDを拒否するテスト
-- [ ] 不正URL・未対応serviceを拒否するテスト
-- [ ] NaN、Infinity、負の開始時刻、終了 <= 開始を拒否するテスト
-- [ ] playlistの空配列、不正item、order重複、上限超過を拒否するテスト
-- [ ] 不正queueでglobal snapshotやownerが更新されないテスト
-- [ ] ownerなしresetで機微なclip / queueデータが残らないテスト
-- [ ] `npm test`を全件成功させる
-- [ ] `npm run lint`でerror 0を確認する
-- [ ] `npm run build`を成功させる
-- [ ] `git diff --check`を成功させる
+- [x] 許可cookieだけがclipへ入るテスト
+- [x] legacyの小文字時刻が正準化されるテスト
+- [x] 不正percent encodingで例外にならないテスト
+- [x] `SET_CLIP_DATA`のpayload欠落・clip欠落を拒否するテスト
+- [x] 0、負数、unsafe integer、非数値clip IDを拒否するテスト
+- [x] 不正URL・未対応serviceを拒否するテスト
+- [x] NaN、Infinity、負の開始時刻、終了 <= 開始を拒否するテスト
+- [x] playlistの空配列、不正item、order重複、上限超過を拒否するテスト
+- [x] 不正queueでglobal snapshotやownerが更新されないテスト
+- [x] ownerなしresetで機微なclip / queueデータが残らないテスト
+- [x] `npm test`を全件成功させる
+- [x] `npm run lint`でerror / warning / info 0を確認する
+- [x] `npm run build`を成功させる
+- [x] `git diff --check`を成功させる
 
 完了条件: bridgeの正常系・異常系が自動テストされ、全検証コマンドが成功する。
 
 ### Phase 4: localhost siteとの結合確認
 
-- [ ] Chromeで最新`dist`を読み込む
-- [ ] 未連携状態からlogin tabを開き、siteと連携できる
-- [ ] unlink後にtokenが消え、再連携で新tokenが保存される
-- [ ] コメントGET / POSTがBearer tokenと正しい`extensionInstanceId`で成功する
+- [x] Chromeで最新`dist`を読み込む
+- [x] 未連携状態からlogin tabを開き、siteと連携できる
+- [x] unlink後にtokenが消え、再連携で新tokenが保存される
+- [x] コメントGET / POSTがBearer tokenと正しい`extensionInstanceId`で成功する
 - [ ] 古いtokenの401と再連携が重なっても新tokenが消えない
-- [ ] localhost起点の単体clipをNetflixで開始できる
-- [ ] localhost起点の単体clipをDisney+で開始できる
-- [ ] nonce付きhandoffが正しいclipへclaimされる
-- [ ] 既存のnonceなしhandoffが一意なopener pendingへclaimされる
-- [ ] query削除・redirect後の挙動を確認する
-- [ ] playlistの同一URL遷移を確認する
-- [ ] playlistの別URL・別service遷移を確認する
+- [x] localhost起点の単体clipをNetflixで開始できる
+- [x] localhost起点の単体clipをDisney+で開始できる
+- [x] nonce付きhandoffが正しいclipへclaimされる
+- [x] 既存のnonceなしhandoffが一意なopener pendingへclaimされる
+- [x] URLからnonceを削除した後もreloadでownershipを復元できる
+- [x] playlistの同一URL遷移を確認する
+- [x] playlistの別URL・別service遷移を確認する
 
 完了条件: site、extension、background、配信サービスを通る主要な正常系が実Chromeで成立する。
 
+#### Phase 4 実施結果（2026-08-21）
+
+検証環境:
+
+- Chrome `151.0.7922.138`
+- extension branch `codex/fix-comment-feature-review`
+- localhost site revision `9f591862fddc9a71d88590c489ac47ffd311c6a9` にPhase 4の未commit修正を追加
+- localhost DB migration `20260809000000_harden_clip_comments` を適用
+
+結合確認結果:
+
+- siteのextension API smokeは31 / 31成功した。
+- 実extensionのBearer tokenと36文字の`extensionInstanceId`でコメントGET / POSTが成功した。作成した検証コメントは確認後に削除した。
+- unlinkでtokenと現instanceの連携行が消え、同じinstance IDの再連携で別tokenが保存された。
+- localhostの単体再生からNetflix clip 61をnonceなし互換経路でclaimし、コメント対象、再生context、コメントボタンが一致した。
+- localhostの単体再生からDisney+ clip 24をnonceなし互換経路でclaimし、コメント対象、再生context、コメントボタン、開始位置812秒が一致した。
+- nonce付きplaylist handoffをDisney+ clip 23でclaimし、同一URLのclip 24へ遷移後、`currentClipOrder`、`currentClipId`、コメント対象、開始位置812秒が更新された。
+- Netflix clip 61からDisney+ clip 24への別URL・別service遷移が同じtabとowner nonceで成立した。
+- URLから`dextPlaybackOwner`を除去してreloadしても、tab-local nonceからclip 24のownershipを復元した。今回の実データではservice側redirect自体は発生しなかった。
+- siteのhandoff成功・失敗通知は同一window / 同一originだけを受け、成功時`role=status`、失敗時`role=alert`で表示された。
+
+実機で判明して修正した結合不整合:
+
+1. siteの`ExtensionLinker`がroot layoutにmountされておらず、自動連携が開始されなかった。
+2. siteの初回認証確認がcontent scriptの`document_idle`登録より先に1回だけ送られ、起動競合で未連携表示が残った。250ms間隔・最大3回の再試行へ変更した。
+3. siteが`EXTENSION_PLAYBACK_HANDOFF_RESULT`を表示していなかったため、共通status / alertを追加した。
+4. siteの単体再生が`service` cookieを書かず、extensionが`invalid_service`で拒否したため、許可済みserviceをcookieへ追加した。
+5. siteのDisney+正式コードが`DISNEY_PLUS`、extensionの受理値が`Disney+` / `disney`だけだったため、`DISNEY_PLUS`を`disneyplus`へ正規化した。
+
+検証コマンド:
+
+- extension: `npm test` 95 / 95、`npm run lint` diagnostics 0、`npm run build`成功
+- site: `npm run codex:quick` 141 / 141、lint成功、typecheck成功
+- site API: `npm run smoke:extension` 31 / 31
+
+未完了項目:
+
+- 古いtokenの401応答と再連携の保存が同一実時間で交錯するケースは、実APIでは意図的に競合させていない。旧token 401後の再連携、再連携後の旧401、置換済みtokenを消さないCASの3経路は自動テスト済みであり、通常のunlink / relink実機確認も成功している。
+- 既存playlist 1のNetflix URLは現在のアカウントでplayerを生成できない古い作品だったため、playlist遷移はsiteと同じ`playQueue`形式の一時fixtureで確認した。DBにはfixtureを保存していない。
+
 ### Phase 5: 複数タブとUIの実機smoke
 
-- [ ] Tab A / Tab Bで別clipを再生し、コメント対象が混線しない
-- [ ] Tab Bを閉じてもTab Aの再生・コメントが維持される
-- [ ] reload後も同じclipのownershipが復元される
-- [ ] 手動で別作品へ移動すると再生contextとコメントパネルが解除される
-- [ ] Disney+の手動SPA遷移をcontent側が検知できる
-- [ ] Disney+の2タブ同時自動遷移で`autoNav` markerが混線しない
-- [ ] controls再生成後もコメントボタンの色とARIAが一致する
-- [ ] コメント・メモ入力中のSpace、矢印、Enter、Escape、IMEを確認する
-- [ ] site CSSでtextareaの表示・操作が崩れない
+- [x] Tab A / Tab Bで別clipを再生し、コメント対象が混線しない
+- [x] Tab Bを閉じてもTab Aの再生・コメントが維持される
+- [x] reload後も同じclipのownershipが復元される
+- [x] 手動で別作品へ移動すると再生contextとコメントパネルが解除される
+- [x] Disney+の手動SPA遷移をcontent側が検知できる
+- [x] Disney+の2タブ同時自動遷移で`autoNav` markerが混線しない
+- [x] controls再生成後もコメントボタンの色とARIAが一致する
+- [x] コメント・メモ入力中のSpace、矢印、Enter、Escape、IMEを確認する
+- [x] site CSSでtextareaの表示・操作が崩れない
 
 失敗時の対応:
 
@@ -416,13 +450,75 @@ Netflixと同様にMAIN world hookへ統一するか、backgroundからcontent�
 
 完了条件: 誤ったclipへ再生・コメント投稿しないことと、入力UIが配信サイトの操作と競合しないことを確認する。
 
+#### Phase 5 実施結果（2026-08-22）
+
+検証環境:
+
+- Chrome `151.0.7922.138`（Windows、専用プロフィール、unpacked extension）
+- extension: `codex/fix-comment-feature-review`、HEAD `6293cb7` + Phase 1〜5の未commit差分
+- localhost site / API: `C:\dev\react--site`、HEAD `9f59186` + Phase 4の未commit結合差分
+
+確認結果:
+
+- Netflix clip 61とDisney+ clip 24を別タブで同時にowner化し、両タブのsession context、owner nonce、コメントパネルが別々に維持された。global stateが後から開いたtabへ切り替わっても、既存tabのコメント対象は変化しなかった。
+- Disney+側のtabを閉じてもNetflix側のclip 61、owner nonce、開いていたコメントパネルは維持された。
+- Netflix clip 61をreloadし、URL queryを除去済みの状態でも同じtab-local nonceとclip 61 contextが復元された。
+- NetflixでMAIN-world `history.pushState`による手動route変更を行い、context、nonce、コメントパネル、global stateが解除された。
+- Disney+では最初の試験で、isolated-world history hookがMAIN-worldのroute変更を捕捉できない不具合を再現した。MAIN-world hookへ修正後、同じ手順でcontext、nonce、パネルの解除を確認した。
+- 一時fixtureを使い、Disney+ Tab Aをclip 23からclip 101 / 別URLへ、Tab Bをclip 24からclip 102 / 別URLへほぼ同時に自動遷移させた。両tabとも固有nonceと期待clip IDを維持し、marker混線はなかった。fixtureはDBへ保存していない。
+- Disney+でコメントパネルを開いたままコメントbuttonをDOMから除去し、再生成後も`aria-expanded=true`とactive表示が維持され、新buttonから閉じると両方がfalseへ戻った。
+- 実clip 24のコメントtextareaでSpace、矢印、Enter、Escape、日本語入力・composition eventを実行した。document / page側のkeydownへ伝播せず、動画はpause位置を維持し、Escapeだけがパネルを閉じた。
+- メモ入力ではSpace、矢印、Escape、日本語入力、IME変換中Enterを実行した。page側へ伝播せず、動画状態とsidebarを維持した。通常Enterは保存操作になるため、不要なAPI書き込みを避けてIME変換中Enterで確認した。
+- textareaは`color: rgb(17, 17, 17)`、白背景、`pointer-events:auto`、実寸`387.3 x 82px`で、Disney+のpage CSSによる表示・操作崩れはなかった。
+
+試験上の境界:
+
+- Netflix同士の同時player起動はサービス側のM7020で拒否されたため、一般の2tab分離はNetflix / Disney+のcross-service、同一serviceの同時自動遷移はDisney+ 2tabで確認した。
+- 実IME候補ウィンドウの視覚確認は自動化対象外だが、composition event、入力値、キー伝播、動画状態は確認した。
+
 ### Phase 6: Merge準備
 
-- [ ] 実機確認日、Chrome version、site revision、API revisionを記録する
-- [ ] 成功・失敗したsmoke結果を本資料へ追記する
-- [ ] 未解決項目があればissue化し、merge blockerかfollow-upかを明記する
-- [ ] 最終diffを再レビューする
-- [ ] commitを作成する
-- [ ] draft PRを通常PRへ切り替える
+- [x] 実機確認日、Chrome version、site revision、API revisionを記録する
+- [x] 成功・失敗したsmoke結果を本資料へ追記する
+- [x] 未解決項目があればissue化し、merge blockerかfollow-upかを明記する
+- [x] 最終diffを再レビューする
+- [x] commitを作成する
+- [x] PRを通常レビュー可能な状態にする（既存draft PRは無いため、通常PRを新規作成）
 
 最終完了条件: Phase 1〜5が完了し、残課題と検証証跡をレビュー可能な状態でmergeする。
+
+#### Phase 6 実施結果（2026-08-23）
+
+- 実機smoke実施日: 2026-08-22
+- Chrome: `151.0.7922.138`（Windows、専用profile、Load unpacked）
+- extension: branch `codex/fix-comment-feature-review`、レビュー開始HEAD `6293cb7` + Phase 1〜5差分
+- localhost site / API: `C:\dev\react--site`、branch `feat/clip-comments-site-ui-squashed`、ローカルHEAD `9f591862fddc9a71d88590c489ac47ffd311c6a9`
+- site remote revision: [FigFingers/react--site#62](https://github.com/FigFingers/react--site/pull/62) のHEAD `486bca3141b897833844e87b5c12cac9040a8dba`
+- 最終自動検証: `npm test` 98/98、`npm run lint` error 0、`npm run build`成功、`git diff --check`成功
+
+最終diffでは、backgroundのauth / timeout / comment schema、tab-scoped playback ownership、localhost bridge validator、Netflix / Disney+ lifecycle、コメントpanel、manifest / webpack、テスト、契約資料を再確認した。新たなコード上のmerge blockerは見つからず、資料冒頭に残っていた退会ユーザーの`userId: null`契約だけを現実装へ合わせて訂正した。
+
+未解決項目はsite PR #62で追跡する。site側の`service` cookie追加とhandoff結果UIは実Chromeで成立しているが、上記remote revisionには未収録であるため、extensionのmerge blockerとする。site側の必要差分をcommit・pushし、PR #62のremote HEADに含まれたことを確認するまではextensionをmergeしない。Netflixの同一アカウント2player制限（M7020）と実IME候補ウィンドウの目視未実施は試験環境上の境界であり、今回のコードmerge blockerにはしない。
+
+## 12. 2026-08-22 未push差分レビューの追加対応
+
+`docs/unpushed-review-2026-08-22.md`を現在のextension・site両作業ツリーへ再照合し、成立した指摘と追加で判明した契約差を修正した。
+
+| 項目 | 対応 |
+|---|---|
+| コメント本文の500文字境界 | UTF-16 code unitではなくUnicode code pointでPOST入力とGET/POSTレスポンスを検証。textareaのnative `maxLength`も外し、絵文字を500 code pointまで扱えるよう統一 |
+| 退会ユーザーのコメント | siteが匿名化時に返す`userId: null`を正常レスポンスとして許可 |
+| 完了済みrefreshの誤timeout | fetchとJSON bodyが完了した後は壁時計を再判定せず、AbortSignalが実際に発火した場合だけtimeout扱い |
+| Disney+ループ切替 | playlist contextをclip loaderが消さず、非clip modeでは現在再生を停止しない |
+| Disney+ auto-navigation | 全タブ共有`chrome.storage.local.autoNav`を廃止。background ownershipのprepared routeをclaim結果へ引き継ぎ、tab/nonce単位で判定 |
+| Netflixクリップ選択エラー | unsupported serviceと一般エラーをalertでユーザーへ通知 |
+| Netflix metadata listener | listener登録時のvideo要素をremoverへ固定し、プレイヤー差し替え後も正しい要素から解除 |
+| 通常ページのclaim | backgroundが`retryable:false`を返した場合は1回で停止。legacy child handoffだけ待機を継続 |
+| ownershipのno-op処理 | ownerも対象pendingもないnavigationではregistryを書き戻さず、global playbackが既に空ならreset書き込みも省略 |
+| route/owner定義 | owner query/storage keyとroute正規化を共通validator moduleへ集約し、canonical snapshot到達後の相対URL死コードを削除 |
+| コメント対象解決 | 本番で到達しないglobal playback storage fallbackを削除し、tab-local contextが無ければfail closed |
+| コメントlabel | shadow rootからlight DOM textareaを参照できない`htmlFor`を削除し、既存の`aria-label`とclick focus処理へ一本化 |
+
+仕様判断として、playback bridge v1はNetflix / Disney+限定を維持する。Prime / YouTubeを含むplaylistの部分再生互換は今回のmerge blockerに含めず、必要なら契約versionを更新する別変更として扱う。
+
+site側の`service` cookie追加はローカル作業ツリーにのみ存在するため、site commit・pushとremote branch包含確認が完了するまではmerge blockerとして残る。

--- a/documentation/localhost-playback-bridge-contract-v1.md
+++ b/documentation/localhost-playback-bridge-contract-v1.md
@@ -1,0 +1,238 @@
+# Localhost playback bridge input contract v1
+
+Status: Phase 1確定  
+Date: 2026-08-21  
+Scope: `http://localhost:3000` / `http://127.0.0.1:3000` から拡張へ渡す単体clip・playlist再生handoff
+
+## 1. 目的
+
+localhost siteから受け取った値を、そのまま`chrome.storage.local`やplayback ownershipへ保存しない。bridge入口で正規化・検証・最小化し、正準snapshotだけを`BEGIN_PLAYBACK_HANDOFF`へ渡す。
+
+この契約は次の3経路へ同じ規則を適用する。
+
+- `clipSelected` CustomEvent: 現行siteの単体clip再生経路
+- `window.postMessage({ type: "SET_CLIP_DATA" })`: 将来互換の単体clip経路。現行siteにはproducerがない
+- `window.postMessage({ type: "PLAY_PLAYLIST_START" })` + `localStorage.playQueue`: 現行siteのplaylist経路
+
+## 2. 正準データ
+
+bridge通過後はキー名をcamelCaseへ統一する。入力に含まれる未知のキーは保存しない。
+
+### 2.1 Canonical clip
+
+```ts
+type CanonicalClip = {
+  clipId: number;           // 正のsafe integer
+  service: "netflix" | "disneyplus";
+  url: string;             // 検証済みHTTPS absolute URL
+  startTime: number;       // finite、0以上
+  endTime: number;         // finite、startTimeより大きい
+  title?: string;          // 最大500文字
+  clipname?: string;       // 最大500文字
+  user?: string;           // 最大200文字
+  username?: string;       // 最大200文字
+  epnumber?: string;       // 最大200文字
+};
+```
+
+`clipId`、`service`、`url`、`startTime`、`endTime`は必須。任意文字列はtrimし、空文字なら省略する。
+
+### 2.2 Canonical playlist item
+
+```ts
+type CanonicalPlaylistItem = CanonicalClip & {
+  id: number;              // clipIdと同じ値を互換目的で保持
+  order: number;           // 0以上のsafe integer、queue内で一意
+};
+```
+
+同じclipをplaylistへ複数回含めることは許可するため、`clipId`の重複は拒否しない。`order`の重複は拒否する。
+
+## 3. 入力の正規化
+
+### 3.1 ID
+
+- `clipId`または`id`を受け付ける
+- number、または10進数字だけのstringを正のsafe integerへ変換する
+- 両方がある場合は同じ値でなければ拒否する
+- `clipSelected`では`event.detail.clipId`を必須かつ正本とする
+- `clipSelected`のcookieにも`clipId`がある場合、detailと一致しなければ拒否する。cookieだけの`clipId`では開始しない
+
+### 3.2 時刻
+
+次のaliasを受け付け、`startTime` / `endTime`へ統一する。
+
+| Canonical | Accepted aliases |
+|---|---|
+| `startTime` | `startTime`, `starttime`, `StartTime` |
+| `endTime` | `endTime`, `endtime`, `EndTime` |
+
+numberまたは数値stringをfinite numberへ変換し、`0 <= startTime < endTime`を必須とする。`NaN`、`Infinity`、空文字は拒否する。
+
+### 3.3 Service
+
+受け付けるcanonical valueは`netflix`と`disneyplus`だけとする。大文字・小文字と空白を正規化し、`disney+` / `disney`は`disneyplus`へ変換する。
+
+`prime`、`amazon`、`youtube`は現行utilityに定義があるが、manifestに再生content scriptがない。このためv1のmanaged playback handoffでは拒否する。対応する場合はmanifest、再生制御、smoke testを追加して契約versionを更新する。
+
+### 3.4 URL
+
+- 入力は1〜4096文字のstring
+- 相対URLはserviceのbase URLを使って解決する
+- 正規化後は`https:`のみ許可する
+- username/password付きURLと明示portは拒否する
+- serviceとhostnameが一致しなければ拒否する
+
+| Service | Allowed hostname |
+|---|---|
+| `netflix` | `www.netflix.com` |
+| `disneyplus` | `www.disneyplus.com` |
+
+判定には文字列の前方一致ではなく`new URL()`の`protocol`、`hostname`、`port`を使う。
+
+### 3.5 Order
+
+- number、または10進数字だけのstringで、0以上のsafe integerを受け付ける
+- 現行siteの`PlaylistView`は`order`を送らないため、欠落時だけ配列indexを補う
+- 明示された不正値をindexへ置き換えて救済しない
+- 正規化後に重複があればplaylist全体を拒否する
+
+## 4. Cookie whitelist
+
+`clipSelected`で読み取るcookie名は次だけとする。
+
+- `title`
+- `user`
+- `url`
+- `service`
+- `clipId`
+- `username`
+- `startTime` / `starttime`
+- `endTime` / `endtime`
+
+それ以外のcookieは読み捨て、snapshotへ含めない。各cookieは個別に`decodeURIComponent`し、不正なpercent encodingはそのcookieを無効として扱う。必須項目が欠けた結果になればhandoff全体を拒否する。
+
+cookieの`clipId`はevent detailとの整合確認専用であり、単独では再生対象IDの正本にしない。
+
+## 5. Playlist制限
+
+- 最小件数: 1
+- 最大件数: 100
+- 正規化後のqueueをUTF-8 JSONへシリアライズした最大サイズ: 524,288 bytes（512 KiB）
+- raw `localStorage.playQueue`も同じ512 KiBを上限とし、上限確認後にだけ`JSON.parse`する
+
+上限を超えた場合は一部を切り詰めず、playlist全体を拒否する。件数・サイズを増やす場合はsiteの実利用量、Chrome storage使用量、runtime messageサイズを計測して契約versionを更新する。
+
+## 6. 経路別envelope
+
+### 6.1 `clipSelected`
+
+```js
+window.dispatchEvent(new CustomEvent("clipSelected", {
+  detail: {
+    clipId: 123,
+    requestId: "optional-correlation-id"
+  }
+}));
+```
+
+clip本体はwhitelist済みcookieとdetailから組み立てる。`detail.clipId`は必須。`requestId`は任意の1〜128文字stringで、結果通知以外には保存しない。
+
+### 6.2 `SET_CLIP_DATA`
+
+```js
+window.postMessage({
+  type: "SET_CLIP_DATA",
+  requestId: "optional-correlation-id",
+  payload: { clip: { /* CanonicalClip compatible input */ } }
+}, window.location.origin);
+```
+
+`payload`と`payload.clip`はplain objectでなければ拒否する。
+
+### 6.3 `PLAY_PLAYLIST_START`
+
+```js
+localStorage.setItem("playQueue", JSON.stringify(items));
+window.postMessage({
+  type: "PLAY_PLAYLIST_START",
+  requestId: "optional-correlation-id"
+}, window.location.origin);
+```
+
+`playQueue`は配列でなければならない。現行site itemの`{ id, clipname, title, service, Subtitles, url, startTime, endTime }`のうち、`Subtitles`は再生・コメント対象解決で未使用のため保存しない。`order`欠落時は配列indexを補う。
+
+## 7. 拒否と結果通知
+
+検証はall-or-nothingとする。1項目でも不正なら次をすべて行わない。
+
+- `BEGIN_PLAYBACK_HANDOFF`
+- ownership registry更新
+- `chrome.storage.local`更新
+- `sessionStorage` playback context更新
+- Netflix / Disney+へのnavigation
+
+bridgeは同一originのwindowへ、成功・失敗とも次のresult messageを1回返す。
+
+```js
+window.postMessage({
+  type: "EXTENSION_PLAYBACK_HANDOFF_RESULT",
+  requestId: "optional-correlation-id",
+  source: "clipSelected", // または SET_CLIP_DATA / PLAY_PLAYLIST_START
+  ok: false,
+  reason: "invalid_time_range",
+  field: "endTime",       // 任意
+  index: 2                 // playlist itemの場合だけ任意
+}, window.location.origin);
+```
+
+`reason`は次の安全な固定値だけを返す。
+
+- `invalid_payload`
+- `invalid_clip_id`
+- `clip_id_mismatch`
+- `invalid_service`
+- `invalid_url`
+- `invalid_time_range`
+- `invalid_order`
+- `duplicate_order`
+- `empty_playlist`
+- `queue_too_large`
+- `payload_too_large`
+- `handoff_failed`
+- `background_unavailable`
+
+consoleには`source`、`reason`、`field`、`index`だけを`console.warn`する。cookie値、token、raw URL、raw payloadは出力しない。
+
+ユーザー通知はlocalhost siteがresult messageを受けて、値を含まない「再生データを確認できなかったため、クリップを開けませんでした。」を表示する。bridge自身は`alert`を出さない。site側がresult messageを表示する実装と結合確認はmerge blockerとする。
+
+## 8. Backgroundでの再検証
+
+content bridgeの検証だけを信頼境界にしない。`BEGIN_PLAYBACK_HANDOFF`を受けるbackgroundも、canonical clip / queue、件数、byte size、`context.clipId`との一致を同じ規則で再検証する。
+
+contentとbackgroundが別実装で乖離しないよう、Phase 2では純粋なvalidatorをbundle可能な共通moduleへ置く。非bundleの`getClipData.js`から使えない場合は、manifest/webpack entryを変更して同じmoduleを利用できる構成へ寄せる。
+
+## 9. 保存と消去
+
+- storageへ保存するのは正準キーだけ
+- ownerもpendingもなくなったglobal resetではmode flagだけでなく`clip`、`playQueue`、`nextClip`も消去する
+- 新しいhandoffを拒否したとき、直前の有効なowner/snapshotは変更しない
+- raw cookie objectとraw queueをログ・storage・ownership registryへ残さない
+
+## 10. Phase 2の受入条件
+
+- 3入力経路が同じcanonical validatorを通る
+- 不正入力はbackgroundまで到達せず、backgroundへ直接送った不正snapshotも拒否される
+- 正常な現行siteデータ例が正規化後のschemaに一致する
+- 拒否時にstorage、registry、navigationへ部分更新がない
+- 正常・異常・上限境界のunit testが追加される
+- localhost siteがresult messageを表示できることをPhase 4で実Chrome確認する
+
+## 11. 根拠と互換性
+
+- 現行siteの単体再生はlegacy cookie（小文字`starttime` / `endtime`）と`clipSelected`を使う
+- 現行siteのplaylist itemは`{ id, clipname, title, service, Subtitles, url, startTime, endTime }`で、`order`を持たない
+- 現行siteに`SET_CLIP_DATA` producerはないため、これは将来互換経路として維持する
+- コメント対象解決には正のserver clip IDが必須
+
+site sourceはこのworkspaceに含まれないため、Phase 4でsite revisionと実payloadを照合する。実payloadがこの契約と異なる場合、validatorを緩めて黙認せず、site修正または契約version更新をレビューする。

--- a/documentation/localhost-playback-bridge-contract-v1.md
+++ b/documentation/localhost-playback-bridge-contract-v1.md
@@ -1,6 +1,6 @@
 # Localhost playback bridge input contract v1
 
-Status: Phase 1確定  
+Status: Phase 1確定・Phase 2実装済み・Phase 4ローカル検証済み（site依存commit待ち）
 Date: 2026-08-21  
 Scope: `http://localhost:3000` / `http://127.0.0.1:3000` から拡張へ渡す単体clip・playlist再生handoff
 
@@ -71,7 +71,7 @@ numberまたは数値stringをfinite numberへ変換し、`0 <= startTime < endT
 
 ### 3.3 Service
 
-受け付けるcanonical valueは`netflix`と`disneyplus`だけとする。大文字・小文字と空白を正規化し、`disney+` / `disney`は`disneyplus`へ変換する。
+受け付けるcanonical valueは`netflix`と`disneyplus`だけとする。大文字・小文字と空白を正規化し、`disney+` / `disney` / `DISNEY_PLUS`は`disneyplus`へ変換する。`DISNEY_PLUS`はlocalhost siteのVOD正式コードである。
 
 `prime`、`amazon`、`youtube`は現行utilityに定義があるが、manifestに再生content scriptがない。このためv1のmanaged playback handoffでは拒否する。対応する場合はmanifest、再生制御、smoke testを追加して契約versionを更新する。
 
@@ -93,7 +93,7 @@ numberまたは数値stringをfinite numberへ変換し、`0 <= startTime < endT
 ### 3.5 Order
 
 - number、または10進数字だけのstringで、0以上のsafe integerを受け付ける
-- 現行siteの`PlaylistView`は`order`を送らないため、欠落時だけ配列indexを補う
+- 現行siteの`PlaylistView`は0始まりの配列indexを`order`として送る。旧site payloadで欠落した場合だけ配列indexを補う
 - 明示された不正値をindexへ置き換えて救済しない
 - 正規化後に重複があればplaylist全体を拒否する
 
@@ -204,7 +204,7 @@ window.postMessage({
 
 consoleには`source`、`reason`、`field`、`index`だけを`console.warn`する。cookie値、token、raw URL、raw payloadは出力しない。
 
-ユーザー通知はlocalhost siteがresult messageを受けて、値を含まない「再生データを確認できなかったため、クリップを開けませんでした。」を表示する。bridge自身は`alert`を出さない。site側がresult messageを表示する実装と結合確認はmerge blockerとする。
+ユーザー通知はlocalhost siteがresult messageを受け、安全な固定`reason`に対応する日本語メッセージを表示する。成功時は`role=status`、失敗時は`role=alert`とし、raw payloadやtokenは表示しない。bridge自身は`alert`を出さない。Phase 4でsite実装と実Chrome表示を確認済みである。
 
 ## 8. Backgroundでの再検証
 
@@ -226,13 +226,25 @@ contentとbackgroundが別実装で乖離しないよう、Phase 2では純粋�
 - 正常な現行siteデータ例が正規化後のschemaに一致する
 - 拒否時にstorage、registry、navigationへ部分更新がない
 - 正常・異常・上限境界のunit testが追加される
-- localhost siteがresult messageを表示できることをPhase 4で実Chrome確認する
+- localhost siteがresult messageを表示できることをPhase 4で実Chrome確認する（確認済み）
+
+実装箇所:
+
+- 共通validator: [`playbackBridgeValidation.js`](../src/shared/playbackBridgeValidation.js)
+- localhost bridge: [`getClipData.js`](../src/content/getClipData.js)
+- background再検証: [`playbackOwnership.js`](../src/background/playbackOwnership.js)
+- manifest参照bundle: `dist/getClipData.js`
+- 回帰テスト: [`playbackBridgeValidation.test.js`](../test/playbackBridgeValidation.test.js)、[`playbackOwnership.test.js`](../test/playbackOwnership.test.js)
 
 ## 11. 根拠と互換性
 
 - 現行siteの単体再生はlegacy cookie（小文字`starttime` / `endtime`）と`clipSelected`を使う
-- 現行siteのplaylist itemは`{ id, clipname, title, service, Subtitles, url, startTime, endTime }`で、`order`を持たない
+- 現行siteのplaylist itemは`{ id, order, clipname, title, service, Subtitles, url, startTime, endTime }`で、`service`には`NETFLIX`または`DISNEY_PLUS`が入る
 - 現行siteに`SET_CLIP_DATA` producerはないため、これは将来互換経路として維持する
 - コメント対象解決には正のserver clip IDが必須
 
-site sourceはこのworkspaceに含まれないため、Phase 4でsite revisionと実payloadを照合する。実payloadがこの契約と異なる場合、validatorを緩めて黙認せず、site修正または契約version更新をレビューする。
+Phase 4ではsite source `C:\dev\react--site` のrevision `9f591862fddc9a71d88590c489ac47ffd311c6a9`とローカル実payloadを照合した。`DISNEY_PLUS`は実service codeとしてvalidatorへ追加済みである。
+
+単体再生に必要な`service` cookieはsite作業ツリーで追加され、ローカル実機確認も成功している。ただし、この修正は2026-08-22時点でsiteのHEAD `9f59186`にもremote branchにも含まれていない。拡張をmergeする前にsite側修正をcommit・pushし、そのcommit hashと包含remote branchをPRへ記載する必要がある。それまではローカル環境では契約成立、配布可能なrevision間では未成立として扱う。
+
+今後実payloadがこの契約と異なる場合も、validatorを緩めて黙認せず、site修正または契約version更新をレビューする。

--- a/manifest.json
+++ b/manifest.json
@@ -37,13 +37,19 @@
     },
     {
       "matches": ["https://www.disneyplus.com/*"],
+      "run_at": "document_start",
+      "world": "MAIN",
+      "js": ["src/util/history_change.js"]
+    },
+    {
+      "matches": ["https://www.disneyplus.com/*"],
       "run_at": "document_idle",
       "js": ["dist/content_disney.js"]
     },
     {
       "matches": ["http://localhost:3000/*", "http://127.0.0.1:3000/*"],
       "run_at": "document_idle",
-      "js": ["dist/extension_link.js", "src/content/getClipData.js"]
+      "js": ["dist/extension_link.js", "dist/getClipData.js"]
     },
     {
       "matches": ["http://localhost:3000/*", "http://127.0.0.1:3000/*"],

--- a/src/background/authState.js
+++ b/src/background/authState.js
@@ -1,0 +1,76 @@
+import {
+  STORAGE_KEYS,
+  clearExtensionAuthState,
+  storageGet,
+  storageRemove,
+  storageSet,
+} from './../shared/storage.js';
+import { runExclusive } from './sync.js';
+
+function normalizeExpiresAt(expiresAt) {
+  const expiresAtMs = Date.parse(expiresAt || '');
+  return Number.isFinite(expiresAtMs)
+    ? new Date(expiresAtMs).toISOString()
+    : null;
+}
+
+async function performSaveExtensionAuthToken({
+  extensionInstanceId,
+  extensionAuthToken,
+  expiresAt,
+}) {
+  const stored = await storageGet([STORAGE_KEYS.extensionInstanceId]);
+  const currentInstanceId = stored[STORAGE_KEYS.extensionInstanceId];
+  if (!currentInstanceId || extensionInstanceId !== currentInstanceId) {
+    console.warn('[extension-sync] ignored auth token for mismatched extensionInstanceId', {
+      expected: currentInstanceId,
+      received: extensionInstanceId,
+    });
+    return { ok: false, reason: 'instance_mismatch' };
+  }
+
+  if (
+    typeof extensionAuthToken !== 'string'
+    || extensionAuthToken.trim().length === 0
+  ) {
+    console.warn('[extension-sync] ignored empty auth token');
+    return { ok: false, reason: 'invalid_token' };
+  }
+
+  await storageSet({
+    [STORAGE_KEYS.extensionAuthToken]: extensionAuthToken,
+    [STORAGE_KEYS.extensionTokenExpiresAt]: normalizeExpiresAt(expiresAt),
+    [STORAGE_KEYS.extensionLinked]: true,
+  });
+  await storageRemove([STORAGE_KEYS.extensionTokenRefreshBackoff]);
+  return { ok: true };
+}
+
+/**
+ * Persist a token received by the site bridge under the same mutex used by
+ * comments, sync, and token refresh. This makes a 401 clear and a re-link
+ * operation ordered rather than relying on a non-atomic storage CAS.
+ */
+export function saveExtensionAuthTokenInBackground(input) {
+  return runExclusive(() => performSaveExtensionAuthToken(input || {}));
+}
+
+async function performUnlinkExtension({ extensionInstanceId }) {
+  const stored = await storageGet([STORAGE_KEYS.extensionInstanceId]);
+  const currentInstanceId = stored[STORAGE_KEYS.extensionInstanceId];
+  if (!currentInstanceId || extensionInstanceId !== currentInstanceId) {
+    console.warn('[extension-sync] ignored unlink for mismatched extensionInstanceId', {
+      expected: currentInstanceId,
+      received: extensionInstanceId,
+    });
+    return { ok: false, reason: 'instance_mismatch' };
+  }
+
+  await clearExtensionAuthState();
+  console.log('[extension-sync] cleared auth state after unlink');
+  return { ok: true };
+}
+
+export function unlinkExtensionInBackground(input) {
+  return runExclusive(() => performUnlinkExtension(input || {}));
+}

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -2,6 +2,11 @@ import {
   fetchClipComments,
   postClipComment,
 } from './comments.js';
+import { createPlaybackOwnershipManager } from './playbackOwnership.js';
+import {
+  saveExtensionAuthTokenInBackground,
+  unlinkExtensionInBackground,
+} from './authState.js';
 import { openLoginTab, syncPendingQueue } from './sync.js';
 import { checkAndRefreshToken } from './tokenRefresh.js';
 
@@ -13,8 +18,14 @@ const DEMO_COOLDOWN_MS = 5 * 60 * 1000;
 
 const TOKEN_REFRESH_ALARM = 'extension-token-refresh';
 const SYNC_RETRY_ALARM = 'extension-sync-retry';
+const PLAYBACK_HANDOFF_ALARM_PREFIX = 'playback-handoff-cleanup:';
 const TOKEN_REFRESH_PERIOD_MINUTES = 6 * 60;
 const SYNC_RETRY_PERIOD_MINUTES = 15;
+
+const playbackOwnership = createPlaybackOwnershipManager({
+  sessionStorage: chrome.storage.session,
+  localStorage: chrome.storage.local,
+});
 
 function getMajor(v) {
   return parseInt(String(v).split('.')[0] || '0', 10);
@@ -83,9 +94,23 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     }), sendResponse);
   }
 
+  if (message?.type === 'SAVE_EXTENSION_AUTH_TOKEN') {
+    return respondToAsyncRequest(saveExtensionAuthTokenInBackground({
+      extensionInstanceId: message.extensionInstanceId,
+      extensionAuthToken: message.extensionAuthToken,
+      expiresAt: message.expiresAt,
+    }), sendResponse, 'save_auth_failed');
+  }
+
+  if (message?.type === 'UNLINK_EXTENSION') {
+    return respondToAsyncRequest(unlinkExtensionInBackground({
+      extensionInstanceId: message.extensionInstanceId,
+    }), sendResponse, 'unlink_failed');
+  }
+
   if (message?.type === 'OPEN_LOGIN_TAB') {
     return respondToAsyncRequest(
-      openLoginTab({ force: true }),
+      openLoginTab(),
       sendResponse,
       'open_login_failed'
     );
@@ -98,6 +123,10 @@ function scheduleAlarms() {
 }
 
 chrome.alarms.onAlarm.addListener((alarm) => {
+  if (alarm.name.startsWith(PLAYBACK_HANDOFF_ALARM_PREFIX)) {
+    void playbackOwnership.cleanupExpired();
+    return;
+  }
   if (alarm.name === TOKEN_REFRESH_ALARM) {
     void checkAndRefreshToken();
     return;
@@ -110,6 +139,100 @@ chrome.alarms.onAlarm.addListener((alarm) => {
 
 chrome.runtime.onStartup.addListener(() => {
   scheduleAlarms();
+  void playbackOwnership.reset();
+});
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message?.type === 'BEGIN_PLAYBACK_HANDOFF') {
+    const handoff = playbackOwnership.beginHandoff({
+      nonce: message.nonce,
+      sourceTabId: sender?.tab?.id,
+      context: message.context,
+      snapshot: message.snapshot,
+    }).then((result) => {
+      if (result?.ok) {
+        chrome.alarms.create(
+          `${PLAYBACK_HANDOFF_ALARM_PREFIX}${message.nonce}`,
+          { delayInMinutes: 0.5 }
+        );
+      }
+      return result;
+    });
+    return respondToAsyncRequest(
+      handoff,
+      sendResponse,
+      'playback_handoff_failed'
+    );
+  }
+
+  if (message?.type === 'CLAIM_PLAYBACK_OWNERSHIP') {
+    return respondToAsyncRequest(
+      playbackOwnership.claim({
+        tabId: sender?.tab?.id,
+        openerTabId: sender?.tab?.openerTabId,
+        nonce: message.nonce,
+        route: message.route,
+      }),
+      sendResponse,
+      'playback_claim_failed'
+    );
+  }
+
+  if (message?.type === 'UPDATE_PLAYBACK_OWNERSHIP') {
+    return respondToAsyncRequest(
+      playbackOwnership.update({
+        tabId: sender?.tab?.id,
+        nonce: message.nonce,
+        context: message.context,
+        patch: message.patch,
+        route: message.route,
+      }),
+      sendResponse,
+      'playback_update_failed'
+    );
+  }
+
+  if (message?.type === 'PREPARE_PLAYBACK_NAVIGATION') {
+    return respondToAsyncRequest(
+      playbackOwnership.prepareNavigation({
+        tabId: sender?.tab?.id,
+        nonce: message.nonce,
+        nextUrl: message.nextUrl,
+      }),
+      sendResponse,
+      'playback_navigation_failed'
+    );
+  }
+
+  if (message?.type === 'RELEASE_PLAYBACK_OWNERSHIP') {
+    return respondToAsyncRequest(
+      playbackOwnership.release({
+        tabId: sender?.tab?.id,
+        nonce: message.nonce,
+      }),
+      sendResponse,
+      'playback_release_failed'
+    );
+  }
+});
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+  void playbackOwnership.removeTab(tabId);
+});
+
+chrome.tabs.onCreated.addListener((tab) => {
+  if (Number.isInteger(tab?.openerTabId)) {
+    void playbackOwnership.bindTarget({
+      tabId: tab.id,
+      openerTabId: tab.openerTabId,
+    });
+  }
+});
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
+  if (changeInfo.url) {
+    void playbackOwnership.handleTabNavigation({ tabId, url: changeInfo.url });
+  }
 });
 
 // SW が起きたタイミングで期限チェックと積み残しの再送を行う(どちらも未連携・空キュー

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -348,7 +348,7 @@ chrome.runtime.onConnect.addListener((port) => {
 });
 
 // content script はこのメッセージ経由で ID を取得し、自前生成せず background に一本化する。
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   if (message?.type !== 'GET_OR_CREATE_INSTANCE_ID') return;
 
   getOrCreateInstanceId()

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -1,4 +1,8 @@
-import { syncPendingQueue } from './sync.js';
+import {
+  fetchClipComments,
+  postClipComment,
+} from './comments.js';
+import { openLoginTab, syncPendingQueue } from './sync.js';
 import { checkAndRefreshToken } from './tokenRefresh.js';
 
 const DEMO_BASE_URL = 'http://localhost:3000/';
@@ -36,7 +40,7 @@ chrome.runtime.onMessage.addListener((message) => {
 
 // クリップ同期は background で fetch する(content の fetch はページオリジンの CORS で
 // サイト API に弾かれるため)。ログインタブ起動も sync 側(openLoginTab)が直接行う。
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   if (message?.type !== 'SYNC_PENDING_CLIPS') return;
 
   syncPendingQueue(message.options || {})
@@ -49,6 +53,43 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     }));
 
   return true;
+});
+
+function respondToAsyncRequest(promise, sendResponse, reason = 'request_failed') {
+  promise
+    .then((result) => sendResponse(result))
+    .catch((error) => sendResponse({
+      ok: false,
+      reason,
+      message: error?.message,
+    }));
+
+  return true;
+}
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (message?.type === 'FETCH_CLIP_COMMENTS') {
+    return respondToAsyncRequest(fetchClipComments({
+      clipId: message.clipId,
+      cursor: message.cursor,
+      limit: message.limit,
+    }), sendResponse);
+  }
+
+  if (message?.type === 'POST_CLIP_COMMENT') {
+    return respondToAsyncRequest(postClipComment({
+      clipId: message.clipId,
+      body: message.body,
+    }), sendResponse);
+  }
+
+  if (message?.type === 'OPEN_LOGIN_TAB') {
+    return respondToAsyncRequest(
+      openLoginTab({ force: true }),
+      sendResponse,
+      'open_login_failed'
+    );
+  }
 });
 
 function scheduleAlarms() {

--- a/src/background/comments.js
+++ b/src/background/comments.js
@@ -9,6 +9,7 @@ import { runExclusive } from './sync.js';
 const DEFAULT_COMMENT_LIMIT = 20;
 const MAX_COMMENT_LIMIT = 100;
 const MAX_COMMENT_BODY_LENGTH = 500;
+export const COMMENTS_REQUEST_TIMEOUT_MS = 15 * 1000;
 
 function validationError(field, message) {
   return {
@@ -102,8 +103,75 @@ export function buildCommentsApiUrl({ clipId, cursor, limit }, extensionInstance
   return url.toString();
 }
 
-function parseResponseJson(response) {
-  return response.json().catch(() => null);
+async function parseResponseJson(response) {
+  try {
+    return await response.json();
+  } catch (error) {
+    // Keep aborts observable by requestCommentsApi so a stalled response body is
+    // reported as a timeout instead of a malformed successful response.
+    if (error?.name === 'AbortError') throw error;
+    return null;
+  }
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isPositiveSafeInteger(value) {
+  return Number.isSafeInteger(value) && value > 0;
+}
+
+function isIsoDateString(value) {
+  if (typeof value !== 'string') return false;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value;
+}
+
+function isComment(value, expectedClipId) {
+  return isPlainObject(value)
+    && isPositiveSafeInteger(value.id)
+    && value.clipId === expectedClipId
+    && isPositiveSafeInteger(value.userId)
+    && (typeof value.username === 'string' || value.username === null)
+    && typeof value.body === 'string'
+    && value.body.trim().length >= 1
+    && value.body.length <= MAX_COMMENT_BODY_LENGTH
+    && isIsoDateString(value.createdAt);
+}
+
+export function isValidCommentsSuccessResponse(method, data, expectedClipId) {
+  if (
+    !isPlainObject(data)
+    || data.ok !== true
+    || !isPositiveSafeInteger(expectedClipId)
+  ) {
+    return false;
+  }
+
+  if (method === 'GET') {
+    if (
+      data.clipId !== expectedClipId
+      || !Array.isArray(data.comments)
+      || !data.comments.every((comment) => isComment(comment, expectedClipId))
+    ) {
+      return false;
+    }
+    if (typeof data.hasNext !== 'boolean') return false;
+
+    if (data.hasNext) {
+      const lastComment = data.comments.at(-1);
+      return lastComment !== undefined && data.nextCursor === lastComment.id;
+    }
+
+    return data.nextCursor === null;
+  }
+
+  if (method === 'POST') {
+    return isComment(data.comment, expectedClipId);
+  }
+
+  return false;
 }
 
 function copyServerErrorDetails(result, data) {
@@ -116,13 +184,23 @@ function copyServerErrorDetails(result, data) {
   return result;
 }
 
-async function requestCommentsApi({ method, value }) {
+function timeoutResult() {
+  return { ok: false, reason: 'timeout' };
+}
+
+async function requestCommentsApi({ method, value, signal, deadline }) {
+  if (signal.aborted || Date.now() >= deadline) return timeoutResult();
+
   const stored = await storageGet([
     STORAGE_KEYS.extensionInstanceId,
     STORAGE_KEYS.extensionAuthToken,
   ]);
   const extensionInstanceId = stored[STORAGE_KEYS.extensionInstanceId];
   const extensionAuthToken = stored[STORAGE_KEYS.extensionAuthToken];
+
+  // The request may have spent its entire deadline waiting for runExclusive or
+  // storage. Never start a stale network request after the caller timed out.
+  if (signal.aborted || Date.now() >= deadline) return timeoutResult();
 
   if (
     typeof extensionInstanceId !== 'string' ||
@@ -141,6 +219,7 @@ async function requestCommentsApi({ method, value }) {
     method,
     headers,
     cache: 'no-store',
+    signal,
   };
 
   if (method === 'GET') {
@@ -154,28 +233,53 @@ async function requestCommentsApi({ method, value }) {
   }
 
   let response;
+  let data;
   try {
     response = await fetch(url, options);
+    data = await parseResponseJson(response);
   } catch (error) {
+    const timedOut = signal.aborted || Date.now() >= deadline;
     console.warn('[extension-comments] network error', {
       method,
       message: error?.message,
+      timedOut,
     });
-    return { ok: false, reason: 'network_error' };
+    return { ok: false, reason: timedOut ? 'timeout' : 'network_error' };
   }
 
-  const data = await parseResponseJson(response);
-  const reason = getCommentsResponseReason(response.status);
+  if (signal.aborted || Date.now() >= deadline) return timeoutResult();
 
-  if (reason === null) {
-    const result = data && typeof data === 'object' && !Array.isArray(data)
-      ? { ...data }
-      : {};
-    result.ok = true;
-    return result;
+  const expectedSuccessStatus = method === 'GET' ? 200 : 201;
+  const successfulStatus = response.status === expectedSuccessStatus;
+  const reason = getCommentsResponseReason(response.status) || 'request_failed';
+
+  if (successfulStatus) {
+    if (!isValidCommentsSuccessResponse(method, data, value.clipId)) {
+      console.warn('[extension-comments] malformed success response', {
+        method,
+        status: response.status,
+      });
+      return {
+        ok: false,
+        reason: 'invalid_response',
+        status: response.status,
+      };
+    }
+
+    return { ...data, ok: true };
   }
 
   if (response.status === 401) {
+    const current = await storageGet([STORAGE_KEYS.extensionAuthToken]);
+    if (current[STORAGE_KEYS.extensionAuthToken] !== extensionAuthToken) {
+      console.log('[extension-comments] stale 401 for replaced token; keeping current token');
+      return copyServerErrorDetails({
+        ok: false,
+        reason: 'stale_unauthorized',
+        status: response.status,
+      }, data);
+    }
+
     await clearExtensionAuthState();
   }
 
@@ -186,22 +290,37 @@ async function requestCommentsApi({ method, value }) {
   }, data);
 }
 
+function runCommentsRequest(method, value) {
+  const abortController = new AbortController();
+  const deadline = Date.now() + COMMENTS_REQUEST_TIMEOUT_MS;
+  let timeoutId;
+  const timeoutPromise = new Promise((resolve) => {
+    timeoutId = setTimeout(() => {
+      abortController.abort();
+      resolve(timeoutResult());
+    }, COMMENTS_REQUEST_TIMEOUT_MS);
+  });
+  const requestPromise = runExclusive(() => requestCommentsApi({
+    method,
+    value,
+    signal: abortController.signal,
+    deadline,
+  }));
+
+  return Promise.race([requestPromise, timeoutPromise])
+    .finally(() => clearTimeout(timeoutId));
+}
+
 export async function fetchClipComments(input = {}) {
   const validated = validateFetchClipCommentsInput(input);
   if (!validated.ok) return validated;
 
-  return runExclusive(() => requestCommentsApi({
-    method: 'GET',
-    value: validated.value,
-  }));
+  return runCommentsRequest('GET', validated.value);
 }
 
 export async function postClipComment(input = {}) {
   const validated = validatePostClipCommentInput(input);
   if (!validated.ok) return validated;
 
-  return runExclusive(() => requestCommentsApi({
-    method: 'POST',
-    value: validated.value,
-  }));
+  return runCommentsRequest('POST', validated.value);
 }

--- a/src/background/comments.js
+++ b/src/background/comments.js
@@ -1,0 +1,207 @@
+import { getApiEndpoint } from './../api.js';
+import {
+  STORAGE_KEYS,
+  clearExtensionAuthState,
+  storageGet,
+} from './../shared/storage.js';
+import { runExclusive } from './sync.js';
+
+const DEFAULT_COMMENT_LIMIT = 20;
+const MAX_COMMENT_LIMIT = 100;
+const MAX_COMMENT_BODY_LENGTH = 500;
+
+function validationError(field, message) {
+  return {
+    ok: false,
+    reason: 'validation_error',
+    field,
+    message,
+  };
+}
+
+function toPositiveSafeInteger(value) {
+  let numberValue;
+
+  if (typeof value === 'number') {
+    numberValue = value;
+  } else if (typeof value === 'string') {
+    const normalized = value.trim();
+    if (!/^\d+$/.test(normalized)) return null;
+    numberValue = Number(normalized);
+  } else {
+    return null;
+  }
+
+  return Number.isSafeInteger(numberValue) && numberValue > 0
+    ? numberValue
+    : null;
+}
+
+export function validateFetchClipCommentsInput(input = {}) {
+  const clipId = toPositiveSafeInteger(input?.clipId);
+  if (clipId === null) {
+    return validationError('clipId', 'clipId must be a positive safe integer');
+  }
+
+  const limitValue = input?.limit === undefined
+    ? DEFAULT_COMMENT_LIMIT
+    : toPositiveSafeInteger(input.limit);
+  if (limitValue === null || limitValue > MAX_COMMENT_LIMIT) {
+    return validationError('limit', 'limit must be an integer from 1 to 100');
+  }
+
+  const value = { clipId, limit: limitValue };
+  if (input?.cursor !== undefined) {
+    const cursor = toPositiveSafeInteger(input.cursor);
+    if (cursor === null) {
+      return validationError('cursor', 'cursor must be a positive safe integer');
+    }
+    value.cursor = cursor;
+  }
+
+  return { ok: true, value };
+}
+
+export function validatePostClipCommentInput(input = {}) {
+  const clipId = toPositiveSafeInteger(input?.clipId);
+  if (clipId === null) {
+    return validationError('clipId', 'clipId must be a positive safe integer');
+  }
+
+  if (typeof input?.body !== 'string') {
+    return validationError('body', 'body must be a string');
+  }
+
+  const body = input.body.trim();
+  if (body.length < 1 || body.length > MAX_COMMENT_BODY_LENGTH) {
+    return validationError('body', 'body must contain 1 to 500 characters after trimming');
+  }
+
+  return {
+    ok: true,
+    value: { clipId, body },
+  };
+}
+
+export function getCommentsResponseReason(status) {
+  if (status === 200 || status === 201) return null;
+  if (status === 400) return 'validation_error';
+  if (status === 401) return 'unauthorized';
+  if (status === 403) return 'forbidden';
+  if (status === 404) return 'not_found';
+  return 'request_failed';
+}
+
+export function buildCommentsApiUrl({ clipId, cursor, limit }, extensionInstanceId) {
+  const url = new URL(getApiEndpoint(`extension/clips/${clipId}/comments`));
+  url.searchParams.set('extensionInstanceId', extensionInstanceId);
+  if (cursor !== undefined) {
+    url.searchParams.set('cursor', String(cursor));
+  }
+  url.searchParams.set('limit', String(limit));
+  return url.toString();
+}
+
+function parseResponseJson(response) {
+  return response.json().catch(() => null);
+}
+
+function copyServerErrorDetails(result, data) {
+  if (typeof data?.message === 'string') {
+    result.message = data.message;
+  }
+  if (typeof data?.code === 'string') {
+    result.code = data.code;
+  }
+  return result;
+}
+
+async function requestCommentsApi({ method, value }) {
+  const stored = await storageGet([
+    STORAGE_KEYS.extensionInstanceId,
+    STORAGE_KEYS.extensionAuthToken,
+  ]);
+  const extensionInstanceId = stored[STORAGE_KEYS.extensionInstanceId];
+  const extensionAuthToken = stored[STORAGE_KEYS.extensionAuthToken];
+
+  if (
+    typeof extensionInstanceId !== 'string' ||
+    extensionInstanceId.length === 0 ||
+    typeof extensionAuthToken !== 'string' ||
+    extensionAuthToken.length === 0
+  ) {
+    return { ok: false, reason: 'missing_token' };
+  }
+
+  const headers = {
+    Authorization: `Bearer ${extensionAuthToken}`,
+  };
+  let url = getApiEndpoint(`extension/clips/${value.clipId}/comments`);
+  const options = {
+    method,
+    headers,
+    cache: 'no-store',
+  };
+
+  if (method === 'GET') {
+    url = buildCommentsApiUrl(value, extensionInstanceId);
+  } else {
+    headers['Content-Type'] = 'application/json';
+    options.body = JSON.stringify({
+      extensionInstanceId,
+      body: value.body,
+    });
+  }
+
+  let response;
+  try {
+    response = await fetch(url, options);
+  } catch (error) {
+    console.warn('[extension-comments] network error', {
+      method,
+      message: error?.message,
+    });
+    return { ok: false, reason: 'network_error' };
+  }
+
+  const data = await parseResponseJson(response);
+  const reason = getCommentsResponseReason(response.status);
+
+  if (reason === null) {
+    const result = data && typeof data === 'object' && !Array.isArray(data)
+      ? { ...data }
+      : {};
+    result.ok = true;
+    return result;
+  }
+
+  if (response.status === 401) {
+    await clearExtensionAuthState();
+  }
+
+  return copyServerErrorDetails({
+    ok: false,
+    reason,
+    status: response.status,
+  }, data);
+}
+
+export async function fetchClipComments(input = {}) {
+  const validated = validateFetchClipCommentsInput(input);
+  if (!validated.ok) return validated;
+
+  return runExclusive(() => requestCommentsApi({
+    method: 'GET',
+    value: validated.value,
+  }));
+}
+
+export async function postClipComment(input = {}) {
+  const validated = validatePostClipCommentInput(input);
+  if (!validated.ok) return validated;
+
+  return runExclusive(() => requestCommentsApi({
+    method: 'POST',
+    value: validated.value,
+  }));
+}

--- a/src/background/comments.js
+++ b/src/background/comments.js
@@ -5,10 +5,10 @@ import {
   storageGet,
 } from './../shared/storage.js';
 import { runExclusive } from './sync.js';
+import { isValidCommentBody } from '../shared/commentText.js';
 
 const DEFAULT_COMMENT_LIMIT = 20;
 const MAX_COMMENT_LIMIT = 100;
-const MAX_COMMENT_BODY_LENGTH = 500;
 export const COMMENTS_REQUEST_TIMEOUT_MS = 15 * 1000;
 
 function validationError(field, message) {
@@ -74,7 +74,7 @@ export function validatePostClipCommentInput(input = {}) {
   }
 
   const body = input.body.trim();
-  if (body.length < 1 || body.length > MAX_COMMENT_BODY_LENGTH) {
+  if (!isValidCommentBody(body)) {
     return validationError('body', 'body must contain 1 to 500 characters after trimming');
   }
 
@@ -132,11 +132,9 @@ function isComment(value, expectedClipId) {
   return isPlainObject(value)
     && isPositiveSafeInteger(value.id)
     && value.clipId === expectedClipId
-    && isPositiveSafeInteger(value.userId)
+    && (isPositiveSafeInteger(value.userId) || value.userId === null)
     && (typeof value.username === 'string' || value.username === null)
-    && typeof value.body === 'string'
-    && value.body.trim().length >= 1
-    && value.body.length <= MAX_COMMENT_BODY_LENGTH
+    && isValidCommentBody(value.body)
     && isIsoDateString(value.createdAt);
 }
 

--- a/src/background/playbackOwnership.js
+++ b/src/background/playbackOwnership.js
@@ -1,9 +1,19 @@
-export const PLAYBACK_OWNER_STORAGE_KEY = 'playbackOwnerNonce';
+import {
+  normalizePlaybackContext,
+  normalizePlaybackRoute as normalizeRoute,
+  normalizePlaybackSnapshot,
+  PLAYBACK_OWNER_QUERY_PARAM,
+  PLAYBACK_OWNER_STORAGE_KEY,
+} from '../shared/playbackBridgeValidation.js';
+
+export { PLAYBACK_OWNER_STORAGE_KEY };
 export const PLAYBACK_REGISTRY_STORAGE_KEY = 'activePlaybackTabsV1';
 export const PLAYBACK_HANDOFF_TTL_MS = 30_000;
-const PLAYBACK_OWNER_QUERY_PARAM = 'dextPlaybackOwner';
 
 const GLOBAL_PLAYBACK_RESET = Object.freeze({
+  clip: null,
+  playQueue: null,
+  nextClip: null,
   playClipSystemKey: 0,
   playlistSystemKey: 0,
   currentClipOrder: 0,
@@ -28,15 +38,6 @@ function isNonce(value) {
   return typeof value === 'string' && value.length >= 8 && value.length <= 200;
 }
 
-function normalizeRoute(value) {
-  try {
-    const url = new URL(value);
-    return `${url.origin}${url.pathname}`;
-  } catch {
-    return null;
-  }
-}
-
 function getOwnerNonceFromUrl(value) {
   try {
     return new URL(value).searchParams.get(PLAYBACK_OWNER_QUERY_PARAM);
@@ -46,38 +47,8 @@ function getOwnerNonceFromUrl(value) {
 }
 
 function normalizeContext(value) {
-  const clipId = Number(value?.clipId);
-  if (
-    (value?.mode !== 'clip' && value?.mode !== 'playlist') ||
-    !Number.isSafeInteger(clipId) ||
-    clipId <= 0
-  ) {
-    return null;
-  }
-  return { mode: value.mode, clipId };
-}
-
-function resolveSnapshotContext(snapshot) {
-  const mode = snapshot?.playmode === 'playlist' || snapshot?.playmode === 'clip'
-    ? snapshot.playmode
-    : snapshot?.playClipSystemKey === 1
-      ? 'clip'
-      : snapshot?.playlistSystemKey === 1
-        ? 'playlist'
-        : null;
-  if (!mode) return null;
-
-  let clipId;
-  if (mode === 'clip') {
-    clipId = snapshot.clip?.clipId ?? snapshot.clip?.id;
-  } else {
-    const order = Number(snapshot.currentClipOrder);
-    const clip = Array.isArray(snapshot.playQueue)
-      ? snapshot.playQueue.find((item) => Number(item?.order) === order)
-      : null;
-    clipId = clip?.clipId ?? clip?.id;
-  }
-  return normalizeContext({ mode, clipId });
+  const normalized = normalizePlaybackContext(value);
+  return normalized.ok ? normalized.value : null;
 }
 
 function resolveSnapshotClip(snapshot, context) {
@@ -93,32 +64,17 @@ function snapshotMatchesRoute(snapshot, context, route) {
   if (!normalizedRoute) return false;
   const rawUrl = resolveSnapshotClip(snapshot, context)?.url;
   if (typeof rawUrl !== 'string' || rawUrl.length === 0) return false;
-  try {
-    const absolute = /^https?:\/\//i.test(rawUrl)
-      ? rawUrl
-      : /^(?:www\.)?(?:netflix|disneyplus)\.com\//i.test(rawUrl)
-        ? `https://${rawUrl}`
-        : new URL(rawUrl.startsWith('/') ? rawUrl : `/${rawUrl}`, normalizedRoute).toString();
-    return normalizeRoute(absolute) === normalizedRoute;
-  } catch {
-    return false;
-  }
+  return normalizeRoute(rawUrl) === normalizedRoute;
 }
 
 function normalizeSnapshot(snapshot, nonce, context) {
   if (snapshot?.[PLAYBACK_OWNER_STORAGE_KEY] !== nonce) return null;
-  const snapshotContext = resolveSnapshotContext(snapshot);
-  if (
-    snapshotContext?.mode !== context.mode ||
-    snapshotContext.clipId !== context.clipId
-  ) {
-    return null;
-  }
-  return Object.fromEntries(
-    SNAPSHOT_KEYS
-      .filter((key) => snapshot[key] !== undefined)
-      .map((key) => [key, snapshot[key]])
-  );
+  const normalized = normalizePlaybackSnapshot({
+    snapshot,
+    context,
+    ownerNonce: nonce,
+  });
+  return normalized.ok ? normalized.value : null;
 }
 
 export function createPlaybackOwnershipManager({
@@ -169,7 +125,13 @@ export function createPlaybackOwnershipManager({
       Object.keys(registry.active).length === 0 &&
       Object.keys(registry.pending).length === 0
     ) {
-      await localStorage.set(GLOBAL_PLAYBACK_RESET);
+      const current = await localStorage.get(SNAPSHOT_KEYS);
+      const alreadyReset = SNAPSHOT_KEYS.every((key) => {
+        const value = current?.[key];
+        const resetValue = GLOBAL_PLAYBACK_RESET[key];
+        return value === resetValue || (value === undefined && resetValue !== undefined);
+      });
+      if (!alreadyReset) await localStorage.set(GLOBAL_PLAYBACK_RESET);
       return true;
     }
     return false;
@@ -265,6 +227,11 @@ export function createPlaybackOwnershipManager({
 
       const registry = await readRegistry();
       const tabKey = String(tabId);
+      const canRetryLegacyHandoff = () =>
+        Number.isInteger(openerTabId) ||
+        Object.values(registry.pending).some(
+          (entry) => Number(entry?.sourceTabId) === tabId
+        );
       let resolvedNonce = nonce;
       if (!isNonce(resolvedNonce)) {
         resolvedNonce = registry.active[tabKey]?.nonce;
@@ -283,9 +250,12 @@ export function createPlaybackOwnershipManager({
         }
       }
       if (!isNonce(resolvedNonce)) {
-        await writeRegistry(registry);
         await clearGlobalIfIdle(registry);
-        return { ok: false, reason: 'handoff_not_found' };
+        return {
+          ok: false,
+          reason: 'handoff_not_found',
+          retryable: canRetryLegacyHandoff(),
+        };
       }
       const existing = registry.active[tabKey];
       const handoff = registry.pending[resolvedNonce];
@@ -299,9 +269,12 @@ export function createPlaybackOwnershipManager({
             Number(handoff?.targetTabId) === tabId
           ));
       if (!mayClaim) {
-        await writeRegistry(registry);
         await clearGlobalIfIdle(registry);
-        return { ok: false, reason: 'handoff_not_found' };
+        return {
+          ok: false,
+          reason: 'handoff_not_found',
+          retryable: canRetryLegacyHandoff(),
+        };
       }
 
       const source = existing?.nonce === resolvedNonce ? existing : handoff;
@@ -315,6 +288,11 @@ export function createPlaybackOwnershipManager({
       }
 
       const claimRoute = normalizeRoute(route);
+      const autoNavigation = Boolean(
+        existing?.nonce === resolvedNonce &&
+        claimRoute &&
+        (existing.expectedRoute === claimRoute || existing.autoNavigationRoute === claimRoute)
+      );
       if (claimRoute && !snapshotMatchesRoute(normalizedSnapshot, normalizedContext, claimRoute)) {
         if (existing?.nonce === resolvedNonce) {
           delete registry.active[tabKey];
@@ -324,7 +302,11 @@ export function createPlaybackOwnershipManager({
         } else {
           await writeRegistry(registry);
         }
-        return { ok: false, reason: 'route_mismatch' };
+        return {
+          ok: false,
+          reason: 'route_mismatch',
+          retryable: canRetryLegacyHandoff(),
+        };
       }
       if (
         existing?.nonce === resolvedNonce &&
@@ -337,7 +319,11 @@ export function createPlaybackOwnershipManager({
         await writeRegistry(registry);
         await restoreLatestOwnedSnapshot(registry, existing.nonce);
         await clearGlobalIfIdle(registry);
-        return { ok: false, reason: 'route_mismatch' };
+        return {
+          ok: false,
+          reason: 'route_mismatch',
+          retryable: canRetryLegacyHandoff(),
+        };
       }
 
       await localStorage.set(normalizedSnapshot);
@@ -347,6 +333,7 @@ export function createPlaybackOwnershipManager({
         snapshot: normalizedSnapshot,
         route: claimRoute || existing?.route || null,
         expectedRoute: null,
+        autoNavigationRoute: null,
         revision: takeRevision(registry),
         updatedAt: now(),
       };
@@ -357,6 +344,7 @@ export function createPlaybackOwnershipManager({
         nonce: resolvedNonce,
         context: normalizedContext,
         snapshot: normalizedSnapshot,
+        autoNavigation,
       };
     });
   }
@@ -408,6 +396,7 @@ export function createPlaybackOwnershipManager({
         snapshot: normalizedSnapshot,
         route: normalizeRoute(route) || existing.route || null,
         expectedRoute: existing.expectedRoute || null,
+        autoNavigationRoute: existing.autoNavigationRoute || null,
         revision: takeRevision(registry),
         updatedAt: now(),
       };
@@ -434,6 +423,7 @@ export function createPlaybackOwnershipManager({
         return { ok: false, reason: 'not_owner' };
       }
       existing.expectedRoute = nextRoute;
+      existing.autoNavigationRoute = null;
       await writeRegistry(registry);
       return { ok: true };
     });
@@ -472,19 +462,21 @@ export function createPlaybackOwnershipManager({
       if (!existing) {
         const pendingNonce = getOwnerNonceFromUrl(url);
         if (isNonce(pendingNonce) && registry.pending[pendingNonce]) {
-          registry.pending[pendingNonce].targetTabId = tabId;
+          if (registry.pending[pendingNonce].targetTabId !== tabId) {
+            registry.pending[pendingNonce].targetTabId = tabId;
+            await writeRegistry(registry);
+          }
         }
-        await writeRegistry(registry);
         return { ok: true, released: false };
       }
       const nextRoute = normalizeRoute(url);
       if (nextRoute && nextRoute === existing.route) {
-        await writeRegistry(registry);
         return { ok: true, released: false };
       }
       if (nextRoute && nextRoute === existing.expectedRoute) {
         existing.route = nextRoute;
         existing.expectedRoute = null;
+        existing.autoNavigationRoute = nextRoute;
         await writeRegistry(registry);
         return { ok: true, released: false };
       }

--- a/src/background/playbackOwnership.js
+++ b/src/background/playbackOwnership.js
@@ -1,0 +1,566 @@
+export const PLAYBACK_OWNER_STORAGE_KEY = 'playbackOwnerNonce';
+export const PLAYBACK_REGISTRY_STORAGE_KEY = 'activePlaybackTabsV1';
+export const PLAYBACK_HANDOFF_TTL_MS = 30_000;
+const PLAYBACK_OWNER_QUERY_PARAM = 'dextPlaybackOwner';
+
+const GLOBAL_PLAYBACK_RESET = Object.freeze({
+  playClipSystemKey: 0,
+  playlistSystemKey: 0,
+  currentClipOrder: 0,
+  currentClipId: null,
+  playmode: null,
+  [PLAYBACK_OWNER_STORAGE_KEY]: null,
+});
+
+const SNAPSHOT_KEYS = [
+  'clip',
+  'playQueue',
+  'currentClipOrder',
+  'currentClipId',
+  'nextClip',
+  'playClipSystemKey',
+  'playlistSystemKey',
+  'playmode',
+  PLAYBACK_OWNER_STORAGE_KEY,
+];
+
+function isNonce(value) {
+  return typeof value === 'string' && value.length >= 8 && value.length <= 200;
+}
+
+function normalizeRoute(value) {
+  try {
+    const url = new URL(value);
+    return `${url.origin}${url.pathname}`;
+  } catch {
+    return null;
+  }
+}
+
+function getOwnerNonceFromUrl(value) {
+  try {
+    return new URL(value).searchParams.get(PLAYBACK_OWNER_QUERY_PARAM);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeContext(value) {
+  const clipId = Number(value?.clipId);
+  if (
+    (value?.mode !== 'clip' && value?.mode !== 'playlist') ||
+    !Number.isSafeInteger(clipId) ||
+    clipId <= 0
+  ) {
+    return null;
+  }
+  return { mode: value.mode, clipId };
+}
+
+function resolveSnapshotContext(snapshot) {
+  const mode = snapshot?.playmode === 'playlist' || snapshot?.playmode === 'clip'
+    ? snapshot.playmode
+    : snapshot?.playClipSystemKey === 1
+      ? 'clip'
+      : snapshot?.playlistSystemKey === 1
+        ? 'playlist'
+        : null;
+  if (!mode) return null;
+
+  let clipId;
+  if (mode === 'clip') {
+    clipId = snapshot.clip?.clipId ?? snapshot.clip?.id;
+  } else {
+    const order = Number(snapshot.currentClipOrder);
+    const clip = Array.isArray(snapshot.playQueue)
+      ? snapshot.playQueue.find((item) => Number(item?.order) === order)
+      : null;
+    clipId = clip?.clipId ?? clip?.id;
+  }
+  return normalizeContext({ mode, clipId });
+}
+
+function resolveSnapshotClip(snapshot, context) {
+  if (context.mode === 'clip') return snapshot?.clip || null;
+  const order = Number(snapshot?.currentClipOrder);
+  return Array.isArray(snapshot?.playQueue)
+    ? snapshot.playQueue.find((item) => Number(item?.order) === order) || null
+    : null;
+}
+
+function snapshotMatchesRoute(snapshot, context, route) {
+  const normalizedRoute = normalizeRoute(route);
+  if (!normalizedRoute) return false;
+  const rawUrl = resolveSnapshotClip(snapshot, context)?.url;
+  if (typeof rawUrl !== 'string' || rawUrl.length === 0) return false;
+  try {
+    const absolute = /^https?:\/\//i.test(rawUrl)
+      ? rawUrl
+      : /^(?:www\.)?(?:netflix|disneyplus)\.com\//i.test(rawUrl)
+        ? `https://${rawUrl}`
+        : new URL(rawUrl.startsWith('/') ? rawUrl : `/${rawUrl}`, normalizedRoute).toString();
+    return normalizeRoute(absolute) === normalizedRoute;
+  } catch {
+    return false;
+  }
+}
+
+function normalizeSnapshot(snapshot, nonce, context) {
+  if (snapshot?.[PLAYBACK_OWNER_STORAGE_KEY] !== nonce) return null;
+  const snapshotContext = resolveSnapshotContext(snapshot);
+  if (
+    snapshotContext?.mode !== context.mode ||
+    snapshotContext.clipId !== context.clipId
+  ) {
+    return null;
+  }
+  return Object.fromEntries(
+    SNAPSHOT_KEYS
+      .filter((key) => snapshot[key] !== undefined)
+      .map((key) => [key, snapshot[key]])
+  );
+}
+
+export function createPlaybackOwnershipManager({
+  sessionStorage,
+  localStorage,
+  now = () => Date.now(),
+}) {
+  let operation = Promise.resolve();
+
+  const exclusive = (task) => {
+    const next = operation.then(task, task);
+    operation = next.catch(() => {});
+    return next;
+  };
+
+  async function readRegistry() {
+    const stored = await sessionStorage.get(PLAYBACK_REGISTRY_STORAGE_KEY);
+    const raw = stored?.[PLAYBACK_REGISTRY_STORAGE_KEY];
+    const active = raw?.active && typeof raw.active === 'object' ? raw.active : {};
+    const pending = raw?.pending && typeof raw.pending === 'object' ? raw.pending : {};
+    const currentTime = now();
+    const retainedPending = Object.fromEntries(
+      Object.entries(pending).filter(([, handoff]) =>
+        Number(handoff?.expiresAt ?? handoff) > currentTime
+      )
+    );
+    const registry = {
+      active: { ...active },
+      pending: retainedPending,
+      revision: Number.isSafeInteger(raw?.revision) && raw.revision >= 0
+        ? raw.revision
+        : 0,
+    };
+    if (Object.keys(retainedPending).length !== Object.keys(pending).length) {
+      await writeRegistry(registry);
+      await reconcileGlobalOwner(registry);
+      await clearGlobalIfIdle(registry);
+    }
+    return registry;
+  }
+
+  async function writeRegistry(registry) {
+    await sessionStorage.set({ [PLAYBACK_REGISTRY_STORAGE_KEY]: registry });
+  }
+
+  async function clearGlobalIfIdle(registry) {
+    if (
+      Object.keys(registry.active).length === 0 &&
+      Object.keys(registry.pending).length === 0
+    ) {
+      await localStorage.set(GLOBAL_PLAYBACK_RESET);
+      return true;
+    }
+    return false;
+  }
+
+  async function restoreLatestOwnedSnapshot(registry, removedNonce) {
+    const globalState = await localStorage.get(PLAYBACK_OWNER_STORAGE_KEY);
+    if (globalState?.[PLAYBACK_OWNER_STORAGE_KEY] !== removedNonce) return false;
+    const latest = latestOwnedSnapshot(registry);
+    if (!latest?.snapshot) return false;
+    await localStorage.set(latest.snapshot);
+    return true;
+  }
+
+  async function reconcileGlobalOwner(registry) {
+    const globalState = await localStorage.get(PLAYBACK_OWNER_STORAGE_KEY);
+    const globalOwner = globalState?.[PLAYBACK_OWNER_STORAGE_KEY];
+    if (
+      Object.values(registry.active).some((entry) => entry?.nonce === globalOwner) ||
+      registry.pending[globalOwner]
+    ) {
+      return false;
+    }
+    const latest = latestOwnedSnapshot(registry);
+    if (!latest?.snapshot) return false;
+    await localStorage.set(latest.snapshot);
+    return true;
+  }
+
+  function compareActiveRecency(a, b) {
+    const revisionDelta = Number(b?.revision || 0) - Number(a?.revision || 0);
+    if (revisionDelta !== 0) return revisionDelta;
+    const timeDelta = Number(b?.updatedAt || 0) - Number(a?.updatedAt || 0);
+    if (timeDelta !== 0) return timeDelta;
+    return String(b?.nonce || '').localeCompare(String(a?.nonce || ''));
+  }
+
+  function latestOwnedSnapshot(registry) {
+    return [
+      ...Object.values(registry.active),
+      ...Object.entries(registry.pending).map(([nonce, entry]) => ({
+        nonce,
+        ...entry,
+      })),
+    ]
+      .filter((entry) => entry?.snapshot)
+      .sort(compareActiveRecency)[0];
+  }
+
+  function takeRevision(registry) {
+    registry.revision = Number(registry.revision || 0) + 1;
+    return registry.revision;
+  }
+
+  function beginHandoff({ nonce, sourceTabId, context, snapshot }) {
+    return exclusive(async () => {
+      const normalizedContext = normalizeContext(context);
+      const normalizedSnapshot = normalizedContext
+        ? normalizeSnapshot(snapshot, nonce, normalizedContext)
+        : null;
+      if (
+        !isNonce(nonce) ||
+        !Number.isInteger(sourceTabId) ||
+        !normalizedContext ||
+        !normalizedSnapshot
+      ) {
+        return { ok: false, reason: 'invalid_handoff' };
+      }
+      const registry = await readRegistry();
+      registry.pending[nonce] = {
+        expiresAt: now() + PLAYBACK_HANDOFF_TTL_MS,
+        sourceTabId,
+        context: normalizedContext,
+        snapshot: normalizedSnapshot,
+        revision: takeRevision(registry),
+        updatedAt: now(),
+      };
+      await localStorage.set(normalizedSnapshot);
+      await writeRegistry(registry);
+      return {
+        ok: true,
+        context: normalizedContext,
+        snapshot: normalizedSnapshot,
+      };
+    });
+  }
+
+  function claim({ tabId, openerTabId, nonce, route }) {
+    return exclusive(async () => {
+      if (!Number.isInteger(tabId)) {
+        return { ok: false, reason: 'invalid_claim' };
+      }
+
+      const registry = await readRegistry();
+      const tabKey = String(tabId);
+      let resolvedNonce = nonce;
+      if (!isNonce(resolvedNonce)) {
+        resolvedNonce = registry.active[tabKey]?.nonce;
+        if (!isNonce(resolvedNonce)) {
+          const eligiblePending = Object.entries(registry.pending).filter(
+            ([, handoff]) => {
+              const sourceTabId = Number(handoff?.sourceTabId);
+              return sourceTabId === tabId || sourceTabId === openerTabId;
+            }
+          );
+          if (eligiblePending.length > 1) {
+            await writeRegistry(registry);
+            return { ok: false, reason: 'ambiguous_handoff' };
+          }
+          resolvedNonce = eligiblePending[0]?.[0];
+        }
+      }
+      if (!isNonce(resolvedNonce)) {
+        await writeRegistry(registry);
+        await clearGlobalIfIdle(registry);
+        return { ok: false, reason: 'handoff_not_found' };
+      }
+      const existing = registry.active[tabKey];
+      const handoff = registry.pending[resolvedNonce];
+      const sourceTabId = Number(handoff?.sourceTabId);
+      const mayClaim =
+        existing?.nonce === resolvedNonce ||
+        (Boolean(handoff) &&
+          (
+            sourceTabId === tabId ||
+            sourceTabId === openerTabId ||
+            Number(handoff?.targetTabId) === tabId
+          ));
+      if (!mayClaim) {
+        await writeRegistry(registry);
+        await clearGlobalIfIdle(registry);
+        return { ok: false, reason: 'handoff_not_found' };
+      }
+
+      const source = existing?.nonce === resolvedNonce ? existing : handoff;
+      const normalizedContext = normalizeContext(source?.context);
+      const normalizedSnapshot = normalizedContext
+        ? normalizeSnapshot(source?.snapshot, resolvedNonce, normalizedContext)
+        : null;
+      if (!normalizedContext || !normalizedSnapshot) {
+        await writeRegistry(registry);
+        return { ok: false, reason: 'snapshot_mismatch' };
+      }
+
+      const claimRoute = normalizeRoute(route);
+      if (claimRoute && !snapshotMatchesRoute(normalizedSnapshot, normalizedContext, claimRoute)) {
+        if (existing?.nonce === resolvedNonce) {
+          delete registry.active[tabKey];
+          await writeRegistry(registry);
+          await restoreLatestOwnedSnapshot(registry, existing.nonce);
+          await clearGlobalIfIdle(registry);
+        } else {
+          await writeRegistry(registry);
+        }
+        return { ok: false, reason: 'route_mismatch' };
+      }
+      if (
+        existing?.nonce === resolvedNonce &&
+        claimRoute &&
+        existing.route &&
+        claimRoute !== existing.route &&
+        claimRoute !== existing.expectedRoute
+      ) {
+        delete registry.active[tabKey];
+        await writeRegistry(registry);
+        await restoreLatestOwnedSnapshot(registry, existing.nonce);
+        await clearGlobalIfIdle(registry);
+        return { ok: false, reason: 'route_mismatch' };
+      }
+
+      await localStorage.set(normalizedSnapshot);
+      registry.active[tabKey] = {
+        nonce: resolvedNonce,
+        context: normalizedContext,
+        snapshot: normalizedSnapshot,
+        route: claimRoute || existing?.route || null,
+        expectedRoute: null,
+        revision: takeRevision(registry),
+        updatedAt: now(),
+      };
+      delete registry.pending[resolvedNonce];
+      await writeRegistry(registry);
+      return {
+        ok: true,
+        nonce: resolvedNonce,
+        context: normalizedContext,
+        snapshot: normalizedSnapshot,
+      };
+    });
+  }
+
+  function update({ tabId, nonce, context, patch, route }) {
+    return exclusive(async () => {
+      const normalizedContext = normalizeContext(context);
+      if (
+        !Number.isInteger(tabId) ||
+        !isNonce(nonce) ||
+        !normalizedContext ||
+        !patch ||
+        typeof patch !== 'object'
+      ) {
+        return { ok: false, reason: 'invalid_update' };
+      }
+
+      const registry = await readRegistry();
+      const tabKey = String(tabId);
+      const existing = registry.active[tabKey];
+      if (existing?.nonce !== nonce) {
+        await writeRegistry(registry);
+        return { ok: false, reason: 'not_owner' };
+      }
+
+      const sanitizedPatch = Object.fromEntries(
+        SNAPSHOT_KEYS
+          .filter((key) => patch[key] !== undefined)
+          .map((key) => [key, patch[key]])
+      );
+      const candidate = {
+        ...existing.snapshot,
+        ...sanitizedPatch,
+        [PLAYBACK_OWNER_STORAGE_KEY]: nonce,
+      };
+      const normalizedSnapshot = normalizeSnapshot(
+        candidate,
+        nonce,
+        normalizedContext
+      );
+      if (!normalizedSnapshot) {
+        return { ok: false, reason: 'snapshot_mismatch' };
+      }
+
+      await localStorage.set(normalizedSnapshot);
+      registry.active[tabKey] = {
+        nonce,
+        context: normalizedContext,
+        snapshot: normalizedSnapshot,
+        route: normalizeRoute(route) || existing.route || null,
+        expectedRoute: existing.expectedRoute || null,
+        revision: takeRevision(registry),
+        updatedAt: now(),
+      };
+      await writeRegistry(registry);
+      return {
+        ok: true,
+        context: normalizedContext,
+        snapshot: normalizedSnapshot,
+      };
+    });
+  }
+
+  function prepareNavigation({ tabId, nonce, nextUrl }) {
+    return exclusive(async () => {
+      if (!Number.isInteger(tabId) || !isNonce(nonce)) {
+        return { ok: false, reason: 'invalid_navigation' };
+      }
+      const nextRoute = normalizeRoute(nextUrl);
+      if (!nextRoute) return { ok: false, reason: 'invalid_navigation' };
+      const registry = await readRegistry();
+      const existing = registry.active[String(tabId)];
+      if (existing?.nonce !== nonce) {
+        await writeRegistry(registry);
+        return { ok: false, reason: 'not_owner' };
+      }
+      existing.expectedRoute = nextRoute;
+      await writeRegistry(registry);
+      return { ok: true };
+    });
+  }
+
+  function bindTarget({ tabId, openerTabId }) {
+    return exclusive(async () => {
+      if (!Number.isInteger(tabId) || !Number.isInteger(openerTabId)) {
+        return { ok: false, reason: 'invalid_tab' };
+      }
+      const registry = await readRegistry();
+      const eligible = Object.values(registry.pending).filter(
+        (handoff) =>
+          Number(handoff?.sourceTabId) === openerTabId &&
+          !Number.isInteger(handoff?.targetTabId)
+      );
+      if (eligible.length !== 1) {
+        await writeRegistry(registry);
+        return {
+          ok: false,
+          reason: eligible.length > 1 ? 'ambiguous_handoff' : 'handoff_not_found',
+        };
+      }
+      eligible[0].targetTabId = tabId;
+      await writeRegistry(registry);
+      return { ok: true };
+    });
+  }
+
+  function handleTabNavigation({ tabId, url }) {
+    return exclusive(async () => {
+      if (!Number.isInteger(tabId)) return { ok: false, reason: 'invalid_tab' };
+      const registry = await readRegistry();
+      const tabKey = String(tabId);
+      const existing = registry.active[tabKey];
+      if (!existing) {
+        const pendingNonce = getOwnerNonceFromUrl(url);
+        if (isNonce(pendingNonce) && registry.pending[pendingNonce]) {
+          registry.pending[pendingNonce].targetTabId = tabId;
+        }
+        await writeRegistry(registry);
+        return { ok: true, released: false };
+      }
+      const nextRoute = normalizeRoute(url);
+      if (nextRoute && nextRoute === existing.route) {
+        await writeRegistry(registry);
+        return { ok: true, released: false };
+      }
+      if (nextRoute && nextRoute === existing.expectedRoute) {
+        existing.route = nextRoute;
+        existing.expectedRoute = null;
+        await writeRegistry(registry);
+        return { ok: true, released: false };
+      }
+
+      delete registry.active[tabKey];
+      await writeRegistry(registry);
+      await restoreLatestOwnedSnapshot(registry, existing.nonce);
+      const cleared = await clearGlobalIfIdle(registry);
+      return { ok: true, released: true, cleared };
+    });
+  }
+
+  function release({ tabId, nonce }) {
+    return exclusive(async () => {
+      if (!Number.isInteger(tabId)) return { ok: false, reason: 'invalid_tab' };
+      const registry = await readRegistry();
+      const tabKey = String(tabId);
+      const existing = registry.active[tabKey];
+      let removed = null;
+      if (existing && isNonce(nonce) && existing.nonce === nonce) {
+        removed = existing;
+        delete registry.active[tabKey];
+      }
+      await writeRegistry(registry);
+      if (removed) {
+        await restoreLatestOwnedSnapshot(registry, removed.nonce);
+      }
+      const cleared = await clearGlobalIfIdle(registry);
+      return { ok: true, cleared };
+    });
+  }
+
+  function removeTab(tabId) {
+    return exclusive(async () => {
+      if (!Number.isInteger(tabId)) return { ok: false, reason: 'invalid_tab' };
+      const registry = await readRegistry();
+      const existing = registry.active[String(tabId)];
+      delete registry.active[String(tabId)];
+      await writeRegistry(registry);
+      if (existing) {
+        await restoreLatestOwnedSnapshot(registry, existing.nonce);
+      }
+      const cleared = await clearGlobalIfIdle(registry);
+      return { ok: true, cleared };
+    });
+  }
+
+  function cleanupExpired() {
+    return exclusive(async () => {
+      const registry = await readRegistry();
+      await writeRegistry(registry);
+      await reconcileGlobalOwner(registry);
+      const cleared = await clearGlobalIfIdle(registry);
+      return { ok: true, cleared };
+    });
+  }
+
+  function reset() {
+    return exclusive(async () => {
+      const registry = { active: {}, pending: {}, revision: 0 };
+      await writeRegistry(registry);
+      await localStorage.set(GLOBAL_PLAYBACK_RESET);
+      return { ok: true };
+    });
+  }
+
+  return {
+    beginHandoff,
+    claim,
+    update,
+    prepareNavigation,
+    bindTarget,
+    handleTabNavigation,
+    release,
+    removeTab,
+    cleanupExpired,
+    reset,
+  };
+}

--- a/src/background/request.js
+++ b/src/background/request.js
@@ -20,7 +20,6 @@ export async function fetchJsonWithTimeout(
   timeoutMs = BACKGROUND_REQUEST_TIMEOUT_MS
 ) {
   const abortController = new AbortController();
-  const deadline = Date.now() + timeoutMs;
   const timeoutId = setTimeout(() => {
     abortController.abort();
   }, timeoutMs);
@@ -31,14 +30,14 @@ export async function fetchJsonWithTimeout(
       signal: abortController.signal,
     });
     const data = await parseJson(response);
-    if (abortController.signal.aborted || Date.now() >= deadline) {
+    if (abortController.signal.aborted) {
       const error = new Error('Request timed out');
       error.name = 'AbortError';
       return { ok: false, error, timedOut: true };
     }
     return { ok: true, response, data };
   } catch (error) {
-    const timedOut = abortController.signal.aborted || Date.now() >= deadline;
+    const timedOut = abortController.signal.aborted;
     return {
       ok: false,
       error,

--- a/src/background/request.js
+++ b/src/background/request.js
@@ -1,0 +1,50 @@
+export const BACKGROUND_REQUEST_TIMEOUT_MS = 15 * 1000;
+
+async function parseJson(response) {
+  try {
+    return await response.json();
+  } catch (error) {
+    if (error?.name === 'AbortError') throw error;
+    return null;
+  }
+}
+
+/**
+ * Bound both receipt of response headers and consumption of the JSON body.
+ * Native fetch observes AbortSignal, so callers holding the background mutex
+ * cannot leave it permanently pending on an unresponsive API request.
+ */
+export async function fetchJsonWithTimeout(
+  url,
+  options = {},
+  timeoutMs = BACKGROUND_REQUEST_TIMEOUT_MS
+) {
+  const abortController = new AbortController();
+  const deadline = Date.now() + timeoutMs;
+  const timeoutId = setTimeout(() => {
+    abortController.abort();
+  }, timeoutMs);
+
+  try {
+    const response = await fetch(url, {
+      ...options,
+      signal: abortController.signal,
+    });
+    const data = await parseJson(response);
+    if (abortController.signal.aborted || Date.now() >= deadline) {
+      const error = new Error('Request timed out');
+      error.name = 'AbortError';
+      return { ok: false, error, timedOut: true };
+    }
+    return { ok: true, response, data };
+  } catch (error) {
+    const timedOut = abortController.signal.aborted || Date.now() >= deadline;
+    return {
+      ok: false,
+      error,
+      timedOut,
+    };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}

--- a/src/background/sync.js
+++ b/src/background/sync.js
@@ -6,6 +6,7 @@ import {
   normalizePendingClips,
   clearExtensionAuthState,
 } from './../shared/storage.js';
+import { fetchJsonWithTimeout } from './request.js';
 
 // 同期 fetch は background(service worker)で実行する。content script の fetch は
 // ページオリジン(netflix.com 等)の CORS に従いサイト API に 403 で弾かれるが、
@@ -52,12 +53,6 @@ function toExtensionSyncItem(clip) {
   };
 }
 
-function parseResponseJson(response) {
-  return response
-    .json()
-    .catch(() => null);
-}
-
 function collectClientItemIds(value, ids = new Set()) {
   if (!value || typeof value !== 'object') return ids;
 
@@ -91,26 +86,46 @@ async function removePendingClipIds(clientItemIds) {
   });
 }
 
-export async function openLoginTab({ force = false } = {}) {
+async function performOpenLoginTab({ force = false } = {}) {
   if (!force) {
     const stored = await storageGet([LOGIN_PROMPT_STORAGE_KEY]);
     const lastOpenedAt = Number(stored[LOGIN_PROMPT_STORAGE_KEY]) || 0;
     if (Date.now() - lastOpenedAt < LOGIN_PROMPT_COOLDOWN_MS) {
-      return { ok: false, reason: 'cooldown' };
+      return { ok: true, skipped: true, reason: 'cooldown' };
     }
   }
 
-  await storageSet({ [LOGIN_PROMPT_STORAGE_KEY]: Date.now() });
-
-  return new Promise((resolve) => {
+  const result = await new Promise((resolve) => {
     chrome.tabs.create({ url: getSiteUrl('/login') }, (tab) => {
       if (chrome.runtime.lastError) {
-        resolve({ ok: false, error: chrome.runtime.lastError.message });
+        resolve({
+          ok: false,
+          reason: 'tab_create_failed',
+          error: chrome.runtime.lastError.message,
+        });
         return;
       }
       resolve({ ok: true, tabId: tab?.id });
     });
   });
+
+  // A failed tabs.create must remain immediately retryable. Record cooldown
+  // only after Chrome confirms that a login tab was actually opened.
+  if (result.ok) {
+    await storageSet({ [LOGIN_PROMPT_STORAGE_KEY]: Date.now() });
+  }
+  return result;
+}
+
+let loginTabInFlight = null;
+export function openLoginTab(options = {}) {
+  if (!loginTabInFlight) {
+    loginTabInFlight = performOpenLoginTab(options)
+      .finally(() => {
+        loginTabInFlight = null;
+      });
+  }
+  return loginTabInFlight;
 }
 
 async function performSyncPendingQueue({ openLoginIfMissingToken = false } = {}) {
@@ -145,30 +160,31 @@ async function performSyncPendingQueue({ openLoginIfMissingToken = false } = {})
     hasToken: true,
   });
 
-  let response;
-  let data = null;
+  const request = await fetchJsonWithTimeout(getApiEndpoint('extension/sync'), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${extensionAuthToken}`,
+    },
+    body: JSON.stringify({
+      extensionInstanceId,
+      items: pendingClips.map(toExtensionSyncItem),
+    }),
+  });
 
-  try {
-    response = await fetch(getApiEndpoint('extension/sync'), {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${extensionAuthToken}`,
-      },
-      body: JSON.stringify({
-        extensionInstanceId,
-        items: pendingClips.map(toExtensionSyncItem),
-      }),
-    });
-
-    data = await parseResponseJson(response);
-  } catch (error) {
+  if (!request.ok) {
     console.warn('[extension-sync] network error; keeping clips queued', {
       clipCount: pendingClips.length,
-      message: error?.message,
+      message: request.error?.message,
+      timedOut: request.timedOut,
     });
-    return { ok: false, queued: true, reason: 'network_error' };
+    return {
+      ok: false,
+      queued: true,
+      reason: request.timedOut ? 'timeout' : 'network_error',
+    };
   }
+  const { response, data } = request;
 
   console.log('[extension-sync] sync result', {
     status: response.status,

--- a/src/background/tokenRefresh.js
+++ b/src/background/tokenRefresh.js
@@ -7,6 +7,7 @@ import {
   clearExtensionAuthState,
 } from './../shared/storage.js';
 import { runExclusive } from './sync.js';
+import { fetchJsonWithTimeout } from './request.js';
 
 // トークンはサーバ発行の不透明トークン(JWT ではない)。期限はサーバが link/refresh 応答の
 // expiresAt で通知し、拡張は storage に保存した値だけを見て更新時期を判断する。
@@ -27,10 +28,8 @@ function computeBackoffMs(failureCount, status) {
 }
 
 // バックオフは「どのトークンで失敗したか」に紐づけて保存する。
-// content 側の saveExtensionAuthToken() は runExclusive の外で storage を書き換えるため、
-// 「保存済みトークンを確認してから書く」形にしても確認と書き込みの間に再連携が割り込む
-// 余地が残る(TOCTOU)。書き込み側の原子性に頼らず、読み出し側で現在のトークンと照合し、
-// 一致しない記録は無効として扱う。これなら古い試行が後から書き戻しても影響しない。
+// auth bridge を含むトークン更新は同じ runExclusive に集約している。fingerprint も保持し、
+// 永続化済みの旧バックオフ記録が再連携後の新トークンを抑制しないようにする。
 async function tokenFingerprint(token) {
   const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(token));
   return Array.from(new Uint8Array(digest).slice(0, 8))
@@ -115,26 +114,27 @@ async function performCheckAndRefreshToken() {
     return { ok: true, skipped: true, reason: 'not_due' };
   }
 
-  let response;
-  let data = null;
+  const request = await fetchJsonWithTimeout(getApiEndpoint('extension/token/refresh'), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ extensionInstanceId }),
+  });
 
-  try {
-    response = await fetch(getApiEndpoint('extension/token/refresh'), {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify({ extensionInstanceId }),
-    });
-    data = await response.json().catch(() => null);
-  } catch (error) {
+  if (!request.ok) {
     console.warn('[extension-sync] token refresh failed; keeping current token', {
-      message: error?.message,
+      message: request.error?.message,
+      timedOut: request.timedOut,
     });
     await recordRefreshFailure(token, null);
-    return { ok: false, reason: 'network_error' };
+    return {
+      ok: false,
+      reason: request.timedOut ? 'timeout' : 'network_error',
+    };
   }
+  const { response, data } = request;
 
   if (response.status === 200 && typeof data?.extensionAuthToken === 'string') {
     await storageSet({

--- a/src/content/commentPanel.js
+++ b/src/content/commentPanel.js
@@ -86,6 +86,19 @@ const PANEL_STYLES = `
     opacity: 0.55;
   }
 
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .refresh {
+    padding: 6px 10px;
+    color: #fff;
+    background: rgba(255, 255, 255, 0.14);
+    font-size: 12px;
+  }
+
   .close {
     width: 32px;
     height: 32px;
@@ -335,6 +348,7 @@ function updateSubmitState(controller) {
   controller.submitButton.disabled =
     !controller.composeAvailable || controller.posting || !hasBody;
   controller.textarea.disabled = !controller.composeAvailable;
+  controller.refreshButton.disabled = controller.posting;
 }
 
 function setComposeAvailable(controller, available) {
@@ -714,6 +728,21 @@ async function postComment(controller) {
   }
 }
 
+/**
+ * 先頭ページを取り直して一覧を作り直す。サイト側でコメントが削除されると
+ * 一覧から消えるだけなので、追記マージのままでは削除済みが残り続ける。
+ */
+function reloadComments(controller) {
+  if (controller.closed || controller.posting) return;
+
+  if (controller.clipId === null) {
+    void refreshCurrentClip(controller);
+    return;
+  }
+
+  void loadComments(controller);
+}
+
 function scheduleStorageRefresh(controller) {
   if (controller.refreshScheduled || controller.closed) return;
   controller.refreshScheduled = true;
@@ -744,6 +773,22 @@ function removeStorageListener(controller) {
   controller.storageListener = null;
 }
 
+// サイトのタブでコメントを消して戻ってきたときに、削除済みを表示したままにしない。
+function addVisibilityListener(controller) {
+  controller.visibilityListener = () => {
+    if (document.visibilityState === 'visible') {
+      reloadComments(controller);
+    }
+  };
+  document.addEventListener('visibilitychange', controller.visibilityListener);
+}
+
+function removeVisibilityListener(controller) {
+  if (!controller.visibilityListener) return;
+  document.removeEventListener('visibilitychange', controller.visibilityListener);
+  controller.visibilityListener = null;
+}
+
 function notifyOpenState(controller, open) {
   try {
     controller.onOpenChange?.(open);
@@ -758,6 +803,7 @@ function closeController(controller, { restoreFocus = true } = {}) {
   controller.contextVersion += 1;
   controller.requestVersion += 1;
   removeStorageListener(controller);
+  removeVisibilityListener(controller);
   window.removeEventListener('beforeunload', controller.beforeUnload);
   controller.host.remove();
   if (activePanel === controller) {
@@ -813,11 +859,18 @@ function createPanel({ mountEl, triggerEl, onOpenChange }) {
   const title = createElement('h2', 'コメント');
   title.id = `${COMMENT_PANEL_ID}-title`;
   title.className = 'title';
+  const refreshButton = createElement('button', '更新');
+  refreshButton.type = 'button';
+  refreshButton.className = 'refresh';
+  refreshButton.setAttribute('aria-label', 'コメントを再読み込み');
   const closeButton = createElement('button', '×');
   closeButton.type = 'button';
   closeButton.className = 'close';
   closeButton.setAttribute('aria-label', 'コメントを閉じる');
-  header.append(title, closeButton);
+  const headerActions = createElement('div');
+  headerActions.className = 'header-actions';
+  headerActions.append(refreshButton, closeButton);
+  header.append(title, headerActions);
 
   const commentsList = createElement('div');
   commentsList.className = 'comments';
@@ -865,6 +918,7 @@ function createPanel({ mountEl, triggerEl, onOpenChange }) {
     panel,
     commentsList,
     closeButton,
+    refreshButton,
     loadMoreButton,
     textarea,
     submitButton,
@@ -884,10 +938,12 @@ function createPanel({ mountEl, triggerEl, onOpenChange }) {
     requestVersion: 0,
     refreshScheduled: false,
     storageListener: null,
+    visibilityListener: null,
     beforeUnload: null,
   };
 
   closeButton.addEventListener('click', () => closeController(controller));
+  refreshButton.addEventListener('click', () => reloadComments(controller));
   textarea.addEventListener('input', () => updateSubmitState(controller));
   form.addEventListener('submit', (event) => {
     event.preventDefault();
@@ -921,6 +977,7 @@ function createPanel({ mountEl, triggerEl, onOpenChange }) {
   controller.beforeUnload = () => closeController(controller, { restoreFocus: false });
   window.addEventListener('beforeunload', controller.beforeUnload, { once: true });
   addStorageListener(controller);
+  addVisibilityListener(controller);
   return controller;
 }
 

--- a/src/content/commentPanel.js
+++ b/src/content/commentPanel.js
@@ -1,6 +1,16 @@
 import { storageGet } from './../shared/storage.js';
+import {
+  CLOSE_COMMENT_PANEL_EVENT,
+  closeMemoSidebar,
+} from './common.js';
+import {
+  PLAYBACK_CONTEXT_CHANGED_EVENT,
+  readPlaybackContext,
+} from './playbackContext.js';
 
 export const COMMENT_PANEL_ID = 'ext-comment-panel';
+export const COMMENT_PANEL_OPEN_STATE_EVENT =
+  'ext:comment-panel-open-state';
 
 const COMMENT_LIMIT = 20;
 const COMMENT_BODY_MAX_LENGTH = 500;
@@ -12,8 +22,7 @@ const PLAYBACK_STORAGE_KEYS = [
   'playQueue',
   'currentClipOrder',
 ];
-const WATCHED_STORAGE_KEYS = new Set([
-  ...PLAYBACK_STORAGE_KEYS,
+const WATCHED_AUTH_STORAGE_KEYS = new Set([
   'extensionAuthToken',
   'extensionLinked',
 ]);
@@ -65,7 +74,7 @@ const PANEL_STYLES = `
   }
 
   button,
-  textarea {
+  ::slotted(textarea) {
     font: inherit;
   }
 
@@ -76,7 +85,7 @@ const PANEL_STYLES = `
   }
 
   button:focus-visible,
-  textarea:focus-visible {
+  ::slotted(textarea:focus-visible) {
     outline: 2px solid #76b7ff;
     outline-offset: 2px;
   }
@@ -182,7 +191,8 @@ const PANEL_STYLES = `
     color: #d0d7de;
   }
 
-  .textarea {
+  ::slotted(.textarea) {
+    box-sizing: border-box;
     width: 100%;
     min-height: 82px;
     max-height: 180px;
@@ -193,6 +203,7 @@ const PANEL_STYLES = `
     color: #111;
     background: #fff;
     line-height: 1.45;
+    pointer-events: auto;
   }
 
   .submit {
@@ -280,6 +291,11 @@ export function resolveCurrentClipIdFromState(state = {}) {
 }
 
 export async function resolveCurrentClipId() {
+  const localPlayback = readPlaybackContext();
+  if (localPlayback.initialized) {
+    return localPlayback.context?.clipId ?? null;
+  }
+
   const state = await storageGet(PLAYBACK_STORAGE_KEYS);
   return resolveCurrentClipIdFromState(state);
 }
@@ -348,7 +364,8 @@ function updateSubmitState(controller) {
   controller.submitButton.disabled =
     !controller.composeAvailable || controller.posting || !hasBody;
   controller.textarea.disabled = !controller.composeAvailable;
-  controller.refreshButton.disabled = controller.posting;
+  controller.refreshButton.disabled =
+    controller.posting || controller.loadingBase || controller.refreshingContext;
 }
 
 function setComposeAvailable(controller, available) {
@@ -411,7 +428,8 @@ function renderComments(controller) {
     controller.loadMoreButton.hidden = !controller.hasNext;
   }
 
-  controller.loadMoreButton.disabled = controller.loadingMore;
+  controller.loadMoreButton.disabled =
+    controller.loadingMore || controller.loadingBase;
   controller.loadMoreButton.textContent = controller.loadingMore
     ? '読込中…'
     : 'さらに表示';
@@ -434,19 +452,51 @@ function mergeComments(existing, incoming) {
   return merged;
 }
 
-async function openLoginPage(controller) {
-  setStatus(controller, 'ログインページを開いています…');
-  const result = await sendRuntimeMessage({ type: 'OPEN_LOGIN_TAB' });
-  if (controller.closed) return;
+export function shouldClearSubmittedDraft(currentValue, submittedValue) {
+  return currentValue === submittedValue;
+}
 
-  if (result?.ok) {
-    setStatus(
-      controller,
-      'ログインページを開きました。連携後に再試行してください。',
-      'success'
-    );
-  } else {
-    setStatus(controller, 'ログインページを開けませんでした。', 'error');
+export function isAmbiguousPostFailure(reason) {
+  return reason === 'invalid_response'
+    || reason === 'network_error'
+    || reason === 'timeout'
+    || reason === 'background_unavailable'
+    || reason === 'request_failed';
+}
+
+async function openLoginPage(controller) {
+  if (controller.closed || controller.openingLogin) return;
+  controller.openingLogin = true;
+  for (const button of controller.actions.querySelectorAll('button')) {
+    button.disabled = true;
+  }
+  setStatus(controller, 'ログインページを開いています…');
+  try {
+    const result = await sendRuntimeMessage({ type: 'OPEN_LOGIN_TAB' });
+    if (controller.closed) return;
+
+    if (result?.ok && result?.skipped && result?.reason === 'cooldown') {
+      setStatus(
+        controller,
+        'ログインページは直前に開いています。連携後に再試行してください。',
+        'success'
+      );
+    } else if (result?.ok) {
+      setStatus(
+        controller,
+        'ログインページを開きました。連携後に再試行してください。',
+        'success'
+      );
+    } else {
+      setStatus(controller, 'ログインページを開けませんでした。', 'error');
+    }
+  } finally {
+    controller.openingLogin = false;
+    if (!controller.closed) {
+      for (const button of controller.actions.querySelectorAll('button')) {
+        button.disabled = false;
+      }
+    }
   }
 }
 
@@ -491,7 +541,42 @@ function showFetchError(controller, result, retry) {
   setActions(controller, [createActionButton('再試行', retry)]);
 }
 
-async function loadComments(
+function loadComments(controller, options = {}) {
+  const append = options.append === true;
+  if (controller.closed || controller.clipId === null) {
+    return Promise.resolve();
+  }
+  if (append && (controller.loadingMore || controller.loadingBase)) {
+    return Promise.resolve();
+  }
+  if (!append && controller.baseLoadPromise) {
+    return controller.baseLoadPromise;
+  }
+
+  if (!append) {
+    controller.loadingBase = true;
+    controller.loadingMore = false;
+    updateSubmitState(controller);
+  }
+
+  const loadPromise = performLoadComments(controller, options);
+  if (!append) {
+    controller.baseLoadPromise = loadPromise;
+    const finishBaseLoad = () => {
+      if (controller.baseLoadPromise !== loadPromise) return;
+      controller.baseLoadPromise = null;
+      controller.loadingBase = false;
+      if (!controller.closed) {
+        controller.loadMoreButton.disabled = controller.loadingMore;
+        updateSubmitState(controller);
+      }
+    };
+    loadPromise.then(finishBaseLoad, finishBaseLoad);
+  }
+  return loadPromise;
+}
+
+async function performLoadComments(
   controller,
   { cursor, append = false, contextVersion = controller.contextVersion } = {}
 ) {
@@ -571,7 +656,46 @@ async function loadComments(
   setStatus(controller);
 }
 
-async function refreshCurrentClip(controller) {
+function refreshCurrentClip(controller, { queueIfBusy = false } = {}) {
+  if (controller.closed) return Promise.resolve();
+  if (controller.refreshPromise) {
+    if (queueIfBusy) controller.refreshQueued = true;
+    return controller.refreshPromise;
+  }
+  if (controller.baseLoadPromise) {
+    if (queueIfBusy && !controller.refreshAfterBase) {
+      controller.refreshAfterBase = true;
+      const activeLoad = controller.baseLoadPromise;
+      const refreshAfterLoad = () => {
+        if (!controller.refreshAfterBase) return;
+        controller.refreshAfterBase = false;
+        if (!controller.closed) void refreshCurrentClip(controller);
+      };
+      activeLoad.then(refreshAfterLoad, refreshAfterLoad);
+    }
+    return controller.baseLoadPromise;
+  }
+
+  controller.refreshingContext = true;
+  updateSubmitState(controller);
+  const refreshPromise = performRefreshCurrentClip(controller);
+  controller.refreshPromise = refreshPromise;
+  const finishRefresh = () => {
+    if (controller.refreshPromise !== refreshPromise) return;
+    controller.refreshPromise = null;
+    controller.refreshingContext = false;
+    if (controller.closed) return;
+    updateSubmitState(controller);
+    if (controller.refreshQueued) {
+      controller.refreshQueued = false;
+      void refreshCurrentClip(controller);
+    }
+  };
+  refreshPromise.then(finishRefresh, finishRefresh);
+  return refreshPromise;
+}
+
+async function performRefreshCurrentClip(controller) {
   if (controller.closed) return;
   const previousClipId = controller.clipId;
   const contextVersion = ++controller.contextVersion;
@@ -661,7 +785,8 @@ function showPostError(controller, result) {
 
 async function postComment(controller) {
   if (controller.closed || controller.posting || !controller.composeAvailable) return;
-  const body = controller.textarea.value.trim();
+  const submittedValue = controller.textarea.value;
+  const body = submittedValue.trim();
   if (!body) {
     updateSubmitState(controller);
     return;
@@ -710,13 +835,32 @@ async function postComment(controller) {
 
     if (controller.closed || controller.contextVersion !== contextVersion) return;
 
+    if (isAmbiguousPostFailure(result?.reason)) {
+      setStatus(
+        controller,
+        '投稿結果を確認できなかったため、一覧を更新しています…',
+        'error'
+      );
+      await loadComments(controller);
+      if (!controller.closed && controller.contextVersion === contextVersion) {
+        setStatus(
+          controller,
+          '投稿結果を確認できませんでした。一覧を確認してから、必要な場合だけ再投稿してください。入力内容は保持されています。',
+          'error'
+        );
+      }
+      return;
+    }
+
     if (!result?.ok || !result.comment || typeof result.comment !== 'object') {
       showPostError(controller, result);
       return;
     }
 
     controller.comments = mergeComments([result.comment], controller.comments);
-    controller.textarea.value = '';
+    if (shouldClearSubmittedDraft(controller.textarea.value, submittedValue)) {
+      controller.textarea.value = '';
+    }
     renderComments(controller);
     setActions(controller);
     setStatus(controller, 'コメントを投稿しました。', 'success');
@@ -733,7 +877,14 @@ async function postComment(controller) {
  * 一覧から消えるだけなので、追記マージのままでは削除済みが残り続ける。
  */
 function reloadComments(controller) {
-  if (controller.closed || controller.posting) return;
+  if (
+    controller.closed ||
+    controller.posting ||
+    controller.loadingBase ||
+    controller.refreshingContext
+  ) {
+    return;
+  }
 
   if (controller.clipId === null) {
     void refreshCurrentClip(controller);
@@ -749,7 +900,7 @@ function scheduleStorageRefresh(controller) {
   queueMicrotask(() => {
     controller.refreshScheduled = false;
     if (!controller.closed) {
-      void refreshCurrentClip(controller);
+      void refreshCurrentClip(controller, { queueIfBusy: true });
     }
   });
 }
@@ -760,7 +911,9 @@ function addStorageListener(controller) {
 
   controller.storageListener = (changes, areaName) => {
     if (areaName !== 'local') return;
-    if (Object.keys(changes).some((key) => WATCHED_STORAGE_KEYS.has(key))) {
+    if (
+      Object.keys(changes).some((key) => WATCHED_AUTH_STORAGE_KEYS.has(key))
+    ) {
       scheduleStorageRefresh(controller);
     }
   };
@@ -771,6 +924,25 @@ function removeStorageListener(controller) {
   if (!controller.storageListener) return;
   globalThis.chrome?.storage?.onChanged?.removeListener?.(controller.storageListener);
   controller.storageListener = null;
+}
+
+function addPlaybackContextListener(controller) {
+  controller.playbackContextListener = () => {
+    scheduleStorageRefresh(controller);
+  };
+  window.addEventListener(
+    PLAYBACK_CONTEXT_CHANGED_EVENT,
+    controller.playbackContextListener
+  );
+}
+
+function removePlaybackContextListener(controller) {
+  if (!controller.playbackContextListener) return;
+  window.removeEventListener(
+    PLAYBACK_CONTEXT_CHANGED_EVENT,
+    controller.playbackContextListener
+  );
+  controller.playbackContextListener = null;
 }
 
 // サイトのタブでコメントを消して戻ってきたときに、削除済みを表示したままにしない。
@@ -789,12 +961,99 @@ function removeVisibilityListener(controller) {
   controller.visibilityListener = null;
 }
 
+function dispatchPanelOpenState(open) {
+  if (!window?.dispatchEvent) return;
+  try {
+    window.dispatchEvent(
+      new CustomEvent(COMMENT_PANEL_OPEN_STATE_EVENT, {
+        detail: { open },
+      })
+    );
+  } catch {
+    // The direct callback and aria state still work on restricted pages.
+  }
+}
+
 function notifyOpenState(controller, open) {
+  for (const trigger of document.querySelectorAll(
+    `[aria-controls="${COMMENT_PANEL_ID}"]`
+  )) {
+    trigger.setAttribute('aria-expanded', String(open));
+  }
   try {
     controller.onOpenChange?.(open);
   } catch (error) {
     console.warn('[extension-comments] onOpenChange failed', error);
   }
+  dispatchPanelOpenState(open);
+}
+
+function eventBelongsToPanel(event, controller) {
+  if (event.target === controller.host) return true;
+  try {
+    if (event.composedPath?.().includes(controller.host)) return true;
+    return controller.host.contains(event.target);
+  } catch {
+    return false;
+  }
+}
+
+function addKeyGuard(controller) {
+  controller.keyGuard = (event) => {
+    if (controller.closed || !eventBelongsToPanel(event, controller)) return;
+    // Capture on window before the event reaches document/player shortcuts.
+    event.stopImmediatePropagation();
+    if (event.type === 'keydown' && event.key === 'Escape') {
+      event.preventDefault();
+      closeController(controller);
+    }
+  };
+  for (const eventName of ['keydown', 'keyup', 'keypress']) {
+    window.addEventListener(eventName, controller.keyGuard, true);
+  }
+}
+
+function removeKeyGuard(controller) {
+  if (!controller.keyGuard) return;
+  for (const eventName of ['keydown', 'keyup', 'keypress']) {
+    window.removeEventListener(eventName, controller.keyGuard, true);
+  }
+  controller.keyGuard = null;
+}
+
+function addDetachedMountObserver(controller) {
+  if (typeof MutationObserver !== 'function' || !document.documentElement) return;
+  controller.mountObserver = new MutationObserver(() => {
+    if (!controller.host.isConnected) {
+      closeController(controller, { restoreFocus: false });
+    }
+  });
+  controller.mountObserver.observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+  });
+}
+
+function removeDetachedMountObserver(controller) {
+  controller.mountObserver?.disconnect();
+  controller.mountObserver = null;
+}
+
+function addCloseRequestListener(controller) {
+  controller.closeRequestListener = () => closeController(controller);
+  window.addEventListener(
+    CLOSE_COMMENT_PANEL_EVENT,
+    controller.closeRequestListener
+  );
+}
+
+function removeCloseRequestListener(controller) {
+  if (!controller.closeRequestListener) return;
+  window.removeEventListener(
+    CLOSE_COMMENT_PANEL_EVENT,
+    controller.closeRequestListener
+  );
+  controller.closeRequestListener = null;
 }
 
 function closeController(controller, { restoreFocus = true } = {}) {
@@ -803,7 +1062,11 @@ function closeController(controller, { restoreFocus = true } = {}) {
   controller.contextVersion += 1;
   controller.requestVersion += 1;
   removeStorageListener(controller);
+  removePlaybackContextListener(controller);
   removeVisibilityListener(controller);
+  removeKeyGuard(controller);
+  removeDetachedMountObserver(controller);
+  removeCloseRequestListener(controller);
   window.removeEventListener('beforeunload', controller.beforeUnload);
   controller.host.remove();
   if (activePanel === controller) {
@@ -811,8 +1074,11 @@ function closeController(controller, { restoreFocus = true } = {}) {
   }
   notifyOpenState(controller, false);
 
-  if (restoreFocus && controller.triggerEl?.isConnected) {
-    controller.triggerEl.focus?.();
+  if (restoreFocus) {
+    const focusTarget = controller.triggerEl?.isConnected
+      ? controller.triggerEl
+      : document.querySelector(`[aria-controls="${COMMENT_PANEL_ID}"]`);
+    focusTarget?.focus?.();
   }
 }
 
@@ -893,14 +1159,22 @@ function createPanel({ mountEl, triggerEl, onOpenChange }) {
   const textarea = createElement('textarea');
   textarea.id = textareaId;
   textarea.className = 'textarea';
+  textarea.slot = 'comment-composer';
   textarea.maxLength = COMMENT_BODY_MAX_LENGTH;
   textarea.rows = 3;
   textarea.placeholder = 'コメントを入力（500文字まで）';
+  textarea.setAttribute('aria-label', 'コメントを入力');
+  // Keep the editable control in the light DOM and render it through a slot.
+  // Streaming sites then see a real textarea target and can apply their normal
+  // shortcut exclusion even though the rest of the panel remains isolated.
+  const textareaSlot = createElement('slot');
+  textareaSlot.name = textarea.slot;
+  label.addEventListener('click', () => textarea.focus());
   const submitButton = createElement('button', '投稿');
   submitButton.type = 'submit';
   submitButton.className = 'submit';
   submitButton.disabled = true;
-  form.append(label, textarea, submitButton);
+  form.append(label, textareaSlot, submitButton);
 
   const actions = createElement('div');
   actions.className = 'actions';
@@ -909,6 +1183,7 @@ function createPanel({ mountEl, triggerEl, onOpenChange }) {
   status.setAttribute('aria-live', 'polite');
 
   panel.append(header, commentsList, pagination, form, actions, status);
+  host.appendChild(textarea);
   shadowRoot.append(style, panel);
   mountEl.appendChild(host);
 
@@ -931,14 +1206,25 @@ function createPanel({ mountEl, triggerEl, onOpenChange }) {
     hasNext: false,
     nextCursor: null,
     composeAvailable: false,
+    loadingBase: false,
     loadingMore: false,
     posting: false,
+    openingLogin: false,
     closed: false,
     contextVersion: 0,
     requestVersion: 0,
+    baseLoadPromise: null,
+    refreshingContext: false,
+    refreshPromise: null,
+    refreshQueued: false,
+    refreshAfterBase: false,
     refreshScheduled: false,
     storageListener: null,
+    playbackContextListener: null,
     visibilityListener: null,
+    keyGuard: null,
+    mountObserver: null,
+    closeRequestListener: null,
     beforeUnload: null,
   };
 
@@ -977,7 +1263,11 @@ function createPanel({ mountEl, triggerEl, onOpenChange }) {
   controller.beforeUnload = () => closeController(controller, { restoreFocus: false });
   window.addEventListener('beforeunload', controller.beforeUnload, { once: true });
   addStorageListener(controller);
+  addPlaybackContextListener(controller);
   addVisibilityListener(controller);
+  addKeyGuard(controller);
+  addDetachedMountObserver(controller);
+  addCloseRequestListener(controller);
   return controller;
 }
 
@@ -988,6 +1278,8 @@ export function toggleCommentPanel({
 } = {}) {
   pruneDetachedPanel();
   if (activePanel) {
+    if (triggerEl?.isConnected) activePanel.triggerEl = triggerEl;
+    if (onOpenChange) activePanel.onOpenChange = onOpenChange;
     closeController(activePanel);
     return false;
   }
@@ -997,6 +1289,7 @@ export function toggleCommentPanel({
     return false;
   }
 
+  closeMemoSidebar();
   activePanel = createPanel({ mountEl, triggerEl, onOpenChange });
   notifyOpenState(activePanel, true);
   void refreshCurrentClip(activePanel);

--- a/src/content/commentPanel.js
+++ b/src/content/commentPanel.js
@@ -1,4 +1,3 @@
-import { storageGet } from './../shared/storage.js';
 import {
   CLOSE_COMMENT_PANEL_EVENT,
   closeMemoSidebar,
@@ -7,21 +6,16 @@ import {
   PLAYBACK_CONTEXT_CHANGED_EVENT,
   readPlaybackContext,
 } from './playbackContext.js';
+import {
+  COMMENT_BODY_MAX_CODE_POINTS,
+  isValidCommentBody,
+} from '../shared/commentText.js';
 
 export const COMMENT_PANEL_ID = 'ext-comment-panel';
 export const COMMENT_PANEL_OPEN_STATE_EVENT =
   'ext:comment-panel-open-state';
 
 const COMMENT_LIMIT = 20;
-const COMMENT_BODY_MAX_LENGTH = 500;
-const PLAYBACK_STORAGE_KEYS = [
-  'playmode',
-  'playClipSystemKey',
-  'playlistSystemKey',
-  'clip',
-  'playQueue',
-  'currentClipOrder',
-];
 const WATCHED_AUTH_STORAGE_KEYS = new Set([
   'extensionAuthToken',
   'extensionLinked',
@@ -292,12 +286,7 @@ export function resolveCurrentClipIdFromState(state = {}) {
 
 export async function resolveCurrentClipId() {
   const localPlayback = readPlaybackContext();
-  if (localPlayback.initialized) {
-    return localPlayback.context?.clipId ?? null;
-  }
-
-  const state = await storageGet(PLAYBACK_STORAGE_KEYS);
-  return resolveCurrentClipIdFromState(state);
+  return localPlayback.context?.clipId ?? null;
 }
 
 function sendRuntimeMessage(message) {
@@ -792,7 +781,7 @@ async function postComment(controller) {
     return;
   }
 
-  if (body.length > COMMENT_BODY_MAX_LENGTH) {
+  if (!isValidCommentBody(body)) {
     setStatus(controller, 'コメントは500文字以内で入力してください。', 'error');
     return;
   }
@@ -1155,14 +1144,12 @@ function createPanel({ mountEl, triggerEl, onOpenChange }) {
   const textareaId = `${COMMENT_PANEL_ID}-body`;
   const label = createElement('label', 'コメントを入力');
   label.className = 'composer-label';
-  label.htmlFor = textareaId;
   const textarea = createElement('textarea');
   textarea.id = textareaId;
   textarea.className = 'textarea';
   textarea.slot = 'comment-composer';
-  textarea.maxLength = COMMENT_BODY_MAX_LENGTH;
   textarea.rows = 3;
-  textarea.placeholder = 'コメントを入力（500文字まで）';
+  textarea.placeholder = `コメントを入力（${COMMENT_BODY_MAX_CODE_POINTS}文字まで）`;
   textarea.setAttribute('aria-label', 'コメントを入力');
   // Keep the editable control in the light DOM and render it through a slot.
   // Streaming sites then see a real textarea target and can apply their normal

--- a/src/content/commentPanel.js
+++ b/src/content/commentPanel.js
@@ -1,0 +1,952 @@
+import { storageGet } from './../shared/storage.js';
+
+export const COMMENT_PANEL_ID = 'ext-comment-panel';
+
+const COMMENT_LIMIT = 20;
+const COMMENT_BODY_MAX_LENGTH = 500;
+const PLAYBACK_STORAGE_KEYS = [
+  'playmode',
+  'playClipSystemKey',
+  'playlistSystemKey',
+  'clip',
+  'playQueue',
+  'currentClipOrder',
+];
+const WATCHED_STORAGE_KEYS = new Set([
+  ...PLAYBACK_STORAGE_KEYS,
+  'extensionAuthToken',
+  'extensionLinked',
+]);
+
+const PANEL_STYLES = `
+  :host {
+    color: #fff;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  }
+
+  *, *::before, *::after {
+    box-sizing: border-box;
+  }
+
+  [hidden] {
+    display: none !important;
+  }
+
+  .panel {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: min(420px, 38vw);
+    min-width: 300px;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 16px;
+    overflow: hidden;
+    color: #fff;
+    background: rgba(13, 17, 23, 0.96);
+    border-left: 1px solid rgba(255, 255, 255, 0.18);
+    box-shadow: -10px 0 28px rgba(0, 0, 0, 0.42);
+    pointer-events: auto;
+  }
+
+  .header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  .title {
+    margin: 0;
+    font-size: 18px;
+    line-height: 1.4;
+  }
+
+  button,
+  textarea {
+    font: inherit;
+  }
+
+  button {
+    border: 0;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+
+  button:focus-visible,
+  textarea:focus-visible {
+    outline: 2px solid #76b7ff;
+    outline-offset: 2px;
+  }
+
+  button:disabled {
+    cursor: default;
+    opacity: 0.55;
+  }
+
+  .close {
+    width: 32px;
+    height: 32px;
+    color: #fff;
+    background: rgba(255, 255, 255, 0.14);
+    font-size: 22px;
+    line-height: 1;
+  }
+
+  .comments {
+    flex: 1;
+    min-height: 100px;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    padding-right: 3px;
+  }
+
+  .message {
+    margin: 16px 0;
+    color: #d0d7de;
+    line-height: 1.6;
+    white-space: pre-wrap;
+  }
+
+  .comment {
+    padding: 12px 2px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.14);
+  }
+
+  .comment-meta {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px;
+    margin-bottom: 6px;
+  }
+
+  .comment-user {
+    color: #fff;
+    font-size: 13px;
+  }
+
+  .comment-time {
+    color: #9da7b1;
+    font-size: 11px;
+    white-space: nowrap;
+  }
+
+  .comment-body {
+    margin: 0;
+    color: #f0f3f6;
+    font-size: 14px;
+    line-height: 1.55;
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
+  }
+
+  .pagination,
+  .actions {
+    display: flex;
+    justify-content: center;
+    gap: 8px;
+  }
+
+  .secondary {
+    padding: 7px 12px;
+    color: #fff;
+    background: rgba(255, 255, 255, 0.14);
+  }
+
+  .composer {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding-top: 10px;
+    border-top: 1px solid rgba(255, 255, 255, 0.18);
+  }
+
+  .composer-label {
+    font-size: 12px;
+    color: #d0d7de;
+  }
+
+  .textarea {
+    width: 100%;
+    min-height: 82px;
+    max-height: 180px;
+    resize: vertical;
+    padding: 9px 10px;
+    border: 1px solid rgba(255, 255, 255, 0.28);
+    border-radius: 7px;
+    color: #111;
+    background: #fff;
+    line-height: 1.45;
+  }
+
+  .submit {
+    align-self: flex-end;
+    padding: 8px 16px;
+    color: #07130b;
+    background: #54d173;
+    font-weight: 700;
+  }
+
+  .status {
+    min-height: 18px;
+    margin: 0;
+    color: #b8c1cc;
+    font-size: 12px;
+    line-height: 1.45;
+    white-space: pre-wrap;
+  }
+
+  .status[data-tone="error"] {
+    color: #ffb4ab;
+  }
+
+  .status[data-tone="success"] {
+    color: #7ee787;
+  }
+
+  @media (max-width: 720px) {
+    .panel {
+      width: 100%;
+      min-width: 0;
+    }
+  }
+`;
+
+let activePanel = null;
+
+function toSafeInteger(value, { positive = false, nonNegative = false } = {}) {
+  let numberValue;
+  if (typeof value === 'number') {
+    numberValue = value;
+  } else if (typeof value === 'string' && /^-?\d+$/.test(value.trim())) {
+    numberValue = Number(value.trim());
+  } else {
+    return null;
+  }
+
+  if (!Number.isSafeInteger(numberValue)) return null;
+  if (positive && numberValue <= 0) return null;
+  if (nonNegative && numberValue < 0) return null;
+  return numberValue;
+}
+
+function resolvePlaybackMode(state) {
+  if (state?.playmode === 'playlist' || state?.playmode === 'clip') {
+    return state.playmode;
+  }
+
+  if (state?.playClipSystemKey === 1) return 'clip';
+  if (state?.playlistSystemKey === 1) return 'playlist';
+  return null;
+}
+
+export function resolveCurrentClipIdFromState(state = {}) {
+  const mode = resolvePlaybackMode(state);
+
+  if (mode === 'playlist') {
+    if (!Array.isArray(state.playQueue)) return null;
+    const currentOrder = toSafeInteger(state.currentClipOrder, { nonNegative: true });
+    if (currentOrder === null) return null;
+
+    const currentClip = state.playQueue.find(
+      (item) => toSafeInteger(item?.order, { nonNegative: true }) === currentOrder
+    );
+    const id = currentClip?.clipId ?? currentClip?.id;
+    return toSafeInteger(id, { positive: true });
+  }
+
+  if (mode === 'clip') {
+    const id = state.clip?.clipId ?? state.clip?.id;
+    return toSafeInteger(id, { positive: true });
+  }
+
+  return null;
+}
+
+export async function resolveCurrentClipId() {
+  const state = await storageGet(PLAYBACK_STORAGE_KEYS);
+  return resolveCurrentClipIdFromState(state);
+}
+
+function sendRuntimeMessage(message) {
+  return new Promise((resolve) => {
+    const runtime = globalThis.chrome?.runtime;
+    if (!runtime?.sendMessage) {
+      resolve({ ok: false, reason: 'background_unavailable' });
+      return;
+    }
+
+    try {
+      runtime.sendMessage(message, (response) => {
+        if (runtime.lastError) {
+          resolve({
+            ok: false,
+            reason: 'background_unavailable',
+            message: runtime.lastError.message,
+          });
+          return;
+        }
+        resolve(response || { ok: false, reason: 'request_failed' });
+      });
+    } catch (error) {
+      resolve({
+        ok: false,
+        reason: 'background_unavailable',
+        message: error?.message,
+      });
+    }
+  });
+}
+
+function createElement(tagName, text) {
+  const element = document.createElement(tagName);
+  if (text !== undefined) {
+    element.textContent = text;
+  }
+  return element;
+}
+
+function setStatus(controller, message = '', tone = '') {
+  controller.status.textContent = message;
+  if (tone) {
+    controller.status.dataset.tone = tone;
+  } else {
+    delete controller.status.dataset.tone;
+  }
+}
+
+function setActions(controller, buttons = []) {
+  controller.actions.replaceChildren(...buttons);
+}
+
+function createActionButton(label, onClick) {
+  const button = createElement('button', label);
+  button.type = 'button';
+  button.className = 'secondary';
+  button.addEventListener('click', onClick);
+  return button;
+}
+
+function updateSubmitState(controller) {
+  const hasBody = controller.textarea.value.trim().length > 0;
+  controller.submitButton.disabled =
+    !controller.composeAvailable || controller.posting || !hasBody;
+  controller.textarea.disabled = !controller.composeAvailable;
+}
+
+function setComposeAvailable(controller, available) {
+  controller.composeAvailable = available;
+  updateSubmitState(controller);
+}
+
+function showListMessage(controller, message) {
+  const paragraph = createElement('p', message);
+  paragraph.className = 'message';
+  controller.commentsList.replaceChildren(paragraph);
+  controller.loadMoreButton.hidden = true;
+}
+
+function formatCommentDate(value) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleString('ja-JP');
+}
+
+function createCommentElement(comment) {
+  const article = createElement('article');
+  article.className = 'comment';
+
+  const meta = createElement('div');
+  meta.className = 'comment-meta';
+
+  const username = createElement(
+    'strong',
+    typeof comment?.username === 'string' && comment.username.trim()
+      ? comment.username
+      : 'ユーザー'
+  );
+  username.className = 'comment-user';
+
+  const time = createElement('time', formatCommentDate(comment?.createdAt));
+  time.className = 'comment-time';
+  if (typeof comment?.createdAt === 'string') {
+    time.dateTime = comment.createdAt;
+  }
+
+  const body = createElement(
+    'p',
+    typeof comment?.body === 'string' ? comment.body : ''
+  );
+  body.className = 'comment-body';
+
+  meta.append(username, time);
+  article.append(meta, body);
+  return article;
+}
+
+function renderComments(controller) {
+  if (controller.comments.length === 0) {
+    showListMessage(controller, 'コメントはまだありません。');
+  } else {
+    controller.commentsList.replaceChildren(
+      ...controller.comments.map(createCommentElement)
+    );
+    controller.loadMoreButton.hidden = !controller.hasNext;
+  }
+
+  controller.loadMoreButton.disabled = controller.loadingMore;
+  controller.loadMoreButton.textContent = controller.loadingMore
+    ? '読込中…'
+    : 'さらに表示';
+}
+
+function commentIdentity(comment) {
+  const id = toSafeInteger(comment?.id, { positive: true });
+  return id === null ? null : String(id);
+}
+
+function mergeComments(existing, incoming) {
+  const seenIds = new Set();
+  const merged = [];
+  for (const comment of [...existing, ...incoming]) {
+    const identity = commentIdentity(comment);
+    if (identity !== null && seenIds.has(identity)) continue;
+    if (identity !== null) seenIds.add(identity);
+    merged.push(comment);
+  }
+  return merged;
+}
+
+async function openLoginPage(controller) {
+  setStatus(controller, 'ログインページを開いています…');
+  const result = await sendRuntimeMessage({ type: 'OPEN_LOGIN_TAB' });
+  if (controller.closed) return;
+
+  if (result?.ok) {
+    setStatus(
+      controller,
+      'ログインページを開きました。連携後に再試行してください。',
+      'success'
+    );
+  } else {
+    setStatus(controller, 'ログインページを開けませんでした。', 'error');
+  }
+}
+
+function showAuthRequired(controller) {
+  showListMessage(controller, 'コメントを利用するには、サイトとの連携が必要です。');
+  setComposeAvailable(controller, false);
+  setStatus(controller, 'サイトとの連携が必要です。', 'error');
+  setActions(controller, [
+    createActionButton('連携する', () => {
+      void openLoginPage(controller);
+    }),
+    createActionButton('再試行', () => {
+      void refreshCurrentClip(controller);
+    }),
+  ]);
+}
+
+function showFetchError(controller, result, retry) {
+  setComposeAvailable(controller, false);
+
+  if (result?.reason === 'missing_token' || result?.reason === 'unauthorized') {
+    showAuthRequired(controller);
+    return;
+  }
+
+  if (result?.reason === 'not_found') {
+    showListMessage(controller, '対象のクリップが見つかりません。');
+    setStatus(controller, 'コメントを取得できません。', 'error');
+    setActions(controller);
+    return;
+  }
+
+  if (result?.reason === 'forbidden') {
+    showListMessage(controller, 'このクリップのコメントにはアクセスできません。');
+    setStatus(controller, 'アクセスが拒否されました。', 'error');
+    setActions(controller);
+    return;
+  }
+
+  showListMessage(controller, 'コメントの取得に失敗しました。');
+  setStatus(controller, result?.message || '通信状態を確認して再試行してください。', 'error');
+  setActions(controller, [createActionButton('再試行', retry)]);
+}
+
+async function loadComments(
+  controller,
+  { cursor, append = false, contextVersion = controller.contextVersion } = {}
+) {
+  if (controller.closed || controller.clipId === null) return;
+
+  const requestVersion = ++controller.requestVersion;
+  if (append) {
+    controller.loadingMore = true;
+    renderComments(controller);
+    setStatus(controller, '以前のコメントを読み込んでいます…');
+  } else {
+    controller.comments = [];
+    controller.hasNext = false;
+    controller.nextCursor = null;
+    showListMessage(controller, '読込中…');
+    setComposeAvailable(controller, false);
+    setActions(controller);
+    setStatus(controller, 'コメントを読み込んでいます…');
+  }
+
+  const message = {
+    type: 'FETCH_CLIP_COMMENTS',
+    clipId: controller.clipId,
+    limit: COMMENT_LIMIT,
+  };
+  if (cursor !== undefined && cursor !== null) {
+    message.cursor = cursor;
+  }
+
+  const result = await sendRuntimeMessage(message);
+  if (
+    controller.closed ||
+    controller.contextVersion !== contextVersion ||
+    controller.requestVersion !== requestVersion
+  ) {
+    return;
+  }
+
+  controller.loadingMore = false;
+  if (!result?.ok) {
+    if (append && controller.comments.length > 0) {
+      renderComments(controller);
+      if (result?.reason === 'missing_token' || result?.reason === 'unauthorized') {
+        showAuthRequired(controller);
+      } else {
+        setStatus(controller, '追加のコメント取得に失敗しました。', 'error');
+        setActions(controller, [
+          createActionButton('再試行', () => {
+            void loadComments(controller, {
+              cursor,
+              append: true,
+              contextVersion,
+            });
+          }),
+        ]);
+      }
+      return;
+    }
+
+    showFetchError(controller, result, () => {
+      void refreshCurrentClip(controller);
+    });
+    return;
+  }
+
+  const receivedComments = Array.isArray(result.comments) ? result.comments : [];
+  controller.comments = append
+    ? mergeComments(controller.comments, receivedComments)
+    : mergeComments([], receivedComments);
+  const nextCursor = toSafeInteger(result.nextCursor, { positive: true });
+  controller.hasNext = Boolean(result.hasNext && nextCursor !== null);
+  controller.nextCursor = controller.hasNext ? nextCursor : null;
+
+  renderComments(controller);
+  setComposeAvailable(controller, true);
+  setActions(controller);
+  setStatus(controller);
+}
+
+async function refreshCurrentClip(controller) {
+  if (controller.closed) return;
+  const previousClipId = controller.clipId;
+  const contextVersion = ++controller.contextVersion;
+  controller.requestVersion += 1;
+  controller.comments = [];
+  controller.hasNext = false;
+  controller.nextCursor = null;
+  controller.loadingMore = false;
+  showListMessage(controller, '再生中のクリップを確認しています…');
+  setComposeAvailable(controller, false);
+  setActions(controller);
+  setStatus(controller);
+
+  let clipId = null;
+  try {
+    clipId = await resolveCurrentClipId();
+  } catch (error) {
+    if (controller.closed || controller.contextVersion !== contextVersion) return;
+    controller.clipId = null;
+    showListMessage(controller, '再生中のクリップを確認できませんでした。');
+    setStatus(controller, error?.message || 'ストレージの読み込みに失敗しました。', 'error');
+    setActions(controller, [
+      createActionButton('再試行', () => {
+        void refreshCurrentClip(controller);
+      }),
+    ]);
+    return;
+  }
+
+  if (controller.closed || controller.contextVersion !== contextVersion) return;
+  if (clipId === null) {
+    controller.clipId = null;
+    if (previousClipId !== null) {
+      controller.textarea.value = '';
+    }
+    showListMessage(
+      controller,
+      'コメントを表示できるのは、サイトから再生したクリップのみです。'
+    );
+    setStatus(controller, 'このクリップにはサーバー上のIDがありません。');
+    return;
+  }
+
+  if (previousClipId !== null && clipId !== previousClipId) {
+    controller.textarea.value = '';
+  }
+  controller.clipId = clipId;
+  await loadComments(controller, { contextVersion });
+}
+
+function showPostError(controller, result) {
+  if (result?.reason === 'missing_token' || result?.reason === 'unauthorized') {
+    setComposeAvailable(controller, false);
+    setStatus(controller, '投稿するにはサイトとの連携が必要です。', 'error');
+    setActions(controller, [
+      createActionButton('連携する', () => {
+        void openLoginPage(controller);
+      }),
+      createActionButton('再試行', () => {
+        void refreshCurrentClip(controller);
+      }),
+    ]);
+    return;
+  }
+
+  if (result?.reason === 'not_found') {
+    setComposeAvailable(controller, false);
+    setStatus(controller, '対象のクリップが見つかりません。', 'error');
+    return;
+  }
+
+  if (result?.reason === 'validation_error') {
+    setStatus(
+      controller,
+      result?.message || 'コメントは1〜500文字で入力してください。',
+      'error'
+    );
+    return;
+  }
+
+  setStatus(
+    controller,
+    result?.message || 'コメントの投稿に失敗しました。入力内容は保持されています。',
+    'error'
+  );
+}
+
+async function postComment(controller) {
+  if (controller.closed || controller.posting || !controller.composeAvailable) return;
+  const body = controller.textarea.value.trim();
+  if (!body) {
+    updateSubmitState(controller);
+    return;
+  }
+
+  if (body.length > COMMENT_BODY_MAX_LENGTH) {
+    setStatus(controller, 'コメントは500文字以内で入力してください。', 'error');
+    return;
+  }
+
+  controller.posting = true;
+  updateSubmitState(controller);
+  setActions(controller);
+  setStatus(controller, '投稿しています…');
+
+  const contextVersion = controller.contextVersion;
+  const expectedClipId = controller.clipId;
+
+  try {
+    let currentClipId = null;
+    try {
+      currentClipId = await resolveCurrentClipId();
+    } catch (error) {
+      if (!controller.closed && controller.contextVersion === contextVersion) {
+        setStatus(
+          controller,
+          error?.message || '再生中のクリップを確認できませんでした。',
+          'error'
+        );
+      }
+      return;
+    }
+
+    if (controller.closed || controller.contextVersion !== contextVersion) return;
+    if (currentClipId === null || currentClipId !== expectedClipId) {
+      setStatus(controller, '再生中のクリップが変わったため、投稿を中止しました。', 'error');
+      await refreshCurrentClip(controller);
+      return;
+    }
+
+    const result = await sendRuntimeMessage({
+      type: 'POST_CLIP_COMMENT',
+      clipId: expectedClipId,
+      body,
+    });
+
+    if (controller.closed || controller.contextVersion !== contextVersion) return;
+
+    if (!result?.ok || !result.comment || typeof result.comment !== 'object') {
+      showPostError(controller, result);
+      return;
+    }
+
+    controller.comments = mergeComments([result.comment], controller.comments);
+    controller.textarea.value = '';
+    renderComments(controller);
+    setActions(controller);
+    setStatus(controller, 'コメントを投稿しました。', 'success');
+  } finally {
+    if (!controller.closed) {
+      controller.posting = false;
+      updateSubmitState(controller);
+    }
+  }
+}
+
+function scheduleStorageRefresh(controller) {
+  if (controller.refreshScheduled || controller.closed) return;
+  controller.refreshScheduled = true;
+  queueMicrotask(() => {
+    controller.refreshScheduled = false;
+    if (!controller.closed) {
+      void refreshCurrentClip(controller);
+    }
+  });
+}
+
+function addStorageListener(controller) {
+  const onChanged = globalThis.chrome?.storage?.onChanged;
+  if (!onChanged?.addListener) return;
+
+  controller.storageListener = (changes, areaName) => {
+    if (areaName !== 'local') return;
+    if (Object.keys(changes).some((key) => WATCHED_STORAGE_KEYS.has(key))) {
+      scheduleStorageRefresh(controller);
+    }
+  };
+  onChanged.addListener(controller.storageListener);
+}
+
+function removeStorageListener(controller) {
+  if (!controller.storageListener) return;
+  globalThis.chrome?.storage?.onChanged?.removeListener?.(controller.storageListener);
+  controller.storageListener = null;
+}
+
+function notifyOpenState(controller, open) {
+  try {
+    controller.onOpenChange?.(open);
+  } catch (error) {
+    console.warn('[extension-comments] onOpenChange failed', error);
+  }
+}
+
+function closeController(controller, { restoreFocus = true } = {}) {
+  if (!controller || controller.closed) return;
+  controller.closed = true;
+  controller.contextVersion += 1;
+  controller.requestVersion += 1;
+  removeStorageListener(controller);
+  window.removeEventListener('beforeunload', controller.beforeUnload);
+  controller.host.remove();
+  if (activePanel === controller) {
+    activePanel = null;
+  }
+  notifyOpenState(controller, false);
+
+  if (restoreFocus && controller.triggerEl?.isConnected) {
+    controller.triggerEl.focus?.();
+  }
+}
+
+function pruneDetachedPanel() {
+  if (activePanel && !activePanel.host.isConnected) {
+    closeController(activePanel, { restoreFocus: false });
+  }
+}
+
+export function isCommentPanelOpen() {
+  pruneDetachedPanel();
+  return Boolean(activePanel);
+}
+
+export function closeCommentPanel() {
+  pruneDetachedPanel();
+  if (activePanel) {
+    closeController(activePanel);
+  }
+}
+
+function createPanel({ mountEl, triggerEl, onOpenChange }) {
+  const host = createElement('div');
+  host.id = COMMENT_PANEL_ID;
+  const isDocumentMount = mountEl === document.body || mountEl === document.documentElement;
+  host.style.cssText = `
+    position:${isDocumentMount ? 'fixed' : 'absolute'};
+    inset:0;
+    z-index:2147483001;
+    pointer-events:none;
+  `;
+
+  const shadowRoot = host.attachShadow({ mode: 'closed' });
+  const style = createElement('style', PANEL_STYLES);
+
+  const panel = createElement('section');
+  panel.className = 'panel';
+  panel.setAttribute('role', 'dialog');
+  panel.setAttribute('aria-modal', 'false');
+  panel.setAttribute('aria-labelledby', `${COMMENT_PANEL_ID}-title`);
+
+  const header = createElement('header');
+  header.className = 'header';
+  const title = createElement('h2', 'コメント');
+  title.id = `${COMMENT_PANEL_ID}-title`;
+  title.className = 'title';
+  const closeButton = createElement('button', '×');
+  closeButton.type = 'button';
+  closeButton.className = 'close';
+  closeButton.setAttribute('aria-label', 'コメントを閉じる');
+  header.append(title, closeButton);
+
+  const commentsList = createElement('div');
+  commentsList.className = 'comments';
+  commentsList.setAttribute('aria-live', 'polite');
+
+  const pagination = createElement('div');
+  pagination.className = 'pagination';
+  const loadMoreButton = createElement('button', 'さらに表示');
+  loadMoreButton.type = 'button';
+  loadMoreButton.className = 'secondary';
+  loadMoreButton.hidden = true;
+  pagination.appendChild(loadMoreButton);
+
+  const form = createElement('form');
+  form.className = 'composer';
+  const textareaId = `${COMMENT_PANEL_ID}-body`;
+  const label = createElement('label', 'コメントを入力');
+  label.className = 'composer-label';
+  label.htmlFor = textareaId;
+  const textarea = createElement('textarea');
+  textarea.id = textareaId;
+  textarea.className = 'textarea';
+  textarea.maxLength = COMMENT_BODY_MAX_LENGTH;
+  textarea.rows = 3;
+  textarea.placeholder = 'コメントを入力（500文字まで）';
+  const submitButton = createElement('button', '投稿');
+  submitButton.type = 'submit';
+  submitButton.className = 'submit';
+  submitButton.disabled = true;
+  form.append(label, textarea, submitButton);
+
+  const actions = createElement('div');
+  actions.className = 'actions';
+  const status = createElement('p');
+  status.className = 'status';
+  status.setAttribute('aria-live', 'polite');
+
+  panel.append(header, commentsList, pagination, form, actions, status);
+  shadowRoot.append(style, panel);
+  mountEl.appendChild(host);
+
+  const controller = {
+    host,
+    shadowRoot,
+    panel,
+    commentsList,
+    closeButton,
+    loadMoreButton,
+    textarea,
+    submitButton,
+    actions,
+    status,
+    triggerEl,
+    onOpenChange,
+    clipId: null,
+    comments: [],
+    hasNext: false,
+    nextCursor: null,
+    composeAvailable: false,
+    loadingMore: false,
+    posting: false,
+    closed: false,
+    contextVersion: 0,
+    requestVersion: 0,
+    refreshScheduled: false,
+    storageListener: null,
+    beforeUnload: null,
+  };
+
+  closeButton.addEventListener('click', () => closeController(controller));
+  textarea.addEventListener('input', () => updateSubmitState(controller));
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    void postComment(controller);
+  });
+  loadMoreButton.addEventListener('click', () => {
+    if (
+      controller.loadingMore ||
+      !controller.hasNext ||
+      controller.nextCursor === null
+    ) {
+      return;
+    }
+    void loadComments(controller, {
+      cursor: controller.nextCursor,
+      append: true,
+    });
+  });
+
+  for (const eventName of ['click', 'mousedown', 'pointerdown', 'keyup']) {
+    panel.addEventListener(eventName, (event) => event.stopPropagation());
+  }
+  panel.addEventListener('keydown', (event) => {
+    event.stopPropagation();
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closeController(controller);
+    }
+  });
+
+  controller.beforeUnload = () => closeController(controller, { restoreFocus: false });
+  window.addEventListener('beforeunload', controller.beforeUnload, { once: true });
+  addStorageListener(controller);
+  return controller;
+}
+
+export function toggleCommentPanel({
+  mountEl,
+  triggerEl = document.activeElement,
+  onOpenChange,
+} = {}) {
+  pruneDetachedPanel();
+  if (activePanel) {
+    closeController(activePanel);
+    return false;
+  }
+
+  if (!mountEl?.appendChild) {
+    console.warn('[extension-comments] comment panel mount element was not found');
+    return false;
+  }
+
+  activePanel = createPanel({ mountEl, triggerEl, onOpenChange });
+  notifyOpenState(activePanel, true);
+  void refreshCurrentClip(activePanel);
+  queueMicrotask(() => {
+    if (!activePanel?.closed) {
+      activePanel.closeButton.focus();
+    }
+  });
+  return true;
+}

--- a/src/content/common.js
+++ b/src/content/common.js
@@ -5,10 +5,37 @@ import {
 
 export const MEMO_SIDEBAR_ID = 'nf-memo-sidebar';
 export const AUTO_NAVIGATION_KEY = 'extAutoNavigation';
+export const CLOSE_COMMENT_PANEL_EVENT = 'ext:close-comment-panel';
 
 // 表示中サイドバーの状態。再オープン時に元のプレイヤー幅を引き継ぎつつ、
 // 前インスタンスのリスナーを確実に外すためモジュールスコープで保持する。
 let activeMemoSession = null;
+
+export function requestCloseCommentPanel() {
+  if (typeof window.dispatchEvent !== 'function') return;
+  const EventConstructor = globalThis.CustomEvent || globalThis.Event;
+  if (typeof EventConstructor !== 'function') return;
+  window.dispatchEvent(new EventConstructor(CLOSE_COMMENT_PANEL_EVENT));
+}
+
+export function closeMemoSidebar() {
+  const session = activeMemoSession;
+  if (session) {
+    session.close();
+    return true;
+  }
+
+  const sidebar = document.getElementById(MEMO_SIDEBAR_ID);
+  if (!sidebar) return false;
+
+  const originalWidth = sidebar.dataset?.originalPlayerWidth;
+  sidebar.remove();
+  const player =
+    document.querySelector('.watch-video--player-view') ||
+    document.querySelector('video')?.parentElement;
+  if (player) player.style.width = originalWidth || '100%';
+  return true;
+}
 
 export function detectService(host = window.location.hostname) {
   if (host.includes('netflix.com')) return 'Netflix';
@@ -88,20 +115,23 @@ export function openMemoSidebar({
     document.querySelector('video')?.parentElement;
   if (!player) return null;
 
+  requestCloseCommentPanel();
+
   // 直前のサイドバーが残っている場合は旧セッションを無効化する。同じプレイヤーなら
   // 最初に開く前の幅を引き継ぎ、別プレイヤーなら旧プレイヤーの幅をここで復元する。
   const previousSession = activeMemoSession;
-  let originalWidth = player.style.width;
+  if (!previousSession) {
+    // Netflix のクリップ一覧など、メモ以外が同じ領域を使っている場合は、
+    // そのサイドバーが保存した元幅へ戻してからメモ側の originalWidth を取得する。
+    closeMemoSidebar();
+  }
+  const originalWidth =
+    previousSession?.player === player
+      ? previousSession.originalWidth
+      : player.style.width;
   if (previousSession) {
     previousSession.supersede();
-    previousSession.teardown();
-    previousSession.sidebar.remove();
-    if (previousSession.player === player) {
-      originalWidth = previousSession.originalWidth;
-    } else {
-      previousSession.player.style.width = previousSession.originalWidth || '100%';
-    }
-    activeMemoSession = null;
+    previousSession.close({ notify: false });
   }
   document.getElementById(MEMO_SIDEBAR_ID)?.remove();
 
@@ -128,7 +158,7 @@ export function openMemoSidebar({
   const closeBtn = document.createElement('button');
   closeBtn.textContent = '×';
   closeBtn.style.cssText = 'background:red;color:#fff;border:none;cursor:pointer;';
-  const closeSidebar = () => {
+  const closeSidebar = ({ notify = true } = {}) => {
     if (closed) return;
     closed = true;
     removeKeyGuard?.();
@@ -138,7 +168,7 @@ export function openMemoSidebar({
       player.style.width = originalWidth || '100%';
     }
     sb.remove();
-    onClose?.();
+    if (notify) onClose?.();
   };
   closeBtn.onclick = closeSidebar;
   header.append(title, closeBtn);
@@ -215,7 +245,11 @@ export function openMemoSidebar({
       e.preventDefault();
       submit();
     }
-    e.stopPropagation();
+    if (typeof e.stopImmediatePropagation === 'function') {
+      e.stopImmediatePropagation();
+    } else {
+      e.stopPropagation();
+    }
   };
   const keyTypes = ['keydown', 'keyup', 'keypress'];
   for (const type of keyTypes) {
@@ -258,6 +292,7 @@ export function openMemoSidebar({
     player,
     originalWidth,
     teardown: removeKeyGuard,
+    close: closeSidebar,
     supersede: () => {
       superseded = true;
     },

--- a/src/content/content_disney.js
+++ b/src/content/content_disney.js
@@ -7,6 +7,11 @@ import {
   requestSeek,
   sendData
 } from './common.js';
+import {
+  COMMENT_PANEL_ID,
+  isCommentPanelOpen,
+  toggleCommentPanel
+} from './commentPanel.js';
 
 (() => {
   const AUTO_NAV_STORAGE_KEY = 'autoNav';
@@ -143,7 +148,13 @@ import {
     const BUTTONS = [
       { id: 'dext-left-button', area: 'left', label: 'Left Button', action: myCustomActionLeft },
       { id: 'dext-right-button-1', area: 'right', label: 'Right Button 1', action: myCustomActionRight1 },
-      { id: 'dext-right-button-2', area: 'right', label: 'Right Button 2', action: myCustomActionRight2 }
+      {
+        id: 'dext-right-button-2',
+        area: 'right',
+        label: 'コメント',
+        action: myCustomActionRight2,
+        controls: COMMENT_PANEL_ID
+      }
     ];
 
     let observer = null;
@@ -306,6 +317,12 @@ import {
         container.id = config.id;
         container.className = 'dext-button-container button-container';
         container.setAttribute('role', 'button');
+        container.setAttribute('aria-label', config.label);
+        if (config.controls) {
+          container.setAttribute('aria-haspopup', 'dialog');
+          container.setAttribute('aria-controls', config.controls);
+          container.setAttribute('aria-expanded', 'false');
+        }
         container.tabIndex = 0; // キーボード対応
 
         // 内側のダミーbutton（Disney+は内側buttonに .control を置いている）
@@ -323,10 +340,15 @@ import {
 
         // クリック＆キーボードで発火（captureも保険で使用）
         const onActivate = (e) => {
+          let nextActiveState;
           if (typeof config.action === 'function') {
-            config.action();   // ボタンごとに関数を実行
+            nextActiveState = config.action(container);   // ボタンごとに関数を実行
           }
-          container.classList.toggle('active');
+          if (typeof nextActiveState === 'boolean') {
+            container.classList.toggle('active', nextActiveState);
+          } else {
+            container.classList.toggle('active');
+          }
           e.stopPropagation();                  // 他のハンドラに奪われないように
         };
 
@@ -344,6 +366,17 @@ import {
         });
 
         host.appendChild(container);
+      }
+
+      const label = container.querySelector('.dext-button-label');
+      if (label) {
+        label.textContent = config.label;
+      }
+      container.setAttribute('aria-label', config.label);
+      if (config.controls) {
+        const panelOpen = isCommentPanelOpen();
+        container.classList.toggle('active', panelOpen);
+        container.setAttribute('aria-expanded', String(panelOpen));
       }
 
       return container;
@@ -402,7 +435,16 @@ import {
       Mode.toggleLoop();
     }
 
-    function myCustomActionRight2() {
+    function myCustomActionRight2(triggerEl) {
+      return toggleCommentPanel({
+        mountEl: getPlayerRoot() || document.body,
+        triggerEl,
+        onOpenChange: (open) => {
+          if (!triggerEl?.isConnected) return;
+          triggerEl.classList.toggle('active', open);
+          triggerEl.setAttribute('aria-expanded', String(open));
+        }
+      });
     }
 
     function injectButtons() {

--- a/src/content/content_disney.js
+++ b/src/content/content_disney.js
@@ -549,6 +549,10 @@ import {
       ensurePlayerIdleStyle();
       const root = document.documentElement;
       let idleTimer = null;
+      // 起動直後やタブ復帰直後は、ユーザーがまだページをクリックしていないと
+      // document.hasFocus() が false を返すことがある。可視タブはひとまずアクティブとし、
+      // 以降は focus / blur / visibilitychange で状態を追跡する。
+      let pageActive = !document.hidden;
 
       const setIdle = (v) => root.classList.toggle(PLAYER_IDLE_CLASS, v);
       const goIdle = () => {
@@ -564,19 +568,37 @@ import {
         idleTimer = isPlaying() ? setTimeout(goIdle, PLAYER_IDLE_MS) : null;
       };
       // blur / 非表示中は play・pause など操作以外のイベントで復帰させない。
-      const markActive = () => (document.hasFocus() ? activate() : goIdle());
+      const markActive = () => (pageActive ? activate() : goIdle());
+      const handleBlur = () => {
+        pageActive = false;
+        goIdle();
+      };
+      const handleFocus = () => {
+        pageActive = true;
+        activate();
+      };
+      const handleVisibilityChange = () => {
+        pageActive = !document.hidden;
+        if (pageActive) {
+          activate();
+        } else {
+          goIdle();
+        }
+      };
 
       for (const type of ['pointermove', 'pointerdown', 'keydown']) {
         document.addEventListener(type, markActive, { passive: true });
       }
       // ウィンドウが非アクティブになったら即座に隠す / 戻ったら復帰。
-      window.addEventListener('blur', goIdle);
-      window.addEventListener('focus', activate);
+      window.addEventListener('blur', handleBlur);
+      window.addEventListener('focus', handleFocus);
+      // タブ切り替えでは window.focus が発火しない場合があるため、可視性でも復帰させる。
+      document.addEventListener('visibilitychange', handleVisibilityChange);
       // 再生/停止（media イベントは bubble しないため capture で拾う）。
       document.addEventListener('play', markActive, true);
       document.addEventListener('pause', markActive, true);
 
-      markActive();
+      handleVisibilityChange();
     }
 
     function bootstrap() {

--- a/src/content/content_disney.js
+++ b/src/content/content_disney.js
@@ -591,8 +591,13 @@ import {
         }
       };
 
+      // Disney+ のマスクや Shadow DOM 内でイベント伝播が止められても拾えるよう、
+      // window のキャプチャ段階で監視する。
       for (const type of ['pointerover', 'pointermove', 'pointerdown', 'keydown']) {
-        document.addEventListener(type, handleUserActivity, { passive: true });
+        window.addEventListener(type, handleUserActivity, {
+          capture: true,
+          passive: true,
+        });
       }
       // ウィンドウが非アクティブになったら即座に隠す / 戻ったら復帰。
       window.addEventListener('blur', handleBlur);

--- a/src/content/content_disney.js
+++ b/src/content/content_disney.js
@@ -1,9 +1,6 @@
 import {
-  clearAutoNavigation,
   detectService,
   EXT_UI_CLASS,
-  isAutoNavigation,
-  markAutoNavigation,
   markExtUi,
   openMemoSidebar,
   requestSeek,
@@ -22,6 +19,7 @@ import {
   setPlaybackContext
 } from './playbackContext.js';
 import { setTextContentIfChanged } from './domUpdates.js';
+import { normalizePlaybackRoute } from '../shared/playbackBridgeValidation.js';
 import {
   addPlaybackOwnerToUrl,
   claimPlaybackOwnership,
@@ -33,19 +31,13 @@ import {
 
 (() => {
   ensurePlaybackContext();
-  const AUTO_NAV_STORAGE_KEY = 'autoNav';
   const AUTO_NAV_TTL_MS = 15000;
   let autoNavCache = null;
   let activePlaybackOwnerNonce = null;
   let playbackLocation = null;
 
   function routeIdentity(url) {
-    try {
-      const parsed = new URL(url, location.href);
-      return `${parsed.origin}${parsed.pathname}`;
-    } catch {
-      return String(url || '');
-    }
+    return normalizePlaybackRoute(url, location.href) || String(url || '');
   }
 
   function applyPlaybackContext(context, ownerNonce) {
@@ -109,28 +101,8 @@ import {
     return isAutoNavValid(autoNavCache);
   }
 
-  async function loadAutoNav() {
-    const { [AUTO_NAV_STORAGE_KEY]: autoNav } = await chrome.storage.local.get([
-      AUTO_NAV_STORAGE_KEY
-    ]);
-
-    if (!isAutoNavValid(autoNav)) {
-      if (autoNav) {
-        await chrome.storage.local.remove(AUTO_NAV_STORAGE_KEY);
-        clearAutoNavigation();
-      }
-      autoNavCache = null;
-      return null;
-    }
-
-    autoNavCache = autoNav;
-    return autoNav;
-  }
-
-  async function clearAutoNavState() {
+  function clearAutoNavState() {
     autoNavCache = null;
-    clearAutoNavigation();
-    await chrome.storage.local.remove(AUTO_NAV_STORAGE_KEY);
   }
 
   async function beginAutoNavigation({ mode, nextUrl, nextOrder, nextId }) {
@@ -151,9 +123,6 @@ import {
     };
 
     autoNavCache = autoNav;
-    markAutoNavigation(mode || 'auto');
-
-    await chrome.storage.local.set({ [AUTO_NAV_STORAGE_KEY]: autoNav });
     return true;
   }
 
@@ -212,7 +181,6 @@ import {
       right: 'dext-control-host-right'
     };
     const STYLE_ID = 'dext-control-style';
-    const HISTORY_HOOK_FLAG = '__dext_history_hooked__';
 
     const BUTTONS = [
       { id: 'dext-left-button', area: 'left', label: 'Left Button', action: myCustomActionLeft },
@@ -380,7 +348,7 @@ import {
       let container = document.getElementById(config.id);
 
       if (!container || !host.contains(container)) {
-        if (container && container.parentNode) container.parentNode.removeChild(container);
+        if (container?.parentNode) container.parentNode.removeChild(container);
 
         // Disney+ に寄せた構造: [div.button-container(tabindex=0, role="button")] ＞ [button.control] ＋ [span.label]
         container = document.createElement('div');
@@ -568,31 +536,6 @@ import {
       attach();
     }
 
-    function hookHistory() {
-      if (window[HISTORY_HOOK_FLAG]) {
-        return;
-      }
-
-      window[HISTORY_HOOK_FLAG] = true;
-
-      const dispatch = () => window.dispatchEvent(new Event('locationchange'));
-
-      for (const type of ['pushState', 'replaceState']) {
-        const original = history[type];
-        if (typeof original !== 'function') {
-          continue;
-        }
-
-        history[type] = function historyPatched() {
-          const result = original.apply(this, arguments);
-          dispatch();
-          return result;
-        };
-      }
-
-      window.addEventListener('popstate', dispatch);
-    }
-
     // Disney+ はマウス静止でネイティブのコントロール行が自動的に消える。拡張ボタンも
     // それに追随させ、(1) 一定時間ポインタ操作が無いアイドル時 (2) ウィンドウが blur した
     // ときに隠す。停止中はネイティブ同様に出したままにする。表示制御は共通の EXT_UI_CLASS
@@ -676,7 +619,6 @@ import {
     }
 
     function bootstrap() {
-      hookHistory();
       startObserver();
       scheduleInjection();
       startTabVisibilityToggle();
@@ -718,7 +660,7 @@ import {
           totalSeconds  : total,
           currentTime   : formatTime(current),
           totalTime     : formatTime(total),
-          progress      : ((current / total) * 100).toFixed(2) + "%"
+          progress      : `${((current / total) * 100).toFixed(2)}%`
         };
       }
 
@@ -992,7 +934,6 @@ import {
       const snapshot = session?.snapshot;
       const clip = snapshot?.clip;
       if (session?.context?.mode !== 'clip' || snapshot?.playClipSystemKey !== 1 || !clip) {
-        clearPlaybackContext();
         console.log('[Clip] No clip data or disabled');
         return null;
       }
@@ -1009,7 +950,10 @@ import {
       currentSession = session;
       const clipData = loadClipData(session);
       if (!clipData) return;
-      stopCurrent = Playlist.play([clipData], { loop: loopEnabled });
+      stopCurrent = Playlist.play([clipData], {
+        loop: loopEnabled,
+        onStart: clearAutoNavState
+      });
     }
 
 async function startPlaylistMode(session) {
@@ -1044,6 +988,7 @@ async function startPlaylistMode(session) {
 
   function playPlaylistClip(clipData) {
     stopCurrent = Clip.play(clipData, {
+      onStart: clearAutoNavState,
       onEnd: handlePlaylistEnd
     });
   }
@@ -1117,11 +1062,10 @@ async function startPlaylistMode(session) {
 
 
     async function startPreferredMode() {
-      const autoNav = await loadAutoNav();
       const ownerNonce = getTabPlaybackOwnerNonce();
       const session = await claimPlaybackSession(ownerNonce);
-      if (autoNav) await clearAutoNavState();
       if (!session) return;
+      autoNavCache = session.autoNavigation ? { ts: Date.now() } : null;
       currentSession = session;
       if (session.context.mode === 'playlist') {
         await startPlaylistMode(session);
@@ -1141,12 +1085,12 @@ async function startPlaylistMode(session) {
       loopEnabled = !loopEnabled;
       if (loopEnabled) {
         console.log('[Loop] ON');
-        stopActiveMode();
         const clipData = loadClipData();
         if (!clipData) {
           loopEnabled = false;
           return;
         }
+        stopActiveMode();
         stopCurrent = Playlist.play([clipData], { loop: loopEnabled });
       } else {
         console.log('[Loop] OFF - stop playback');
@@ -1181,13 +1125,12 @@ async function startPlaylistMode(session) {
 
   Mode.bootstrap();
 
-  window.addEventListener('locationchange', () => {
+  window.addEventListener('historyChange', (event) => {
     UI.scheduleInjection();
-    const nextLocation = routeIdentity(location.href);
+    const nextLocation = routeIdentity(event.detail?.url || location.href);
     if (
       activePlaybackOwnerNonce &&
       nextLocation !== playbackLocation &&
-      !isAutoNavigation() &&
       !isAutoNavActive()
     ) {
       deactivatePlaybackContext();

--- a/src/content/content_disney.js
+++ b/src/content/content_disney.js
@@ -12,14 +12,91 @@ import {
 } from './common.js';
 import {
   COMMENT_PANEL_ID,
+  closeCommentPanel,
   isCommentPanelOpen,
   toggleCommentPanel
 } from './commentPanel.js';
+import {
+  clearPlaybackContext,
+  ensurePlaybackContext,
+  setPlaybackContext
+} from './playbackContext.js';
+import { setTextContentIfChanged } from './domUpdates.js';
+import {
+  addPlaybackOwnerToUrl,
+  claimPlaybackOwnership,
+  getTabPlaybackOwnerNonce,
+  preparePlaybackNavigation,
+  releasePlaybackOwnership,
+  updatePlaybackOwnership
+} from './playbackOwnership.js';
 
 (() => {
+  ensurePlaybackContext();
   const AUTO_NAV_STORAGE_KEY = 'autoNav';
   const AUTO_NAV_TTL_MS = 15000;
   let autoNavCache = null;
+  let activePlaybackOwnerNonce = null;
+  let playbackLocation = null;
+
+  function routeIdentity(url) {
+    try {
+      const parsed = new URL(url, location.href);
+      return `${parsed.origin}${parsed.pathname}`;
+    } catch {
+      return String(url || '');
+    }
+  }
+
+  function applyPlaybackContext(context, ownerNonce) {
+    setPlaybackContext(context);
+    activePlaybackOwnerNonce = ownerNonce;
+    playbackLocation = routeIdentity(location.href);
+  }
+
+  async function claimPlaybackSession(ownerNonce) {
+    try {
+      const claim = await claimPlaybackOwnership({ nonce: ownerNonce });
+      if (
+        !claim?.ok ||
+        typeof claim.nonce !== 'string' ||
+        claim.nonce.length < 8
+      ) {
+        throw new Error(claim?.reason || 'Playback claim failed');
+      }
+      applyPlaybackContext(claim.context, claim.nonce);
+      return claim;
+    } catch {
+      clearPlaybackContext();
+      return null;
+    }
+  }
+
+  async function transitionPlaybackSession(mode, clip, patch) {
+    const clipId = clip?.clipId ?? clip?.id;
+    const update = await updatePlaybackOwnership({
+      nonce: activePlaybackOwnerNonce,
+      mode,
+      clipId,
+      patch
+    });
+    if (!update?.ok) {
+      deactivatePlaybackContext();
+      return null;
+    }
+    applyPlaybackContext(update.context, activePlaybackOwnerNonce);
+    return update;
+  }
+
+  function deactivatePlaybackContext() {
+    const ownerNonce = activePlaybackOwnerNonce;
+    activePlaybackOwnerNonce = null;
+    playbackLocation = null;
+    clearPlaybackContext();
+    closeCommentPanel();
+    releasePlaybackOwnership(ownerNonce);
+    Mode.stop();
+  }
 
   function isAutoNavValid(autoNav) {
     if (!autoNav || typeof autoNav !== 'object') return false;
@@ -57,6 +134,14 @@ import {
   }
 
   async function beginAutoNavigation({ mode, nextUrl, nextOrder, nextId }) {
+    const prepared = await preparePlaybackNavigation(
+      activePlaybackOwnerNonce,
+      nextUrl
+    );
+    if (!prepared?.ok) {
+      deactivatePlaybackContext();
+      return false;
+    }
     const autoNav = {
       ts: Date.now(),
       mode,
@@ -68,27 +153,8 @@ import {
     autoNavCache = autoNav;
     markAutoNavigation(mode || 'auto');
 
-    const update = { [AUTO_NAV_STORAGE_KEY]: autoNav };
-
-    if (mode === 'playlist') {
-      update.playClipSystemKey = 0;
-      update.playlistSystemKey = 1;
-      update.playmode = 'playlist';
-    } else if (mode === 'clip') {
-      update.playClipSystemKey = 1;
-      update.playlistSystemKey = 0;
-      update.playmode = 'clip';
-    }
-
-    if (Number.isFinite(nextOrder)) {
-      update.currentClipOrder = nextOrder;
-    }
-
-    if (nextId !== undefined) {
-      update.currentClipId = nextId;
-    }
-
-    await chrome.storage.local.set(update);
+    await chrome.storage.local.set({ [AUTO_NAV_STORAGE_KEY]: autoNav });
+    return true;
   }
 
   // === Disney+ DOM ヘルパー（Shadow DOM 対応） ===
@@ -373,9 +439,7 @@ import {
       }
 
       const label = container.querySelector('.dext-button-label');
-      if (label) {
-        label.textContent = config.label;
-      }
+      setTextContentIfChanged(label, config.label);
       container.setAttribute('aria-label', config.label);
       if (config.controls) {
         const panelOpen = isCommentPanelOpen();
@@ -922,14 +986,13 @@ import {
   const Mode = (() => {
     let stopCurrent = null;
     let loopEnabled = false; // loop state
+    let currentSession = null;
 
-    async function loadClipData() {
-      const { playClipSystemKey, clip } = await chrome.storage.local.get([
-        'playClipSystemKey',
-        'clip'
-      ]);
-
-      if (playClipSystemKey !== 1 || !clip) {
+    function loadClipData(session = currentSession) {
+      const snapshot = session?.snapshot;
+      const clip = snapshot?.clip;
+      if (session?.context?.mode !== 'clip' || snapshot?.playClipSystemKey !== 1 || !clip) {
+        clearPlaybackContext();
         console.log('[Clip] No clip data or disabled');
         return null;
       }
@@ -937,29 +1000,26 @@ import {
       return {
         startTime: Number(clip.startTime ?? clip.starttime),
         endTime:   Number(clip.endTime   ?? clip.endtime),
-        title:     String(clip.title || '')
+        title:     String(clip.title || ''),
+        clipId:    clip.clipId ?? clip.id
       };
     }
 
-    async function startClipMode() {
-      const clipData = await loadClipData();
+    async function startClipMode(session) {
+      currentSession = session;
+      const clipData = loadClipData(session);
       if (!clipData) return;
-
-      await chrome.storage.local.set({ playClipSystemKey: 1, playlistSystemKey: 0, playmode: "clip" });
       stopCurrent = Playlist.play([clipData], { loop: loopEnabled });
     }
 
-async function startPlaylistMode() {
+async function startPlaylistMode(session) {
   stopActiveMode();
-
-  await chrome.storage.local.set({ playClipSystemKey: 0, playlistSystemKey: 1, playmode: "playlist" });
-
-  const { playQueue, currentClipOrder } = await chrome.storage.local.get([
-    'playQueue',
-    'currentClipOrder'
-  ]);
+  currentSession = session;
+  const { playQueue, currentClipOrder } = session?.snapshot || {};
+  if (session?.context?.mode !== 'playlist') return;
 
   if (!Array.isArray(playQueue) || playQueue.length === 0) {
+    clearPlaybackContext();
     console.warn('[Playlist] playQueue が存在しません');
     return;
   }
@@ -969,17 +1029,13 @@ async function startPlaylistMode() {
 
   const order = Number.isInteger(currentClipOrder) ? currentClipOrder : fallbackOrder;
   const currentClip = sortedQueue.find((clip) => clip.order === order) || sortedQueue[0];
+  let activeOrder = currentClip?.order ?? order;
 
   if (!currentClip) {
+    clearPlaybackContext();
     console.warn('[Playlist] 該当clipが見つかりません:', order);
     return;
   }
-
-  if (currentClipOrder !== currentClip.order) {
-    await chrome.storage.local.set({ currentClipOrder: currentClip.order });
-  }
-
-  await chrome.storage.local.set({ currentClipId: currentClip.id });
 
   const clipData = normalizeClipData(currentClip);
   if (!clipData) return;
@@ -993,15 +1049,7 @@ async function startPlaylistMode() {
   }
 
   function handlePlaylistEnd() {
-    chrome.storage.local.get(['playQueue', 'currentClipOrder'], (res) => {
-      const { playQueue, currentClipOrder } = res;
-      if (Array.isArray(playQueue)) {
-        playlistNextClip(playQueue, currentClipOrder ?? fallbackOrder);
-      } else {
-        console.warn('[Playlist] playQueue が無効。playlist終了');
-        chrome.storage.local.set({ playlistSystemKey: 0 });
-      }
-    });
+    void playlistNextClip(sortedQueue, activeOrder ?? fallbackOrder);
   }
 
   async function playlistNextClip(playQueue, currentOrder) {
@@ -1020,12 +1068,20 @@ async function startPlaylistMode() {
 
     const next = isLast ? sortedQueue[0] : sortedQueue[currentIndex + 1];
     const nextOrder = next.order ?? 0;
-    const nextId = next.id;
+    const nextId = next.clipId ?? next.id;
 
-    await chrome.storage.local.set({
+    const transitioned = await transitionPlaybackSession('playlist', next, {
+      playQueue: sortedQueue,
       currentClipOrder: nextOrder,
-      currentClipId: nextId
+      currentClipId: nextId,
+      nextClip: next,
+      playClipSystemKey: 0,
+      playlistSystemKey: 1,
+      playmode: 'playlist'
     });
+    if (!transitioned) return;
+    currentSession = transitioned;
+    activeOrder = nextOrder;
 
     const nextClipData = normalizeClipData(next);
     if (!nextClipData) {
@@ -1037,17 +1093,19 @@ async function startPlaylistMode() {
     const nextUrl = normalizeClipUrl(next);
 
     if (currentUrl && nextUrl && currentUrl !== nextUrl) {
-      const url = buildClipUrl(nextUrl, nextClipData.startTime);
+      const baseUrl = buildClipUrl(nextUrl, nextClipData.startTime);
+      if (!baseUrl) return;
+      const url = addPlaybackOwnerToUrl(baseUrl, activePlaybackOwnerNonce);
       console.log('[Playlist] 異なるURL → ページ遷移:', url);
-      if (!url) return;
 
       setTimeout(async () => {
-        await beginAutoNavigation({
+        const prepared = await beginAutoNavigation({
           mode: 'playlist',
           nextUrl: url,
           nextOrder,
           nextId
         });
+        if (!prepared) return;
         window.location.href = url;
       }, 150);
       return;
@@ -1058,73 +1116,18 @@ async function startPlaylistMode() {
 }
 
 
-    function resolvePlayMode(playmode, playClipSystemKey, playlistSystemKey) {
-      if (playmode === 'playlist' || playmode === 'clip') {
-        return playmode;
-      }
-
-      if (playClipSystemKey === 1 && playlistSystemKey === 1) {
-        return 'clip';
-      }
-
-      if (playClipSystemKey === 1) {
-        return 'clip';
-      }
-
-      if (playlistSystemKey === 1) {
-        return 'playlist';
-      }
-
-      return null;
-    }
-
     async function startPreferredMode() {
       const autoNav = await loadAutoNav();
-      if (autoNav?.mode === 'playlist') {
-        console.log('[AutoNav] Restore playlist:', autoNav);
-        await chrome.storage.local.set({ playClipSystemKey: 0, playlistSystemKey: 1, playmode: 'playlist' });
-        await startPlaylistMode();
-        await clearAutoNavState();
-        return;
+      const ownerNonce = getTabPlaybackOwnerNonce();
+      const session = await claimPlaybackSession(ownerNonce);
+      if (autoNav) await clearAutoNavState();
+      if (!session) return;
+      currentSession = session;
+      if (session.context.mode === 'playlist') {
+        await startPlaylistMode(session);
+      } else if (session.context.mode === 'clip') {
+        await startClipMode(session);
       }
-
-      if (autoNav?.mode === 'clip') {
-        console.log('[AutoNav] Restore clip:', autoNav);
-        await chrome.storage.local.set({ playClipSystemKey: 1, playlistSystemKey: 0, playmode: 'clip' });
-        await startClipMode();
-        await clearAutoNavState();
-        return;
-      }
-
-      if (autoNav) {
-        console.warn('[AutoNav] Unknown mode, clearing:', autoNav);
-        await clearAutoNavState();
-      }
-
-      const { playClipSystemKey, playlistSystemKey, playmode } = await chrome.storage.local.get([
-        'playClipSystemKey',
-        'playlistSystemKey',
-        'playmode'
-      ]);
-
-      const resolvedMode = resolvePlayMode(playmode, playClipSystemKey, playlistSystemKey);
-
-      if (resolvedMode === 'playlist') {
-        await chrome.storage.local.set({ playClipSystemKey: 0, playlistSystemKey: 1, playmode: 'playlist' });
-        await startPlaylistMode();
-        return;
-      }
-
-      if (resolvedMode === 'clip') {
-        if (playClipSystemKey === 1 && playlistSystemKey === 1 && !playmode) {
-          console.warn("⚠️ 両モードがON。Clipを優先して矯正します。");
-        }
-
-        await chrome.storage.local.set({ playClipSystemKey: 1, playlistSystemKey: 0, playmode: 'clip' });
-        await startClipMode();
-        return;
-      }
-
     }
 
     function stopActiveMode() {
@@ -1139,7 +1142,7 @@ async function startPlaylistMode() {
       if (loopEnabled) {
         console.log('[Loop] ON');
         stopActiveMode();
-        const clipData = await loadClipData();
+        const clipData = loadClipData();
         if (!clipData) {
           loopEnabled = false;
           return;
@@ -1152,15 +1155,21 @@ async function startPlaylistMode() {
     }
 
     function bootstrap() {
-      window.addEventListener('load', () => {
+      const start = () => {
         stopActiveMode();
-        startPreferredMode();
-      });
+        void startPreferredMode();
+      };
+      if (document.readyState === 'complete') {
+        start();
+      } else {
+        window.addEventListener('load', start, { once: true });
+      }
     }
 
     return {
       bootstrap,
-      toggleLoop
+      toggleLoop,
+      stop: stopActiveMode
     };
   })();
 
@@ -1172,19 +1181,22 @@ async function startPlaylistMode() {
 
   Mode.bootstrap();
 
-  window.addEventListener('locationchange', () => UI.scheduleInjection());
+  window.addEventListener('locationchange', () => {
+    UI.scheduleInjection();
+    const nextLocation = routeIdentity(location.href);
+    if (
+      activePlaybackOwnerNonce &&
+      nextLocation !== playbackLocation &&
+      !isAutoNavigation() &&
+      !isAutoNavActive()
+    ) {
+      deactivatePlaybackContext();
+    }
+  });
   window.addEventListener('load', () => UI.scheduleInjection(), { once: true });
 
   window.addEventListener('beforeunload', () => {
-    if (isAutoNavigation() || isAutoNavActive()) {
-      return;
-    }
-
-    chrome.storage.local.set({
-      playClipSystemKey: 0,
-      playlistSystemKey: 0,
-      currentClipOrder: 0,
-      playmode: null
-    });
+    clearPlaybackContext();
+    closeCommentPanel();
   });
 })();

--- a/src/content/content_disney.js
+++ b/src/content/content_disney.js
@@ -569,6 +569,11 @@ import {
       };
       // blur / 非表示中は play・pause など操作以外のイベントで復帰させない。
       const markActive = () => (pageActive ? activate() : goIdle());
+      // 表示中のプレイヤー上にカーソルが戻った時点で、クリックを待たずに復帰する。
+      const handleUserActivity = () => {
+        pageActive = !document.hidden;
+        markActive();
+      };
       const handleBlur = () => {
         pageActive = false;
         goIdle();
@@ -586,8 +591,8 @@ import {
         }
       };
 
-      for (const type of ['pointermove', 'pointerdown', 'keydown']) {
-        document.addEventListener(type, markActive, { passive: true });
+      for (const type of ['pointerover', 'pointermove', 'pointerdown', 'keydown']) {
+        document.addEventListener(type, handleUserActivity, { passive: true });
       }
       // ウィンドウが非アクティブになったら即座に隠す / 戻ったら復帰。
       window.addEventListener('blur', handleBlur);

--- a/src/content/content_netflix.js
+++ b/src/content/content_netflix.js
@@ -7,6 +7,7 @@ import {
 import { getApiEndpoint } from './../api.js';
 import {
   clearAutoNavigation,
+  closeMemoSidebar,
   detectService,
   handleClipTransition,
   isAutoNavigation,
@@ -14,15 +15,34 @@ import {
   markExtUi,
   MEMO_SIDEBAR_ID,
   openMemoSidebar,
+  requestCloseCommentPanel,
   sendData,
   startTabVisibilityToggle,
   requestSeek
 } from './common.js';
 import {
   COMMENT_PANEL_ID,
+  COMMENT_PANEL_OPEN_STATE_EVENT,
+  closeCommentPanel,
   isCommentPanelOpen,
   toggleCommentPanel
 } from './commentPanel.js';
+import {
+  clearPlaybackContext,
+  ensurePlaybackContext,
+  setPlaybackContext
+} from './playbackContext.js';
+import { commitSelectedClip } from './netflixClipSelection.js';
+import {
+  addPlaybackOwnerToUrl,
+  beginPlaybackHandoff,
+  claimPlaybackOwnership,
+  createPlaybackOwnerNonce,
+  getTabPlaybackOwnerNonce,
+  preparePlaybackNavigation,
+  releasePlaybackOwnership,
+  updatePlaybackOwnership
+} from './playbackOwnership.js';
 import { setCookie } from '../util/cookies.js';
 import { buildServiceUrl } from '../util/services.js';
 
@@ -44,25 +64,7 @@ function initializeNetflixPlayback() {
     return;
   }
   netflixPlaybackInitialized = true;
-
-  if (!sessionStorage.getItem("nfClipInitialized")) {
-    chrome.storage.local.get(["playClipSystemKey", "playlistSystemKey", "playmode"], (res) => {
-      const clipModeActive = res.playClipSystemKey === 1;
-      const playlistActive = res.playlistSystemKey === 1;
-      const playmodeActive = res.playmode === "clip" || res.playmode === "playlist";
-
-      if (!clipModeActive && !playlistActive && !playmodeActive) {
-        chrome.storage.local.set({
-          playClipSystemKey: 0,
-          playlistSystemKey: 0,
-          currentClipOrder: 0,
-          playmode: null,
-          clip: null
-        });
-      }
-    });
-    sessionStorage.setItem("nfClipInitialized", "true");
-  }
+  ensurePlaybackContext();
 
   // ---------------------------------------------------------------------------
   // グローバル変数
@@ -89,6 +91,84 @@ function initializeNetflixPlayback() {
   let isLooping = false;
   let togglekey = false;
   let uiWarmerInterval = null;
+  let activePlaybackOwnerNonce = null;
+  let playbackLocation = null;
+  let stopClipEndMonitor = null;
+  let activePlaylistQueue = null;
+  let activePlaylistOrder = null;
+  let playbackGeneration = 0;
+  let removePendingMetadataListener = null;
+
+  function applyPlaybackContext(context, ownerNonce) {
+    setPlaybackContext(context);
+    activePlaybackOwnerNonce = ownerNonce;
+    playbackLocation = routeIdentity(location.href);
+    playbackGeneration += 1;
+  }
+
+  async function claimPlaybackSession(ownerNonce) {
+    try {
+      const claim = await claimPlaybackOwnership({ nonce: ownerNonce });
+      if (
+        !claim?.ok ||
+        typeof claim.nonce !== 'string' ||
+        claim.nonce.length < 8
+      ) {
+        throw new Error(claim?.reason || 'Playback claim failed');
+      }
+      applyPlaybackContext(claim.context, claim.nonce);
+      return claim;
+    } catch {
+      clearPlaybackContext();
+      return null;
+    }
+  }
+
+  async function transitionPlaybackSession(mode, clip, patch) {
+    const clipId = clip?.clipId ?? clip?.id;
+    const update = await updatePlaybackOwnership({
+      nonce: activePlaybackOwnerNonce,
+      mode,
+      clipId,
+      patch
+    });
+    if (!update?.ok) {
+      deactivatePlaybackContext();
+      return null;
+    }
+    applyPlaybackContext(update.context, activePlaybackOwnerNonce);
+    return update;
+  }
+
+  function deactivatePlaybackContext() {
+    const ownerNonce = activePlaybackOwnerNonce;
+    activePlaybackOwnerNonce = null;
+    playbackLocation = null;
+    playbackGeneration += 1;
+    clearPlaybackContext();
+    closeCommentPanel();
+    releasePlaybackOwnership(ownerNonce);
+
+    stopClipEndMonitor?.();
+    stopClipEndMonitor = null;
+    removePendingMetadataListener?.();
+    removePendingMetadataListener = null;
+    if (countdownIntervalId !== null) {
+      clearInterval(countdownIntervalId);
+      countdownIntervalId = null;
+    }
+    stopUIWarmer();
+    clipData = null;
+    activePlaylistQueue = null;
+    activePlaylistOrder = null;
+  }
+
+  function handlePlaybackRouteChange(nextUrl) {
+    const resolvedUrl = routeIdentity(nextUrl || location.href);
+    if (!activePlaybackOwnerNonce || resolvedUrl === playbackLocation) return;
+    if (isAutoNavigation()) return;
+    deactivatePlaybackContext();
+  }
 
   clearAutoNavigation();
   bootstrapRecordControls();
@@ -218,6 +298,7 @@ function initializeNetflixPlayback() {
 
       window.addEventListener("historyChange", (e) => {
         resetRecordState();
+        handlePlaybackRouteChange(e.detail?.url);
         chrome.runtime.sendMessage({ type: "HISTORY_CHANGE", data: e.detail });
       });
 
@@ -292,14 +373,28 @@ function initializeNetflixPlayback() {
         document.querySelector('div[data-uia="player"]') ||
         document.querySelector(".watch-video--player-view") ||
         document.body;
-      toggleCommentPanel({
+      const open = toggleCommentPanel({
         mountEl,
         triggerEl: btn,
         onOpenChange: updateOpenState
       });
+      updateOpenState(open);
     });
     return { btn, svg: svgIcon };
   }
+
+  function updateCurrentCommentButton(open) {
+    const button = document.getElementById(COMMENT_BUTTON_ID);
+    if (!button) return;
+    button.setAttribute("aria-expanded", String(open));
+    const icon = button.querySelector("svg");
+    if (icon) icon.style.color = open ? COLOR_LOOPING : COLOR_DEFAULT;
+  }
+
+  const handleCommentPanelOpenState = (event) => {
+    updateCurrentCommentButton(Boolean(event?.detail?.open));
+  };
+  window.addEventListener(COMMENT_PANEL_OPEN_STATE_EVENT, handleCommentPanelOpenState);
 
   const uiObserver = new MutationObserver(() => {
     const controls    = document.querySelector(SELECTOR_STANDARD);
@@ -363,24 +458,35 @@ function initializeNetflixPlayback() {
     }
   });
   uiObserver.observe(document.body, { childList: true, subtree: true });
-  window.addEventListener("beforeunload", () => uiObserver.disconnect());
+  window.addEventListener("beforeunload", () => {
+    uiObserver.disconnect();
+    window.removeEventListener(
+      COMMENT_PANEL_OPEN_STATE_EVENT,
+      handleCommentPanelOpenState
+    );
+  });
 
   // ---------------------------------------------------------------------------
   // サイドバー
   // ---------------------------------------------------------------------------
   function toggleSidebar() {
     const sb = document.getElementById(SIDEBAR_ID);
-    sb ? closeSidebar() : openSidebar();
+    sb?.dataset?.sidebarType === "clip-list" ? closeSidebar() : openSidebar();
   }
 
   function openSidebar() {
     const player = document.querySelector(".watch-video--player-view");
     if (!player) return;
+    closeMemoSidebar();
+    requestCloseCommentPanel();
+    const originalPlayerWidth = player.style.width;
     player.style.transition = "width .3s";
     player.style.width = `calc(100% - ${SIDEBAR_PCT}%)`;
 
     const sb = document.createElement("div");
     sb.id = SIDEBAR_ID;
+    sb.dataset.sidebarType = "clip-list";
+    sb.dataset.originalPlayerWidth = originalPlayerWidth;
     sb.style.cssText = `
       position:fixed;top:0;right:0;width:${SIDEBAR_PCT}%;
       height:100%;background:rgba(0,0,0,.9);color:white;
@@ -409,9 +515,7 @@ function initializeNetflixPlayback() {
   }
 
   function closeSidebar() {
-    const player = document.querySelector(".watch-video--player-view");
-    if (player) player.style.width = "100%";
-    document.getElementById(SIDEBAR_ID)?.remove();
+    closeMemoSidebar();
   }
 
   /**
@@ -474,9 +578,27 @@ function initializeNetflixPlayback() {
       const res = await fetch(getApiEndpoint(`fetchClip?id=${encodeURIComponent(clipId)}`));
       if (!res.ok) throw new Error(`HTTP error! status: ${res.status}`);
       const data = await res.json();
-      setClipDataOnCookies(data);
-      redirectToClip(data);
-      chrome.storage.local.set({ playClipSystemKey: 1, playlistSystemKey: 0 });
+      const ownerNonce = createPlaybackOwnerNonce();
+      await commitSelectedClip({
+        data,
+        requestedClipId: clipId,
+        ownerNonce,
+        storage: {
+          async set(snapshot) {
+            const handoff = await beginPlaybackHandoff({
+              nonce: ownerNonce,
+              mode: 'clip',
+              clipId: snapshot.currentClipId,
+              snapshot
+            });
+            if (!handoff?.ok) {
+              throw new Error('Playback handoff registration failed');
+            }
+          }
+        },
+        setCookies: setClipDataOnCookies,
+        openClip: (selectedClip) => redirectToClip(selectedClip, ownerNonce)
+      });
     } catch (err) {
       console.error("クリップ選択処理でエラー:", err);
     }
@@ -500,7 +622,7 @@ function initializeNetflixPlayback() {
     }
   }
 
-  function redirectToClip({ url, service, startTime }) {
+  function redirectToClip({ url, service, startTime }, ownerNonce) {
     if (!url || !service) {
       alert("URL または サービス情報が不正です");
       return;
@@ -510,29 +632,27 @@ function initializeNetflixPlayback() {
       alert(`未対応のサービス: ${service}`);
       return;
     }
-    window.open(finalUrl, "_blank");
+    window.open(addPlaybackOwnerToUrl(finalUrl, ownerNonce), "_blank");
   }
 
   // ---------------------------------------------------------------------------
   // Clip再生モード
   // ---------------------------------------------------------------------------
-  function loadClipFromStorage() {
-    return new Promise((resolve, reject) => {
-      chrome.storage.local.get(['playClipSystemKey', 'clip'], res => {
-        if (chrome.runtime.lastError) return reject(chrome.runtime.lastError);
-        if (res.playClipSystemKey === 1 && res.clip) {
-          clipData = {
-            startTime: Number(res.clip.startTime ?? res.clip.starttime),
-            endTime:   Number(res.clip.endTime   ?? res.clip.endtime),
-            title:     res.clip.title
-          };
-          console.info('[Clip] loaded:', clipData);
-          resolve();
-        } else {
-          resolve();
-        }
-      });
-    });
+  function loadClipFromSession(session) {
+    const snapshot = session?.snapshot;
+    if (session?.context?.mode !== 'clip' || snapshot?.playClipSystemKey !== 1 || !snapshot.clip) {
+      clipData = null;
+      clearPlaybackContext();
+      return false;
+    }
+    clipData = {
+      startTime: Number(snapshot.clip.startTime ?? snapshot.clip.starttime),
+      endTime: Number(snapshot.clip.endTime ?? snapshot.clip.endtime),
+      title: snapshot.clip.title,
+      clipId: snapshot.clip.clipId ?? snapshot.clip.id
+    };
+    console.info('[Clip] loaded:', clipData);
+    return true;
   }
 
   function waitForVideoElement() {
@@ -547,10 +667,10 @@ function initializeNetflixPlayback() {
     });
   }
 
-  async function init() {
-    chrome.storage.local.set({ playClipSystemKey: 1, playlistSystemKey: 0, playmode: "clip" });
+  async function init(session) {
     try {
-      await loadClipFromStorage();
+      const loaded = loadClipFromSession(session);
+      if (!loaded) return;
       videoPlayer = await waitForVideoElement();
       setupPlayer("clip");
     } catch (err) {
@@ -561,20 +681,24 @@ function initializeNetflixPlayback() {
   // ---------------------------------------------------------------------------
   // Playlist再生モード
   // ---------------------------------------------------------------------------
-  async function startPlaylistMode() {
-    chrome.storage.local.set({ playClipSystemKey: 0, playlistSystemKey: 1, playmode: "playlist" });
-    chrome.storage.local.get(["playQueue", "currentClipOrder"], async ({ playQueue, currentClipOrder }) => {
+  async function startPlaylistMode(session) {
+      let { playQueue, currentClipOrder } = session?.snapshot || {};
+      if (session?.context?.mode !== 'playlist') return;
       if (!Array.isArray(playQueue) || playQueue.length === 0) {
+        clearPlaybackContext();
         console.warn("[Playlist] playQueue が存在しません");
         return;
       }
-      playQueue.sort((a, b) => a.order - b.order);
+      playQueue = [...playQueue].sort((a, b) => a.order - b.order);
       const order = Number.isInteger(currentClipOrder) ? currentClipOrder : 0;
       const currentClip = playQueue.find(c => c.order === order);
       if (!currentClip) {
+        clearPlaybackContext();
         console.warn("[Playlist] 該当clipが見つかりません:", order);
         return;
       }
+      activePlaylistQueue = playQueue;
+      activePlaylistOrder = currentClip.order;
       clipData = {
         startTime: Number(currentClip.startTime ?? currentClip.starttime),
         endTime:   Number(currentClip.endTime   ?? currentClip.endtime),
@@ -582,7 +706,6 @@ function initializeNetflixPlayback() {
       };
       videoPlayer = await waitForVideoElement();
       setupPlayer("playlist");
-    });
   }
 
   async function playlistNextClip(playQueue, currentOrder) {
@@ -597,9 +720,18 @@ function initializeNetflixPlayback() {
     const isLast = currentIndex === sortedQueue.length - 1;
     const next = isLast ? sortedQueue[0] : sortedQueue[currentIndex + 1];
 
-    await new Promise((resolve) => {
-      chrome.storage.local.set({ currentClipOrder: next.order, currentClipId: next.id }, resolve);
+    const transitioned = await transitionPlaybackSession('playlist', next, {
+      playQueue: sortedQueue,
+      currentClipOrder: next.order,
+      currentClipId: next.clipId ?? next.id,
+      nextClip: next,
+      playClipSystemKey: 0,
+      playlistSystemKey: 1,
+      playmode: 'playlist'
     });
+    if (!transitioned) return;
+    activePlaylistQueue = sortedQueue;
+    activePlaylistOrder = next.order;
 
     clipData = {
       startTime: Number(next.startTime ?? next.starttime),
@@ -612,10 +744,12 @@ function initializeNetflixPlayback() {
       nextUrl: next.url,
 
       onSameUrl: async () => {
+        const transitionGeneration = playbackGeneration;
         startUIWarmer();
         const targetTime = Math.floor(next.startTime);
 
         for (;;) {
+          if (transitionGeneration !== playbackGeneration) return;
           try {
             await requestSeek({ service: 'Netflix', seconds: targetTime });
           } catch (err) {
@@ -623,6 +757,7 @@ function initializeNetflixPlayback() {
           }
 
           await new Promise(r => setTimeout(r, 300));
+          if (transitionGeneration !== playbackGeneration) return;
 
           const currentSec = Math.floor(videoPlayer?.currentTime ?? 0);
           if (Math.abs(currentSec - targetTime) <= 1) {
@@ -631,13 +766,25 @@ function initializeNetflixPlayback() {
           }
         }
 
+        if (transitionGeneration !== playbackGeneration || !clipData) return;
         monitorClipEnd(clipData.endTime, clipData.startTime, "playlist");
         startCountdownLogger(clipData.endTime);
       },
 
-      onDifferentUrl: () => {
+      onDifferentUrl: async () => {
         markAutoNavigation("playlist");
-        const url = `https://www.netflix.com${next.url}?t=${Math.floor(next.startTime)}`;
+        const url = addPlaybackOwnerToUrl(
+          `https://www.netflix.com${next.url}?t=${Math.floor(next.startTime)}`,
+          activePlaybackOwnerNonce
+        );
+        const prepared = await preparePlaybackNavigation(
+          activePlaybackOwnerNonce,
+          url
+        );
+        if (!prepared?.ok) {
+          deactivatePlaybackContext();
+          return;
+        }
         setTimeout(() => { window.location.href = url; }, 150);
       }
     });
@@ -655,7 +802,10 @@ function initializeNetflixPlayback() {
       return;
     }
 
+    const setupGeneration = playbackGeneration;
     const onReady = () => {
+      removePendingMetadataListener = null;
+      if (setupGeneration !== playbackGeneration || !clipData) return;
       monitorClipEnd(end, start, mode);
       startCountdownLogger(end);
     };
@@ -664,31 +814,41 @@ function initializeNetflixPlayback() {
       onReady();
     } else {
       videoPlayer.addEventListener('loadedmetadata', onReady, { once: true });
+      removePendingMetadataListener?.();
+      removePendingMetadataListener = () =>
+        videoPlayer?.removeEventListener('loadedmetadata', onReady);
     }
 
     videoPlayer.addEventListener('error', e => console.error('[Video] error:', e));
   }
 
   function monitorClipEnd(end, start, mode /* "clip" | "playlist" */) {
+    stopClipEndMonitor?.();
+    const monitoredPlayer = videoPlayer;
+    let stopped = false;
+    const stopMonitor = () => {
+      if (stopped) return;
+      stopped = true;
+      monitoredPlayer?.removeEventListener("timeupdate", onTimeUpdate);
+      if (stopClipEndMonitor === stopMonitor) stopClipEndMonitor = null;
+    };
+    stopClipEndMonitor = stopMonitor;
+
     function onTimeUpdate() {
-      if (videoPlayer.currentTime + EPSILON >= end) {
+      if (monitoredPlayer.currentTime + EPSILON >= end) {
         console.info("[Clip] Reached end:", clipData?.title || "unknown");
-        videoPlayer.removeEventListener("timeupdate", onTimeUpdate);
+        stopMonitor();
         clearInterval(countdownIntervalId);
 
         if (mode === "playlist") {
-          chrome.storage.local.get(
-            ["playQueue", "currentClipOrder"],
-            (res) => {
-              const { playQueue, currentClipOrder } = res;
-              if (Array.isArray(playQueue)) {
-                playlistNextClip(playQueue, currentClipOrder ?? 0);
-              } else {
-                console.warn("[Playlist] playQueue が無効。playlist終了");
-                chrome.storage.local.set({ playlistSystemKey: 0 });
-              }
-            }
-          );
+          if (Array.isArray(activePlaylistQueue)) {
+            void playlistNextClip(
+              activePlaylistQueue,
+              activePlaylistOrder ?? 0
+            );
+          } else {
+            console.warn("[Playlist] playQueue が無効。playlist終了");
+          }
         } else {
           try {
             requestSeek({ service: 'Netflix', seconds: start, videoElement: videoPlayer });
@@ -700,7 +860,7 @@ function initializeNetflixPlayback() {
         }
       }
     }
-    videoPlayer.addEventListener("timeupdate", onTimeUpdate);
+    monitoredPlayer.addEventListener("timeupdate", onTimeUpdate);
   }
 
   function startCountdownLogger(end) {
@@ -750,49 +910,33 @@ function initializeNetflixPlayback() {
   // ページロード時のモード起動
   // ---------------------------------------------------------------------------
   onWindowLoad(async () => {
-    chrome.storage.local.get(["playClipSystemKey", "playlistSystemKey", "playmode"], async ({ playClipSystemKey, playlistSystemKey, playmode }) => {
-      if (playmode === "playlist") {
-        await chrome.storage.local.set({ playClipSystemKey: 0, playlistSystemKey: 1 });
-        await startPlaylistMode();
-        return;
-      }
-
-      if (playmode === "clip") {
-        await chrome.storage.local.set({ playClipSystemKey: 1, playlistSystemKey: 0 });
-        await init();
-        return;
-      }
-
-      if (playClipSystemKey === 1 && playlistSystemKey === 1) {
-        console.warn("[Clip] 両モードがON。Clipを優先して矯正します。");
-        await chrome.storage.local.set({ playClipSystemKey: 1, playlistSystemKey: 0 });
-        await init();
-        return;
-      }
-
-      if (playClipSystemKey === 1) {
-        await init();
-      } else if (playlistSystemKey === 1) {
-        await startPlaylistMode();
-      }
-    });
+    const ownerNonce = getTabPlaybackOwnerNonce();
+    const session = await claimPlaybackSession(ownerNonce);
+    if (!session) return;
+    if (session.context.mode === 'playlist') {
+      await startPlaylistMode(session);
+    } else if (session.context.mode === 'clip') {
+      await init(session);
+    }
   });
 
   // ---------------------------------------------------------------------------
   // 離脱処理
   // ---------------------------------------------------------------------------
   window.addEventListener("beforeunload", () => {
-    if (isAutoNavigation()) {
-      return;
-    }
-
-    chrome.storage.local.set({
-      playClipSystemKey: 0,
-      playlistSystemKey: 0,
-      currentClipOrder: 0,
-      playmode: null
-    });
+    playbackGeneration += 1;
+    clearPlaybackContext();
+    closeCommentPanel();
   });
 }
 
 initializeNetflixPlayback();
+
+function routeIdentity(url) {
+  try {
+    const parsed = new URL(url, location.href);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    return String(url || '');
+  }
+}

--- a/src/content/content_netflix.js
+++ b/src/content/content_netflix.js
@@ -16,6 +16,11 @@ import {
   sendData,
   requestSeek
 } from './common.js';
+import {
+  COMMENT_PANEL_ID,
+  isCommentPanelOpen,
+  toggleCommentPanel
+} from './commentPanel.js';
 import { setCookie } from '../util/cookies.js';
 import { buildServiceUrl } from '../util/services.js';
 
@@ -68,6 +73,7 @@ function initializeNetflixPlayback() {
 
   const BUTTON_ID = "nf-loop-toggle-btn";
   const NEXT_BUTTON_ID = "nf-next-clip-btn";
+  const COMMENT_BUTTON_ID = "nf-comment-toggle-btn";
   const SIDEBAR_ID = MEMO_SIDEBAR_ID;
   const SIDEBAR_PCT = 30;
 
@@ -261,6 +267,36 @@ function initializeNetflixPlayback() {
     return { btn, svg: svgIcon };
   }
 
+  function createCommentButton() {
+    const svgIcon = createIcon("comment");
+    const btn = document.createElement("button");
+    btn.id = COMMENT_BUTTON_ID;
+    btn.setAttribute("aria-label", "コメント表示");
+    btn.setAttribute("aria-haspopup", "dialog");
+    btn.setAttribute("aria-controls", COMMENT_PANEL_ID);
+    btn.appendChild(svgIcon);
+    btn.style.cursor = "pointer";
+
+    const updateOpenState = (open) => {
+      btn.setAttribute("aria-expanded", String(open));
+      svgIcon.style.color = open ? COLOR_LOOPING : COLOR_DEFAULT;
+    };
+    updateOpenState(isCommentPanelOpen());
+
+    btn.addEventListener("click", () => {
+      const mountEl =
+        document.querySelector('div[data-uia="player"]') ||
+        document.querySelector(".watch-video--player-view") ||
+        document.body;
+      toggleCommentPanel({
+        mountEl,
+        triggerEl: btn,
+        onOpenChange: updateOpenState
+      });
+    });
+    return { btn, svg: svgIcon };
+  }
+
   const uiObserver = new MutationObserver(() => {
     const controls    = document.querySelector(SELECTOR_STANDARD);
     const episodeBtn  = document.querySelector(SELECTOR_EPISODE);
@@ -268,18 +304,28 @@ function initializeNetflixPlayback() {
 
     const loopBtnExists = document.getElementById(BUTTON_ID);
     const nextBtnExists = document.getElementById(NEXT_BUTTON_ID);
+    const commentBtnExists = document.getElementById(COMMENT_BUTTON_ID);
 
-    if (controls && !loopBtnExists && !nextBtnExists && (episodeBtn || subtitleBtn)) {
+    if (
+      controls &&
+      !loopBtnExists &&
+      !nextBtnExists &&
+      !commentBtnExists &&
+      (episodeBtn || subtitleBtn)
+    ) {
       const anchorBtn = episodeBtn || subtitleBtn;
 
       const { btn: loopButton, svg: loopSvg } = createLoopButton();
       const { btn: playNextButton, svg: playSvg } = createPlayNextClipButton();
+      const { btn: commentButton, svg: commentSvg } = createCommentButton();
 
       loopButton.className     = anchorBtn.className;
       playNextButton.className = anchorBtn.className;
+      commentButton.className  = anchorBtn.className;
 
       loopSvg.style.color = isLooping ? COLOR_LOOPING : COLOR_DEFAULT;
       playSvg.style.color = togglekey ? COLOR_LOOPING : COLOR_DEFAULT;
+      commentSvg.style.color = isCommentPanelOpen() ? COLOR_LOOPING : COLOR_DEFAULT;
 
       const wrapper = document.createElement("div");
       wrapper.className = anchorBtn.parentNode.className;
@@ -294,6 +340,7 @@ function initializeNetflixPlayback() {
       wrapper.appendChild(loopButton);
       wrapper.appendChild(separator);
       wrapper.appendChild(playNextButton);
+      wrapper.appendChild(commentButton);
 
       anchorBtn.parentNode.after(wrapper);
 
@@ -305,6 +352,7 @@ function initializeNetflixPlayback() {
     if (!document.querySelector(SELECTOR_FWD10)) {
       document.getElementById(BUTTON_ID)?.remove();
       document.getElementById(NEXT_BUTTON_ID)?.remove();
+      document.getElementById(COMMENT_BUTTON_ID)?.remove();
     }
   });
   uiObserver.observe(document.body, { childList: true, subtree: true });

--- a/src/content/content_netflix.js
+++ b/src/content/content_netflix.js
@@ -45,6 +45,7 @@ import {
 } from './playbackOwnership.js';
 import { setCookie } from '../util/cookies.js';
 import { buildServiceUrl } from '../util/services.js';
+import { normalizePlaybackRoute } from '../shared/playbackBridgeValidation.js';
 
 /** @typedef {import('../types/clip').ClipDataProps} ClipDataProps */
 /** @typedef {import('../types/clip').ClipListProps} ClipListProps */
@@ -601,6 +602,12 @@ function initializeNetflixPlayback() {
       });
     } catch (err) {
       console.error("クリップ選択処理でエラー:", err);
+      const unsupported = err?.message?.includes('invalid_service');
+      window.alert(
+        unsupported
+          ? 'このクリップの配信サービスには対応していません。'
+          : 'クリップを開けませんでした。時間をおいて再度お試しください。'
+      );
     }
   }
 
@@ -773,10 +780,17 @@ function initializeNetflixPlayback() {
 
       onDifferentUrl: async () => {
         markAutoNavigation("playlist");
-        const url = addPlaybackOwnerToUrl(
-          `https://www.netflix.com${next.url}?t=${Math.floor(next.startTime)}`,
-          activePlaybackOwnerNonce
+        const targetUrl = buildServiceUrl(
+          next.service,
+          next.url,
+          Math.floor(next.startTime),
+          't'
         );
+        if (!targetUrl) {
+          deactivatePlaybackContext();
+          return;
+        }
+        const url = addPlaybackOwnerToUrl(targetUrl, activePlaybackOwnerNonce);
         const prepared = await preparePlaybackNavigation(
           activePlaybackOwnerNonce,
           url
@@ -813,10 +827,12 @@ function initializeNetflixPlayback() {
     if (videoPlayer.readyState >= 1) {
       onReady();
     } else {
-      videoPlayer.addEventListener('loadedmetadata', onReady, { once: true });
       removePendingMetadataListener?.();
-      removePendingMetadataListener = () =>
-        videoPlayer?.removeEventListener('loadedmetadata', onReady);
+      const metadataPlayer = videoPlayer;
+      const removeMetadataListener = () =>
+        metadataPlayer.removeEventListener('loadedmetadata', onReady);
+      removePendingMetadataListener = removeMetadataListener;
+      metadataPlayer.addEventListener('loadedmetadata', onReady, { once: true });
     }
 
     videoPlayer.addEventListener('error', e => console.error('[Video] error:', e));
@@ -852,8 +868,8 @@ function initializeNetflixPlayback() {
         } else {
           try {
             requestSeek({ service: 'Netflix', seconds: start, videoElement: videoPlayer });
-          } catch(e) {
-            try { videoPlayer.currentTime = start; videoPlayer.play?.(); } catch(_) {}
+          } catch {
+            try { videoPlayer.currentTime = start; videoPlayer.play?.(); } catch {}
           }
           monitorClipEnd(end, start, mode);
           startCountdownLogger(end);
@@ -933,10 +949,5 @@ function initializeNetflixPlayback() {
 initializeNetflixPlayback();
 
 function routeIdentity(url) {
-  try {
-    const parsed = new URL(url, location.href);
-    return `${parsed.origin}${parsed.pathname}`;
-  } catch {
-    return String(url || '');
-  }
+  return normalizePlaybackRoute(url, location.href) || String(url || '');
 }

--- a/src/content/domUpdates.js
+++ b/src/content/domUpdates.js
@@ -1,0 +1,5 @@
+export function setTextContentIfChanged(element, nextText) {
+  if (!element || element.textContent === nextText) return false;
+  element.textContent = nextText;
+  return true;
+}

--- a/src/content/extensionSync.js
+++ b/src/content/extensionSync.js
@@ -2,9 +2,7 @@ import {
   STORAGE_KEYS,
   storageGet,
   storageSet,
-  storageRemove,
   normalizePendingClips,
-  clearExtensionAuthState,
 } from './../shared/storage.js';
 
 // このモジュールは content script 専用。サイト API への fetch(同期・トークンリフレッシュ)は
@@ -97,34 +95,13 @@ export async function getExtensionConnectionState() {
 }
 
 export async function saveExtensionAuthToken(extensionInstanceId, extensionAuthToken, expiresAt) {
-  const currentInstanceId = await getOrCreateExtensionInstanceId();
-  if (extensionInstanceId !== currentInstanceId) {
-    console.warn('[extension-sync] ignored auth token for mismatched extensionInstanceId', {
-      expected: currentInstanceId,
-      received: extensionInstanceId,
-    });
-    return false;
-  }
-
-  if (!extensionAuthToken || typeof extensionAuthToken !== 'string') {
-    console.warn('[extension-sync] ignored empty auth token');
-    return false;
-  }
-
-  // expiresAt はサーバ発行の ISO 文字列。欠落時(旧サイト)でもトークン自体は保存し、
-  // background のリフレッシュが期限付きトークンへ移行させる。
-  const expiresAtMs = Date.parse(expiresAt || '');
-  await storageSet({
-    [STORAGE_KEYS.extensionAuthToken]: extensionAuthToken,
-    [STORAGE_KEYS.extensionTokenExpiresAt]: Number.isFinite(expiresAtMs)
-      ? new Date(expiresAtMs).toISOString()
-      : null,
-    [STORAGE_KEYS.extensionLinked]: true,
+  const result = await sendRuntimeMessage({
+    type: 'SAVE_EXTENSION_AUTH_TOKEN',
+    extensionInstanceId,
+    extensionAuthToken,
+    expiresAt,
   });
-  // 新しいトークンを受けた時点で旧トークン時代の失敗回数は無効。抑制を持ち越すと
-  // 再連携直後のリフレッシュが不要に待たされる。
-  await storageRemove([STORAGE_KEYS.extensionTokenRefreshBackoff]);
-  return true;
+  return Boolean(result?.ok);
 }
 
 export function toExtensionClipPayload(clip) {
@@ -203,17 +180,8 @@ export async function handleExtensionLinkWithAuthToken(message) {
 }
 
 export async function handleExtensionUnlinked(message) {
-  // 未連携時に unlink を受けても instanceId を新規発行しないよう、保存済みの値だけ読む。
-  const currentInstanceId = await getExtensionInstanceId();
-  if (!currentInstanceId || message?.extensionInstanceId !== currentInstanceId) {
-    console.warn('[extension-sync] ignored unlink for mismatched extensionInstanceId', {
-      expected: currentInstanceId,
-      received: message?.extensionInstanceId,
-    });
-    return { ok: false };
-  }
-
-  await clearExtensionAuthState();
-  console.log('[extension-sync] cleared auth state after unlink');
-  return { ok: true };
+  return sendRuntimeMessage({
+    type: 'UNLINK_EXTENSION',
+    extensionInstanceId: message?.extensionInstanceId,
+  });
 }

--- a/src/content/getClipData.js
+++ b/src/content/getClipData.js
@@ -1,50 +1,64 @@
 /** @typedef {import('../types/clip').CacheItem} CacheItem */
 
-window.addEventListener("clipSelected", (event) => {
+const PLAYBACK_OWNER_STORAGE_KEY = "playbackOwnerNonce";
+const PLAYBACK_OWNER_QUERY_PARAM = "dextPlaybackOwner";
+
+function createPlaybackOwnerNonce() {
+  return crypto.randomUUID?.() ||
+    `playback-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function beginPlaybackHandoff({ nonce, mode, clipId, snapshot }) {
+  return new Promise((resolve) => {
+    chrome.runtime.sendMessage(
+      {
+        type: "BEGIN_PLAYBACK_HANDOFF",
+        nonce,
+        context: { mode, clipId },
+        snapshot: {
+          ...snapshot,
+          [PLAYBACK_OWNER_STORAGE_KEY]: nonce,
+        },
+      },
+      (response) => {
+        if (chrome.runtime.lastError) {
+          resolve({ ok: false, reason: "background_unavailable" });
+          return;
+        }
+        resolve(response || { ok: false, reason: "handoff_failed" });
+      }
+    );
+  });
+}
+
+function addPlaybackOwnerToUrl(url, nonce) {
+  const target = new URL(url);
+  target.searchParams.set(PLAYBACK_OWNER_QUERY_PARAM, nonce);
+  return target.toString();
+}
+
+window.addEventListener("clipSelected", async (event) => {
   // 再生モードの遷移は 1 回の書き込みにまとめる。分割すると commentPanel が
   // 「新しい clip + 前回の playmode」を読み、直前のプレイリストのクリップの
   // コメントを表示する瞬間が生まれる。
-  safeSetStorage({
-    clip: withDetailClipId(getCookies(), event?.detail),
-    playClipSystemKey: 1,
-    playlistSystemKey: 0,
-    playmode: "clip",
+  const ownerNonce = createPlaybackOwnerNonce();
+  const clip = withDetailClipId(getCookies(), event?.detail);
+  await beginPlaybackHandoff({
+    nonce: ownerNonce,
+    mode: "clip",
+    clipId: clip.clipId ?? clip.id,
+    snapshot: {
+      clip,
+      playClipSystemKey: 1,
+      playlistSystemKey: 0,
+      playmode: "clip",
+    },
   });
 });
 
 // ------------------------------------------------------
 // Chrome storage 安全書き込みユーティリティ
 // ------------------------------------------------------
-const SENSITIVE_LOG_KEYS = new Set([
-  "authorization",
-  "extensionauthtoken",
-]);
-
-function sanitizeForLog(value) {
-  if (Array.isArray(value)) {
-    return value.map((item) => sanitizeForLog(item));
-  }
-
-  if (!value || typeof value !== "object") {
-    return value;
-  }
-
-  return Object.fromEntries(
-    Object.entries(value).map(([key, item]) => [
-      key,
-      SENSITIVE_LOG_KEYS.has(key.toLowerCase()) ? "[redacted]" : sanitizeForLog(item),
-    ])
-  );
-}
-
-async function safeSetStorage(data) {
-  try {
-    await chrome.storage.local.set(data);
-  } catch (err) {
-    console.warn("[EXT] chrome.storage.local.set failed:", sanitizeForLog(data), err);
-  }
-}
-
 // ------------------------------------------------------
 // window.postMessage 受信ハンドラ
 // ------------------------------------------------------
@@ -60,11 +74,17 @@ window.addEventListener("message", async (event) => {
   // ---- クリップデータ受信 ----
   if (msg.type === "SET_CLIP_DATA") {
     const { clip } = msg.payload;
-    await safeSetStorage({
-      clip,
-      playClipSystemKey: 1,
-      playlistSystemKey: 0,
-      playmode: "clip",
+    const ownerNonce = createPlaybackOwnerNonce();
+    await beginPlaybackHandoff({
+      nonce: ownerNonce,
+      mode: "clip",
+      clipId: clip?.clipId ?? clip?.id,
+      snapshot: {
+        clip,
+        playClipSystemKey: 1,
+        playlistSystemKey: 0,
+        playmode: "clip",
+      },
     });
   }
 
@@ -100,13 +120,25 @@ window.addEventListener("message", async (event) => {
     // 単体再生の clip は破棄する。サイト側もプレイリスト開始時に clipId cookie を
     // 失効させており、プレイリスト再生中に前回の単体クリップを現在クリップとして
     // 解決できる余地を残さない。
-    await safeSetStorage({
-      clip: null,
-      playQueue: normalizedQueue,
-      currentClipOrder: firstOrder,
-      playmode: "playlist",
+    const ownerNonce = createPlaybackOwnerNonce();
+    const firstClip = normalizedQueue.find((item) => item.order === firstOrder);
+    const handoff = await beginPlaybackHandoff({
+      nonce: ownerNonce,
+      mode: "playlist",
+      clipId: firstClip?.clipId ?? firstClip?.id,
+      snapshot: {
+        clip: null,
+        playQueue: normalizedQueue,
+        currentClipOrder: firstOrder,
+        currentClipId: firstClip?.clipId ?? firstClip?.id,
+        nextClip: firstClip,
+        playClipSystemKey: 0,
+        playlistSystemKey: 1,
+        playmode: "playlist",
+      },
     });
-    playQueue(normalizedQueue);
+    if (!handoff?.ok) return;
+    playQueue(normalizedQueue, ownerNonce);
   }
 
   // EXT/SET_SESSION ハンドラは削除済み (issue #98)。ペイロードを無検証で
@@ -224,7 +256,7 @@ function buildServiceUrl(service, rawUrl, startTime, paramKey = "t") {
 /**
  * @param {CacheItem[]} queue
  */
-async function playQueue(queue) {
+async function playQueue(queue, ownerNonce) {
   if (!Array.isArray(queue) || queue.length === 0) {
     console.warn("[EXT] playQueue: キューが空です");
     return;
@@ -246,15 +278,8 @@ async function playQueue(queue) {
     return;
   }
 
-  await safeSetStorage({ playmode: "playlist", nextClip });
-
   setTimeout(() => {
     // 再生開始位置は先頭固定(0)ではなく、実際に選んだ最小 order のクリップに合わせる。
-    chrome.storage.local.set({
-      playClipSystemKey: 0,
-      playlistSystemKey: 1,
-      currentClipOrder: Number.isFinite(Number(nextClip.order)) ? Number(nextClip.order) : 0,
-    });
-    window.location.href = url;
+    window.location.href = addPlaybackOwnerToUrl(url, ownerNonce);
   }, 300);
 }

--- a/src/content/getClipData.js
+++ b/src/content/getClipData.js
@@ -1,10 +1,15 @@
 /** @typedef {import('../types/clip').CacheItem} CacheItem */
 
-window.addEventListener("clipSelected", () => {
-  const playClipData = getCookies();
-  chrome.storage.local.set({ clip: playClipData });
-  chrome.storage.local.set({ playClipSystemKey: 1 });
-  safeSetStorage({ playmode: "clip" });
+window.addEventListener("clipSelected", (event) => {
+  // 再生モードの遷移は 1 回の書き込みにまとめる。分割すると commentPanel が
+  // 「新しい clip + 前回の playmode」を読み、直前のプレイリストのクリップの
+  // コメントを表示する瞬間が生まれる。
+  safeSetStorage({
+    clip: withDetailClipId(getCookies(), event?.detail),
+    playClipSystemKey: 1,
+    playlistSystemKey: 0,
+    playmode: "clip",
+  });
 });
 
 // ------------------------------------------------------
@@ -55,9 +60,12 @@ window.addEventListener("message", async (event) => {
   // ---- クリップデータ受信 ----
   if (msg.type === "SET_CLIP_DATA") {
     const { clip } = msg.payload;
-    await chrome.storage.local.set({ clip });
-    await safeSetStorage({ playmode: "clip" });
-    chrome.storage.local.set({ playClipSystemKey: 1, playlistSystemKey: 0 });
+    await safeSetStorage({
+      clip,
+      playClipSystemKey: 1,
+      playlistSystemKey: 0,
+      playmode: "clip",
+    });
   }
 
   // ---- プレイリスト再生開始 ----
@@ -76,9 +84,9 @@ window.addEventListener("message", async (event) => {
       return;
     }
 
-    // サイト側の playQueue は表示順の配列で order フィールドを持たない。
-    // 再生側 (content_netflix / content_disney) は order を正として現在位置・次クリップを
-    // 解決するため、欠落時は配列添字で補完しておく（order 付きで来た場合はそれを尊重）。
+    // サイト側は playQueue の各項目に id と order（0 始まりの配列添字）を必ず付ける。
+    // 再生側 (content_netflix / content_disney) と commentPanel は order を正として
+    // 現在位置・次クリップを解決するため、旧サイト向けに欠落時は配列添字で補完する。
     const normalizedQueue = queue.map((item, index) => ({
       ...item,
       order: Number.isFinite(Number(item?.order)) ? Number(item.order) : index,
@@ -89,7 +97,15 @@ window.addEventListener("message", async (event) => {
       normalizedQueue[0].order
     );
 
-    await safeSetStorage({ playQueue: normalizedQueue, currentClipOrder: firstOrder, playmode: "playlist" });
+    // 単体再生の clip は破棄する。サイト側もプレイリスト開始時に clipId cookie を
+    // 失効させており、プレイリスト再生中に前回の単体クリップを現在クリップとして
+    // 解決できる余地を残さない。
+    await safeSetStorage({
+      clip: null,
+      playQueue: normalizedQueue,
+      currentClipOrder: firstOrder,
+      playmode: "playlist",
+    });
     playQueue(normalizedQueue);
   }
 
@@ -108,6 +124,28 @@ function getCookies() {
     cookieObj[key] = decodeURIComponent(value || "");
   }
   return cookieObj;
+}
+
+/**
+ * clipId は cookie ではなく clipSelected の detail を正とする。
+ * サイトは id を持たないクリップのハンドオフで clipId cookie を失効させるが、
+ * 失効が届かなくても前回の clipId を引き継がないようにする。
+ * detail を読めない場合（旧サイト）は cookie の値をそのまま使う。
+ *
+ * @param {Record<string, string>} clip
+ * @param {unknown} detail
+ */
+function withDetailClipId(clip, detail) {
+  if (!detail || typeof detail !== "object") return clip;
+
+  const clipId = /** @type {{ clipId?: unknown }} */ (detail).clipId;
+  if (clipId !== undefined && clipId !== null) {
+    return { ...clip, clipId: String(clipId) };
+  }
+
+  return Object.fromEntries(
+    Object.entries(clip).filter(([key]) => key !== "clipId")
+  );
 }
 
 // ------------------------------------------------------

--- a/src/content/getClipData.js
+++ b/src/content/getClipData.js
@@ -1,285 +1,162 @@
-/** @typedef {import('../types/clip').CacheItem} CacheItem */
+import {
+  normalizeClipInput,
+  normalizeClipSelectedInput,
+  normalizePlaylistJson,
+} from '../shared/playbackBridgeValidation.js';
+import {
+  addPlaybackOwnerToUrl,
+  beginPlaybackHandoff,
+  createPlaybackOwnerNonce,
+} from './playbackOwnership.js';
 
-const PLAYBACK_OWNER_STORAGE_KEY = "playbackOwnerNonce";
-const PLAYBACK_OWNER_QUERY_PARAM = "dextPlaybackOwner";
+const HANDOFF_RESULT_TYPE = 'EXTENSION_PLAYBACK_HANDOFF_RESULT';
+const SAFE_HANDOFF_REASONS = new Set([
+  'invalid_payload',
+  'invalid_clip_id',
+  'clip_id_mismatch',
+  'invalid_service',
+  'invalid_url',
+  'invalid_time_range',
+  'invalid_order',
+  'duplicate_order',
+  'empty_playlist',
+  'queue_too_large',
+  'payload_too_large',
+  'handoff_failed',
+  'background_unavailable',
+]);
 
-function createPlaybackOwnerNonce() {
-  return crypto.randomUUID?.() ||
-    `playback-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+function normalizeRequestId(value) {
+  return typeof value === 'string' && value.length > 0 && value.length <= 128
+    ? value
+    : undefined;
 }
 
-function beginPlaybackHandoff({ nonce, mode, clipId, snapshot }) {
-  return new Promise((resolve) => {
-    chrome.runtime.sendMessage(
-      {
-        type: "BEGIN_PLAYBACK_HANDOFF",
-        nonce,
-        context: { mode, clipId },
-        snapshot: {
-          ...snapshot,
-          [PLAYBACK_OWNER_STORAGE_KEY]: nonce,
-        },
-      },
-      (response) => {
-        if (chrome.runtime.lastError) {
-          resolve({ ok: false, reason: "background_unavailable" });
-          return;
-        }
-        resolve(response || { ok: false, reason: "handoff_failed" });
-      }
-    );
-  });
+function sanitizeHandoffResult(result) {
+  if (result?.ok) return { ok: true };
+  const reason = SAFE_HANDOFF_REASONS.has(result?.reason)
+    ? result.reason
+    : 'handoff_failed';
+  return {
+    ok: false,
+    reason,
+    ...(typeof result?.field === 'string' ? { field: result.field } : {}),
+    ...(Number.isInteger(result?.index) ? { index: result.index } : {}),
+  };
 }
 
-function addPlaybackOwnerToUrl(url, nonce) {
-  const target = new URL(url);
-  target.searchParams.set(PLAYBACK_OWNER_QUERY_PARAM, nonce);
-  return target.toString();
+function publishHandoffResult({ source, requestId, result }) {
+  const safeResult = sanitizeHandoffResult(result);
+  const message = {
+    type: HANDOFF_RESULT_TYPE,
+    source,
+    ...safeResult,
+    ...(requestId ? { requestId } : {}),
+  };
+  window.postMessage(message, window.location.origin);
+  if (!safeResult.ok) {
+    console.warn('[EXT] Playback handoff rejected', {
+      source,
+      reason: safeResult.reason,
+      field: safeResult.field,
+      index: safeResult.index,
+    });
+  }
 }
 
-window.addEventListener("clipSelected", async (event) => {
-  // 再生モードの遷移は 1 回の書き込みにまとめる。分割すると commentPanel が
-  // 「新しい clip + 前回の playmode」を読み、直前のプレイリストのクリップの
-  // コメントを表示する瞬間が生まれる。
-  const ownerNonce = createPlaybackOwnerNonce();
-  const clip = withDetailClipId(getCookies(), event?.detail);
-  await beginPlaybackHandoff({
-    nonce: ownerNonce,
-    mode: "clip",
-    clipId: clip.clipId ?? clip.id,
+async function registerClipHandoff(clip) {
+  const nonce = createPlaybackOwnerNonce();
+  const result = await beginPlaybackHandoff({
+    nonce,
+    mode: 'clip',
+    clipId: clip.clipId,
     snapshot: {
       clip,
+      currentClipId: clip.clipId,
+      currentClipOrder: 0,
       playClipSystemKey: 1,
       playlistSystemKey: 0,
-      playmode: "clip",
+      playmode: 'clip',
     },
   });
-});
-
-// ------------------------------------------------------
-// Chrome storage 安全書き込みユーティリティ
-// ------------------------------------------------------
-// ------------------------------------------------------
-// window.postMessage 受信ハンドラ
-// ------------------------------------------------------
-// 認証・連携 (EXTENSION_CHECK_AUTH / EXT_LINK_WITH_AUTH_TOKEN / instanceId 発行) は
-// extension_link.js + extensionSync.js に一本化。getClipData.js は再生専用 (refs #110)。
-
-window.addEventListener("message", async (event) => {
-  if (event.source !== window) return;
-  if (event.origin !== window.location.origin) return;
-  const msg = event.data;
-  if (!msg || typeof msg.type !== "string") return;
-
-  // ---- クリップデータ受信 ----
-  if (msg.type === "SET_CLIP_DATA") {
-    const { clip } = msg.payload;
-    const ownerNonce = createPlaybackOwnerNonce();
-    await beginPlaybackHandoff({
-      nonce: ownerNonce,
-      mode: "clip",
-      clipId: clip?.clipId ?? clip?.id,
-      snapshot: {
-        clip,
-        playClipSystemKey: 1,
-        playlistSystemKey: 0,
-        playmode: "clip",
-      },
-    });
-  }
-
-  // ---- プレイリスト再生開始 ----
-  if (msg.type === "PLAY_PLAYLIST_START") {
-    const stored = localStorage.getItem("playQueue");
-    let queue = null;
-    try {
-      queue = stored ? JSON.parse(stored) : null;
-    } catch (err) {
-      console.warn("[EXT] PLAY_PLAYLIST_START: playQueue の JSON 解析に失敗しました", err);
-      return;
-    }
-
-    if (!queue || !Array.isArray(queue) || queue.length === 0) {
-      console.warn("[EXT] PLAY_PLAYLIST_START: playQueue が空です");
-      return;
-    }
-
-    // サイト側は playQueue の各項目に id と order（0 始まりの配列添字）を必ず付ける。
-    // 再生側 (content_netflix / content_disney) と commentPanel は order を正として
-    // 現在位置・次クリップを解決するため、旧サイト向けに欠落時は配列添字で補完する。
-    const normalizedQueue = queue.map((item, index) => ({
-      ...item,
-      order: Number.isFinite(Number(item?.order)) ? Number(item.order) : index,
-    }));
-
-    const firstOrder = normalizedQueue.reduce(
-      (min, item) => (item.order < min ? item.order : min),
-      normalizedQueue[0].order
-    );
-
-    // 単体再生の clip は破棄する。サイト側もプレイリスト開始時に clipId cookie を
-    // 失効させており、プレイリスト再生中に前回の単体クリップを現在クリップとして
-    // 解決できる余地を残さない。
-    const ownerNonce = createPlaybackOwnerNonce();
-    const firstClip = normalizedQueue.find((item) => item.order === firstOrder);
-    const handoff = await beginPlaybackHandoff({
-      nonce: ownerNonce,
-      mode: "playlist",
-      clipId: firstClip?.clipId ?? firstClip?.id,
-      snapshot: {
-        clip: null,
-        playQueue: normalizedQueue,
-        currentClipOrder: firstOrder,
-        currentClipId: firstClip?.clipId ?? firstClip?.id,
-        nextClip: firstClip,
-        playClipSystemKey: 0,
-        playlistSystemKey: 1,
-        playmode: "playlist",
-      },
-    });
-    if (!handoff?.ok) return;
-    playQueue(normalizedQueue, ownerNonce);
-  }
-
-  // EXT/SET_SESSION ハンドラは削除済み (issue #98)。ペイロードを無検証で
-  // chrome.storage.local に書き込める経路であり、サイト側も送信していなかった。
-});
-
-// ------------------------------------------------------
-// Cookie取得ユーティリティ
-// ------------------------------------------------------
-function getCookies() {
-  const cookies = document.cookie.split("; ");
-  const cookieObj = {};
-  for (const cookie of cookies) {
-    const [key, value] = cookie.split("=");
-    cookieObj[key] = decodeURIComponent(value || "");
-  }
-  return cookieObj;
+  return { result, nonce };
 }
 
-/**
- * clipId は cookie ではなく clipSelected の detail を正とする。
- * サイトは id を持たないクリップのハンドオフで clipId cookie を失効させるが、
- * 失効が届かなくても前回の clipId を引き継がないようにする。
- * detail を読めない場合（旧サイト）は cookie の値をそのまま使う。
- *
- * @param {Record<string, string>} clip
- * @param {unknown} detail
- */
-function withDetailClipId(clip, detail) {
-  if (!detail || typeof detail !== "object") return clip;
-
-  const clipId = /** @type {{ clipId?: unknown }} */ (detail).clipId;
-  if (clipId !== undefined && clipId !== null) {
-    return { ...clip, clipId: String(clipId) };
-  }
-
-  return Object.fromEntries(
-    Object.entries(clip).filter(([key]) => key !== "clipId")
-  );
+function buildPlaybackUrl(clip, nonce) {
+  const target = new URL(clip.url);
+  target.searchParams.set('t', String(Math.floor(clip.startTime)));
+  return addPlaybackOwnerToUrl(target.toString(), nonce);
 }
 
-// ------------------------------------------------------
-// サービス URL ユーティリティ
-// ------------------------------------------------------
-const SERVICE_BASE_URL = {
-  netflix: "https://www.netflix.com",
-  prime: "https://www.primevideo.com",
-  disneyplus: "https://www.disneyplus.com",
-  youtube: "https://www.youtube.com"
-};
-
-const SERVICE_ALIASES = {
-  "disney+": "disneyplus",
-  disney: "disneyplus",
-  primevideo: "prime",
-  prime_video: "prime",
-  amazonprime: "prime"
-};
-
-function normalizeService(service) {
-  if (!service) return "";
-  const normalized = service.toString().trim().toLowerCase().replace(/\s+/g, "");
-  return SERVICE_ALIASES[normalized] || normalized;
-}
-
-function ensureAbsoluteUrl(rawUrl, baseUrl) {
-  if (!rawUrl) return "";
-  if (rawUrl.startsWith("http")) return rawUrl;
-  const normalized = rawUrl.startsWith("/") ? rawUrl : `/${rawUrl}`;
-  return `${baseUrl}${normalized}`;
-}
-
-function buildYoutubeUrl(rawUrl) {
-  if (!rawUrl) return "";
-  if (rawUrl.startsWith("http")) {
-    return rawUrl;
-  }
-  if (
-    rawUrl.startsWith("youtu.be") ||
-    rawUrl.startsWith("www.youtube.com") ||
-    rawUrl.startsWith("youtube.com")
-  ) {
-    return `https://${rawUrl}`;
-  }
-  const normalized = rawUrl.startsWith("/") ? rawUrl : `/${rawUrl}`;
-  return `${SERVICE_BASE_URL.youtube}${normalized}`;
-}
-
-function appendStartTimeParam(baseUrl, paramKey, startTime) {
-  try {
-    const urlObj = new URL(baseUrl);
-    urlObj.searchParams.set(paramKey, String(startTime));
-    return urlObj.toString();
-  } catch (error) {
-    console.warn("[EXT] URL 解析に失敗しました:", baseUrl, error);
-    return baseUrl;
-  }
-}
-
-function buildServiceUrl(service, rawUrl, startTime, paramKey = "t") {
-  const normalizedService = normalizeService(service);
-  if (normalizedService === "youtube") {
-    const base = buildYoutubeUrl(rawUrl);
-    return appendStartTimeParam(base, paramKey, startTime);
-  }
-  const baseUrl = SERVICE_BASE_URL[normalizedService];
-  if (!baseUrl) return "";
-  const resolved = ensureAbsoluteUrl(rawUrl, baseUrl);
-  return appendStartTimeParam(resolved, paramKey, startTime);
-}
-
-// ------------------------------------------------------
-// プレイキュー再生ロジック
-// ------------------------------------------------------
-/**
- * @param {CacheItem[]} queue
- */
-async function playQueue(queue, ownerNonce) {
-  if (!Array.isArray(queue) || queue.length === 0) {
-    console.warn("[EXT] playQueue: キューが空です");
+window.addEventListener('clipSelected', async (event) => {
+  const source = 'clipSelected';
+  const requestId = normalizeRequestId(event?.detail?.requestId);
+  const normalized = normalizeClipSelectedInput(document.cookie, event?.detail);
+  if (!normalized.ok) {
+    publishHandoffResult({ source, requestId, result: normalized });
     return;
   }
 
-  /** @type {CacheItem} */
-  const nextClip = queue.reduce((min, item) =>
-    item.order < min.order ? item : min
-  );
+  for (const key of normalized.invalidCookieKeys || []) {
+    console.warn('[EXT] Ignored malformed playback cookie', { key });
+  }
+  const { result } = await registerClipHandoff(normalized.value);
+  publishHandoffResult({ source, requestId, result });
+});
 
-  const normalizedService = normalizeService(nextClip.service);
-  const startTime = Math.floor(nextClip.startTime) || 0;
-  const url = buildServiceUrl(normalizedService, nextClip.url, startTime, "t");
+window.addEventListener('message', async (event) => {
+  if (event.source !== window || event.origin !== window.location.origin) return;
+  const message = event.data;
+  if (!message || typeof message.type !== 'string') return;
 
-  if (!url) {
-    const message = `未対応のサービスです: ${normalizedService || "unknown"}`;
-    console.warn("[EXT]", message);
-    window.alert(message);
+  if (message.type === 'SET_CLIP_DATA') {
+    const source = 'SET_CLIP_DATA';
+    const requestId = normalizeRequestId(message.requestId);
+    const normalized = normalizeClipInput(message.payload?.clip);
+    if (!normalized.ok) {
+      publishHandoffResult({ source, requestId, result: normalized });
+      return;
+    }
+    const { result } = await registerClipHandoff(normalized.value);
+    publishHandoffResult({ source, requestId, result });
     return;
   }
 
+  if (message.type !== 'PLAY_PLAYLIST_START') return;
+
+  const source = 'PLAY_PLAYLIST_START';
+  const requestId = normalizeRequestId(message.requestId);
+  const normalized = normalizePlaylistJson(localStorage.getItem('playQueue'));
+  if (!normalized.ok) {
+    publishHandoffResult({ source, requestId, result: normalized });
+    return;
+  }
+
+  const queue = normalized.value;
+  const firstClip = queue.reduce((first, item) =>
+    item.order < first.order ? item : first
+  );
+  const nonce = createPlaybackOwnerNonce();
+  const handoff = await beginPlaybackHandoff({
+    nonce,
+    mode: 'playlist',
+    clipId: firstClip.clipId,
+    snapshot: {
+      clip: null,
+      playQueue: queue,
+      currentClipOrder: firstClip.order,
+      currentClipId: firstClip.clipId,
+      nextClip: firstClip,
+      playClipSystemKey: 0,
+      playlistSystemKey: 1,
+      playmode: 'playlist',
+    },
+  });
+  publishHandoffResult({ source, requestId, result: handoff });
+  if (!handoff?.ok) return;
+
+  const targetUrl = buildPlaybackUrl(firstClip, nonce);
   setTimeout(() => {
-    // 再生開始位置は先頭固定(0)ではなく、実際に選んだ最小 order のクリップに合わせる。
-    window.location.href = addPlaybackOwnerToUrl(url, ownerNonce);
+    window.location.href = targetUrl;
   }, 300);
-}
+});

--- a/src/content/netflixClipSelection.js
+++ b/src/content/netflixClipSelection.js
@@ -1,6 +1,18 @@
+import { normalizeClipInput } from '../shared/playbackBridgeValidation.js';
+
 export function normalizeSelectedClip(data = {}, requestedClipId) {
   const clipId = data.clipId ?? data.id ?? requestedClipId;
-  return { ...data, clipId };
+  const normalized = normalizeClipInput({
+    ...data,
+    clipId,
+    startTime: data.startTime ?? data.starttime ?? data.StartTime,
+    endTime: data.endTime ?? data.endtime ?? data.EndTime,
+    url: data.url ?? data.URL ?? data.Url,
+  });
+  if (!normalized.ok) {
+    throw new Error(`Invalid selected clip: ${normalized.reason}`);
+  }
+  return normalized.value;
 }
 
 export async function commitSelectedClip({

--- a/src/content/netflixClipSelection.js
+++ b/src/content/netflixClipSelection.js
@@ -1,0 +1,30 @@
+export function normalizeSelectedClip(data = {}, requestedClipId) {
+  const clipId = data.clipId ?? data.id ?? requestedClipId;
+  return { ...data, clipId };
+}
+
+export async function commitSelectedClip({
+  data,
+  requestedClipId,
+  ownerNonce,
+  storage,
+  setCookies,
+  openClip,
+}) {
+  const selectedClip = normalizeSelectedClip(data, requestedClipId);
+  const clipId = selectedClip.clipId;
+
+  await storage.set({
+    clip: selectedClip,
+    currentClipId: clipId,
+    currentClipOrder: 0,
+    playClipSystemKey: 1,
+    playlistSystemKey: 0,
+    playmode: 'clip',
+    playbackOwnerNonce: ownerNonce,
+  });
+
+  setCookies(selectedClip);
+  await openClip(selectedClip);
+  return selectedClip;
+}

--- a/src/content/playbackContext.js
+++ b/src/content/playbackContext.js
@@ -1,0 +1,132 @@
+export const PLAYBACK_CONTEXT_CHANGED_EVENT =
+  'ext:playback-context-changed';
+
+const PLAYBACK_CONTEXT_STORAGE_KEY = 'dextPlaybackContextV1';
+const EMPTY_SNAPSHOT = Object.freeze({ initialized: false, context: null });
+let memorySnapshot = EMPTY_SNAPSHOT;
+let memoryFallbackActive = false;
+
+function normalizeClipId(value) {
+  const numberValue =
+    typeof value === 'string' && /^\d+$/.test(value.trim())
+      ? Number(value.trim())
+      : value;
+  return Number.isSafeInteger(numberValue) && numberValue > 0
+    ? numberValue
+    : null;
+}
+
+function normalizeContext(value) {
+  if (value?.mode !== 'clip' && value?.mode !== 'playlist') return null;
+  const clipId = normalizeClipId(value.clipId);
+  if (clipId === null) return null;
+  return { mode: value.mode, clipId };
+}
+
+function getSessionStorage() {
+  try {
+    return globalThis.sessionStorage || null;
+  } catch {
+    return null;
+  }
+}
+
+function parseStoredSnapshot(rawValue) {
+  if (rawValue === null) return EMPTY_SNAPSHOT;
+
+  try {
+    const parsed = JSON.parse(rawValue);
+    if (parsed?.initialized !== true) {
+      // A present marker must never fall back to another tab's global state.
+      return { initialized: true, context: null };
+    }
+    return {
+      initialized: true,
+      context: normalizeContext(parsed.context),
+    };
+  } catch {
+    // Treat a corrupt, but present, marker as explicitly initialized and empty.
+    return { initialized: true, context: null };
+  }
+}
+
+export function readPlaybackContext() {
+  const storage = getSessionStorage();
+  if (!storage) return memorySnapshot;
+  if (memoryFallbackActive) return memorySnapshot;
+
+  try {
+    const rawValue = storage.getItem(PLAYBACK_CONTEXT_STORAGE_KEY);
+    return parseStoredSnapshot(rawValue);
+  } catch {
+    return memorySnapshot;
+  }
+}
+
+function dispatchChange(snapshot) {
+  const eventTarget = globalThis.window;
+  if (!eventTarget?.dispatchEvent) return;
+
+  try {
+    const event = new CustomEvent(PLAYBACK_CONTEXT_CHANGED_EVENT, {
+      detail: snapshot,
+    });
+    eventTarget.dispatchEvent(event);
+  } catch {
+    // Old/locked-down pages can expose EventTarget without a usable CustomEvent.
+    try {
+      eventTarget.dispatchEvent(new Event(PLAYBACK_CONTEXT_CHANGED_EVENT));
+    } catch {
+      // The stored context remains authoritative even when notification is blocked.
+    }
+  }
+}
+
+function writePlaybackContext(context) {
+  const nextSnapshot = { initialized: true, context };
+  const previousSnapshot = readPlaybackContext();
+  const unchanged =
+    previousSnapshot.initialized &&
+    previousSnapshot.context?.mode === context?.mode &&
+    previousSnapshot.context?.clipId === context?.clipId;
+
+  memorySnapshot = nextSnapshot;
+  const storage = getSessionStorage();
+  if (storage) {
+    try {
+      storage.setItem(
+        PLAYBACK_CONTEXT_STORAGE_KEY,
+        JSON.stringify(nextSnapshot)
+      );
+      memoryFallbackActive = false;
+    } catch {
+      // Keep the module-local value so this tab still remains isolated.
+      memoryFallbackActive = true;
+    }
+  } else {
+    memoryFallbackActive = true;
+  }
+
+  if (!unchanged) dispatchChange(nextSnapshot);
+  return nextSnapshot;
+}
+
+/** Mark this tab as initialized without borrowing another tab's playback state. */
+export function ensurePlaybackContext() {
+  const current = readPlaybackContext();
+  if (current.initialized) return current;
+  return writePlaybackContext(null);
+}
+
+export function setPlaybackContext({ mode, clipId } = {}) {
+  const context = normalizeContext({ mode, clipId });
+  if (!context) {
+    throw new TypeError('Playback context requires clip/playlist mode and a positive clipId');
+  }
+  return writePlaybackContext(context);
+}
+
+/** Clear this tab's playback state while retaining the initialized-null marker. */
+export function clearPlaybackContext() {
+  return writePlaybackContext(null);
+}

--- a/src/content/playbackOwnership.js
+++ b/src/content/playbackOwnership.js
@@ -1,0 +1,148 @@
+export const PLAYBACK_OWNER_STORAGE_KEY = 'playbackOwnerNonce';
+export const PLAYBACK_OWNER_QUERY_PARAM = 'dextPlaybackOwner';
+export const PLAYBACK_OWNER_TAB_KEY = 'dextPlaybackOwnerTab';
+function sendMessage(message) {
+  return new Promise((resolve) => {
+    const runtime = globalThis.chrome?.runtime;
+    if (!runtime?.sendMessage) {
+      resolve({ ok: false, reason: 'background_unavailable' });
+      return;
+    }
+    try {
+      runtime.sendMessage(message, (response) => {
+        if (runtime.lastError) {
+          resolve({ ok: false, reason: 'background_unavailable' });
+          return;
+        }
+        resolve(response || { ok: false, reason: 'request_failed' });
+      });
+    } catch {
+      resolve({ ok: false, reason: 'background_unavailable' });
+    }
+  });
+}
+
+export function createPlaybackOwnerNonce() {
+  return globalThis.crypto?.randomUUID?.() ||
+    `playback-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+export function getPlaybackOwnerNonceFromUrl(url = globalThis.location?.href) {
+  try {
+    return new URL(url).searchParams.get(PLAYBACK_OWNER_QUERY_PARAM);
+  } catch {
+    return null;
+  }
+}
+
+export function getTabPlaybackOwnerNonce() {
+  const fromUrl = getPlaybackOwnerNonceFromUrl();
+  if (fromUrl) return fromUrl;
+  try {
+    return globalThis.sessionStorage?.getItem(PLAYBACK_OWNER_TAB_KEY) || null;
+  } catch {
+    return null;
+  }
+}
+
+function rememberTabOwner(nonce) {
+  try {
+    globalThis.sessionStorage?.setItem(PLAYBACK_OWNER_TAB_KEY, nonce);
+  } catch {
+    // The background tab binding remains authoritative if sessionStorage is blocked.
+  }
+}
+
+function forgetTabOwner(nonce) {
+  try {
+    if (globalThis.sessionStorage?.getItem(PLAYBACK_OWNER_TAB_KEY) === nonce) {
+      globalThis.sessionStorage.removeItem(PLAYBACK_OWNER_TAB_KEY);
+    }
+  } catch {
+    // Nothing else to tear down locally.
+  }
+}
+
+export function addPlaybackOwnerToUrl(url, nonce) {
+  const target = new URL(url);
+  target.searchParams.set(PLAYBACK_OWNER_QUERY_PARAM, nonce);
+  return target.toString();
+}
+
+export function beginPlaybackHandoff({ nonce, mode, clipId, snapshot }) {
+  return sendMessage({
+    type: 'BEGIN_PLAYBACK_HANDOFF',
+    nonce,
+    context: { mode, clipId },
+    snapshot: {
+      ...snapshot,
+      [PLAYBACK_OWNER_STORAGE_KEY]: nonce,
+    },
+  });
+}
+
+export async function claimPlaybackOwnership({ nonce }) {
+  const mayNeedLegacyHandoff = !getPlaybackOwnerNonceFromUrl();
+  let requestedNonce = nonce;
+  for (let attempt = 0; attempt < (mayNeedLegacyHandoff ? 20 : 1); attempt += 1) {
+    const result = await sendMessage({
+      type: 'CLAIM_PLAYBACK_OWNERSHIP',
+      nonce: requestedNonce,
+      route: globalThis.location?.href,
+    });
+    if (result?.ok) {
+      rememberTabOwner(result.nonce || requestedNonce);
+      return result;
+    }
+    if (
+      !getPlaybackOwnerNonceFromUrl() &&
+      requestedNonce &&
+      (result?.reason === 'handoff_not_found' || result?.reason === 'route_mismatch')
+    ) {
+      forgetTabOwner(requestedNonce);
+    }
+    if (
+      (result?.reason !== 'handoff_not_found' && result?.reason !== 'route_mismatch') ||
+      !mayNeedLegacyHandoff
+    ) {
+      return result;
+    }
+    requestedNonce = null;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return { ok: false, reason: 'handoff_not_found' };
+}
+
+export async function updatePlaybackOwnership({ nonce, mode, clipId, patch }) {
+  const result = await sendMessage({
+    type: 'UPDATE_PLAYBACK_OWNERSHIP',
+    nonce,
+    context: { mode, clipId },
+    patch,
+    route: globalThis.location?.href,
+  });
+  if (result?.ok) rememberTabOwner(nonce);
+  return result;
+}
+
+export function preparePlaybackNavigation(nonce, nextUrl) {
+  return sendMessage({
+    type: 'PREPARE_PLAYBACK_NAVIGATION',
+    nonce,
+    nextUrl,
+  });
+}
+
+export function releasePlaybackOwnership(nonce) {
+  if (!nonce) return;
+  forgetTabOwner(nonce);
+  try {
+    const runtime = globalThis.chrome?.runtime;
+    runtime?.sendMessage?.(
+      { type: 'RELEASE_PLAYBACK_OWNERSHIP', nonce },
+      () => void runtime.lastError
+    );
+  } catch {
+    // tabs.onRemoved is the reliable fallback when an unloading page cannot message.
+  }
+}

--- a/src/content/playbackOwnership.js
+++ b/src/content/playbackOwnership.js
@@ -1,5 +1,9 @@
-export const PLAYBACK_OWNER_STORAGE_KEY = 'playbackOwnerNonce';
-export const PLAYBACK_OWNER_QUERY_PARAM = 'dextPlaybackOwner';
+import {
+  PLAYBACK_OWNER_QUERY_PARAM,
+  PLAYBACK_OWNER_STORAGE_KEY,
+} from '../shared/playbackBridgeValidation.js';
+
+export { PLAYBACK_OWNER_QUERY_PARAM, PLAYBACK_OWNER_STORAGE_KEY };
 export const PLAYBACK_OWNER_TAB_KEY = 'dextPlaybackOwnerTab';
 function sendMessage(message) {
   return new Promise((resolve) => {
@@ -103,7 +107,8 @@ export async function claimPlaybackOwnership({ nonce }) {
     }
     if (
       (result?.reason !== 'handoff_not_found' && result?.reason !== 'route_mismatch') ||
-      !mayNeedLegacyHandoff
+      !mayNeedLegacyHandoff ||
+      result?.retryable === false
     ) {
       return result;
     }

--- a/src/shared/commentText.js
+++ b/src/shared/commentText.js
@@ -1,0 +1,11 @@
+export const COMMENT_BODY_MAX_CODE_POINTS = 500;
+
+export function countUnicodeCodePoints(value) {
+  return Array.from(value).length;
+}
+
+export function isValidCommentBody(value) {
+  if (typeof value !== 'string') return false;
+  const length = countUnicodeCodePoints(value.trim());
+  return length >= 1 && length <= COMMENT_BODY_MAX_CODE_POINTS;
+}

--- a/src/shared/playbackBridgeValidation.js
+++ b/src/shared/playbackBridgeValidation.js
@@ -1,0 +1,370 @@
+export const MAX_PLAYLIST_ITEMS = 100;
+export const MAX_PLAYBACK_PAYLOAD_BYTES = 512 * 1024;
+export const MAX_PLAYBACK_URL_LENGTH = 4096;
+export const PLAYBACK_OWNER_STORAGE_KEY = 'playbackOwnerNonce';
+export const PLAYBACK_OWNER_QUERY_PARAM = 'dextPlaybackOwner';
+
+const STRING_LIMITS = Object.freeze({
+  title: 500,
+  clipname: 500,
+  user: 200,
+  username: 200,
+  epnumber: 200,
+});
+const COOKIE_KEYS = new Set([
+  'title',
+  'user',
+  'url',
+  'service',
+  'clipId',
+  'username',
+  'startTime',
+  'starttime',
+  'endTime',
+  'endtime',
+]);
+const SERVICE_CONFIG = Object.freeze({
+  netflix: {
+    baseUrl: 'https://www.netflix.com',
+    hostname: 'www.netflix.com',
+  },
+  disneyplus: {
+    baseUrl: 'https://www.disneyplus.com',
+    hostname: 'www.disneyplus.com',
+  },
+});
+const SERVICE_ALIASES = Object.freeze({
+  'disney+': 'disneyplus',
+  disney: 'disneyplus',
+  disney_plus: 'disneyplus',
+});
+
+function failure(reason, field, index) {
+  return {
+    ok: false,
+    reason,
+    ...(field ? { field } : {}),
+    ...(Number.isInteger(index) ? { index } : {}),
+  };
+}
+
+function isRecord(value) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  try {
+    return Object.prototype.toString.call(value) === '[object Object]';
+  } catch {
+    return false;
+  }
+}
+
+export function normalizePlaybackRoute(value, baseUrl) {
+  try {
+    const url = new URL(value, baseUrl);
+    return `${url.origin}${url.pathname}`;
+  } catch {
+    return null;
+  }
+}
+
+function utf8ByteLength(value) {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+function parseFiniteNumber(value) {
+  if (typeof value !== 'number' && typeof value !== 'string') return null;
+  if (typeof value === 'string' && value.trim().length === 0) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseNonNegativeSafeInteger(value) {
+  if (typeof value === 'string' && !/^\d+$/.test(value)) return null;
+  if (typeof value !== 'number' && typeof value !== 'string') return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
+}
+
+export function normalizePositiveClipId(value) {
+  const parsed = parseNonNegativeSafeInteger(value);
+  return parsed !== null && parsed > 0 ? parsed : null;
+}
+
+function readConsistentNumberAlias(input, aliases) {
+  const present = aliases
+    .filter((key) => input[key] !== undefined && input[key] !== null)
+    .map((key) => parseFiniteNumber(input[key]));
+  if (present.length === 0 || present.some((value) => value === null)) return null;
+  return present.every((value) => value === present[0]) ? present[0] : null;
+}
+
+function normalizeClipIdFromInput(input, index) {
+  const rawIds = [input.clipId, input.id]
+    .filter((value) => value !== undefined && value !== null);
+  if (rawIds.length === 0) return failure('invalid_clip_id', 'clipId', index);
+  const ids = rawIds.map(normalizePositiveClipId);
+  if (ids.some((value) => value === null) || ids.some((value) => value !== ids[0])) {
+    return failure('invalid_clip_id', 'clipId', index);
+  }
+  return { ok: true, value: ids[0] };
+}
+
+function normalizeService(value, index) {
+  if (typeof value !== 'string' || value.length > 32) {
+    return failure('invalid_service', 'service', index);
+  }
+  const lowered = value.trim().toLowerCase().replace(/\s+/g, '');
+  const normalized = SERVICE_ALIASES[lowered] || lowered;
+  if (!SERVICE_CONFIG[normalized]) {
+    return failure('invalid_service', 'service', index);
+  }
+  return { ok: true, value: normalized };
+}
+
+function normalizeUrl(value, service, index) {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > MAX_PLAYBACK_URL_LENGTH
+  ) {
+    return failure('invalid_url', 'url', index);
+  }
+
+  const config = SERVICE_CONFIG[service];
+  try {
+    const url = new URL(value, config.baseUrl);
+    if (
+      url.protocol !== 'https:' ||
+      url.hostname !== config.hostname ||
+      url.port !== '' ||
+      url.username !== '' ||
+      url.password !== '' ||
+      url.href.length > MAX_PLAYBACK_URL_LENGTH
+    ) {
+      return failure('invalid_url', 'url', index);
+    }
+    return { ok: true, value: url.toString() };
+  } catch {
+    return failure('invalid_url', 'url', index);
+  }
+}
+
+function normalizeOptionalStrings(input, index) {
+  const normalized = {};
+  for (const [key, limit] of Object.entries(STRING_LIMITS)) {
+    const value = input[key];
+    if (value === undefined || value === null) continue;
+    if (typeof value !== 'string' || value.length > limit) {
+      return failure('invalid_payload', key, index);
+    }
+    const trimmed = value.trim();
+    if (trimmed) normalized[key] = trimmed;
+  }
+  return { ok: true, value: normalized };
+}
+
+export function normalizeClipInput(input, { playlist = false, index } = {}) {
+  if (!isRecord(input)) return failure('invalid_payload', 'clip', index);
+
+  const clipId = normalizeClipIdFromInput(input, index);
+  if (!clipId.ok) return clipId;
+
+  const service = normalizeService(input.service, index);
+  if (!service.ok) return service;
+
+  const url = normalizeUrl(input.url, service.value, index);
+  if (!url.ok) return url;
+
+  const startTime = readConsistentNumberAlias(input, [
+    'startTime',
+    'starttime',
+    'StartTime',
+  ]);
+  const endTime = readConsistentNumberAlias(input, [
+    'endTime',
+    'endtime',
+    'EndTime',
+  ]);
+  if (startTime === null || startTime < 0) {
+    return failure('invalid_time_range', 'startTime', index);
+  }
+  if (endTime === null || endTime <= startTime) {
+    return failure('invalid_time_range', 'endTime', index);
+  }
+
+  const optional = normalizeOptionalStrings(input, index);
+  if (!optional.ok) return optional;
+
+  const value = {
+    clipId: clipId.value,
+    service: service.value,
+    url: url.value,
+    startTime,
+    endTime,
+    ...optional.value,
+  };
+
+  if (playlist) {
+    const hasOrder = Object.hasOwn(input, 'order');
+    const order = hasOrder
+      ? parseNonNegativeSafeInteger(input.order)
+      : parseNonNegativeSafeInteger(index);
+    if (order === null) return failure('invalid_order', 'order', index);
+    value.id = clipId.value;
+    value.order = order;
+  }
+
+  return { ok: true, value };
+}
+
+export function normalizePlaylistInput(input) {
+  if (!Array.isArray(input)) return failure('invalid_payload', 'playQueue');
+  if (input.length === 0) return failure('empty_playlist', 'playQueue');
+  if (input.length > MAX_PLAYLIST_ITEMS) {
+    return failure('queue_too_large', 'playQueue');
+  }
+
+  const queue = [];
+  const orders = new Set();
+  for (let index = 0; index < input.length; index += 1) {
+    const item = normalizeClipInput(input[index], { playlist: true, index });
+    if (!item.ok) return item;
+    if (orders.has(item.value.order)) {
+      return failure('duplicate_order', 'order', index);
+    }
+    orders.add(item.value.order);
+    queue.push(item.value);
+  }
+
+  const serialized = JSON.stringify(queue);
+  if (utf8ByteLength(serialized) > MAX_PLAYBACK_PAYLOAD_BYTES) {
+    return failure('payload_too_large', 'playQueue');
+  }
+  return { ok: true, value: queue };
+}
+
+export function normalizePlaylistJson(rawValue) {
+  if (typeof rawValue !== 'string' || rawValue.length === 0) {
+    return failure('empty_playlist', 'playQueue');
+  }
+  if (utf8ByteLength(rawValue) > MAX_PLAYBACK_PAYLOAD_BYTES) {
+    return failure('payload_too_large', 'playQueue');
+  }
+  try {
+    return normalizePlaylistInput(JSON.parse(rawValue));
+  } catch {
+    return failure('invalid_payload', 'playQueue');
+  }
+}
+
+export function parsePlaybackCookies(cookieString) {
+  const values = {};
+  const invalidKeys = [];
+  if (typeof cookieString !== 'string' || cookieString.length === 0) {
+    return { values, invalidKeys };
+  }
+
+  for (const part of cookieString.split(';')) {
+    const separator = part.indexOf('=');
+    if (separator < 0) continue;
+    const key = part.slice(0, separator).trim();
+    if (!COOKIE_KEYS.has(key)) continue;
+    try {
+      values[key] = decodeURIComponent(part.slice(separator + 1));
+    } catch {
+      invalidKeys.push(key);
+    }
+  }
+  return { values, invalidKeys };
+}
+
+export function normalizeClipSelectedInput(cookieString, detail) {
+  if (!isRecord(detail)) return failure('invalid_payload', 'detail');
+  const detailClipId = normalizePositiveClipId(detail.clipId);
+  if (detailClipId === null) return failure('invalid_clip_id', 'clipId');
+
+  const { values, invalidKeys } = parsePlaybackCookies(cookieString);
+  if (invalidKeys.includes('clipId')) {
+    return failure('invalid_clip_id', 'clipId');
+  }
+  if (values.clipId !== undefined) {
+    const cookieClipId = normalizePositiveClipId(values.clipId);
+    if (cookieClipId === null) return failure('invalid_clip_id', 'clipId');
+    if (cookieClipId !== detailClipId) {
+      return failure('clip_id_mismatch', 'clipId');
+    }
+  }
+
+  const clip = normalizeClipInput({ ...values, clipId: detailClipId });
+  return clip.ok ? { ...clip, invalidCookieKeys: invalidKeys } : clip;
+}
+
+export function normalizePlaybackContext(value) {
+  if (!isRecord(value) || (value.mode !== 'clip' && value.mode !== 'playlist')) {
+    return failure('invalid_payload', 'context');
+  }
+  const clipId = normalizePositiveClipId(value.clipId);
+  if (clipId === null) return failure('invalid_clip_id', 'context.clipId');
+  return { ok: true, value: { mode: value.mode, clipId } };
+}
+
+export function normalizePlaybackSnapshot({ snapshot, context, ownerNonce }) {
+  if (!isRecord(snapshot)) return failure('invalid_payload', 'snapshot');
+  const normalizedContext = normalizePlaybackContext(context);
+  if (!normalizedContext.ok) return normalizedContext;
+
+  const common = {
+    currentClipOrder: 0,
+    currentClipId: normalizedContext.value.clipId,
+    [PLAYBACK_OWNER_STORAGE_KEY]: ownerNonce,
+  };
+
+  if (normalizedContext.value.mode === 'clip') {
+    const clip = normalizeClipInput(snapshot.clip);
+    if (!clip.ok) return clip;
+    if (clip.value.clipId !== normalizedContext.value.clipId) {
+      return failure('clip_id_mismatch', 'context.clipId');
+    }
+    return {
+      ok: true,
+      context: normalizedContext.value,
+      value: {
+        ...common,
+        clip: clip.value,
+        playQueue: null,
+        nextClip: null,
+        playClipSystemKey: 1,
+        playlistSystemKey: 0,
+        playmode: 'clip',
+      },
+    };
+  }
+
+  const queue = normalizePlaylistInput(snapshot.playQueue);
+  if (!queue.ok) return queue;
+  const currentClipOrder = parseNonNegativeSafeInteger(snapshot.currentClipOrder);
+  if (currentClipOrder === null) {
+    return failure('invalid_order', 'currentClipOrder');
+  }
+  const currentClip = queue.value.find((item) => item.order === currentClipOrder);
+  if (!currentClip) return failure('invalid_order', 'currentClipOrder');
+  if (currentClip.clipId !== normalizedContext.value.clipId) {
+    return failure('clip_id_mismatch', 'context.clipId');
+  }
+
+  return {
+    ok: true,
+    context: normalizedContext.value,
+    value: {
+      ...common,
+      clip: null,
+      playQueue: queue.value,
+      currentClipOrder,
+      nextClip: currentClip,
+      playClipSystemKey: 0,
+      playlistSystemKey: 1,
+      playmode: 'playlist',
+    },
+  };
+}

--- a/src/ui/icons.js
+++ b/src/ui/icons.js
@@ -43,10 +43,19 @@ const MARKUP = {
       <path d="M12 2a10 10 0 1 1 0 20a10 10 0 1 1 0-20z" />
       <path d="M10 10l6 -2l-2 6l-6 2z" />
     </svg>`,
+  // クリップ別コメント
+  comment: `
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+         fill="none" stroke="currentColor" stroke-width="1.5"
+         stroke-linecap="round" stroke-linejoin="round"
+         aria-hidden="true" focusable="false">
+      <path d="M5 4.5h14a2.5 2.5 0 0 1 2.5 2.5v8a2.5 2.5 0 0 1-2.5 2.5H10l-5.8 3v-3.2A2.5 2.5 0 0 1 2.5 15V7A2.5 2.5 0 0 1 5 4.5z" />
+      <path d="M7.5 9h9M7.5 13h6" />
+    </svg>`,
 };
 
 /** 色変化をアニメーションするアイコン（旧 moreDetailSVG / LoopButtonSVG の挙動）。 */
-const COLOR_TRANSITION = new Set(["loop", "list"]);
+const COLOR_TRANSITION = new Set(["loop", "list", "comment"]);
 
 /** アイコン名の一覧（凍結）。 */
 export const ICON_NAMES = Object.freeze(Object.keys(MARKUP));
@@ -75,7 +84,7 @@ function fromMarkup(markup) {
 
 /**
  * アイコン名から SVG 要素を生成する。未知の名前は Error を投げる。
- * @param {'record'|'loop'|'list'} name
+ * @param {'record'|'loop'|'list'|'comment'} name
  * @returns {SVGSVGElement}
  */
 export function createIcon(name) {

--- a/src/util/cookies.js
+++ b/src/util/cookies.js
@@ -36,6 +36,7 @@ export function setCookie(name, value, options = {}) {
     parts.push("");
   }
 
+  // biome-ignore lint/suspicious/noDocumentCookie: Cookie Store API is unavailable in some supported extension contexts.
   document.cookie = parts.join("; ");
 }
 

--- a/src/util/history_change.js
+++ b/src/util/history_change.js
@@ -30,7 +30,7 @@
     };
   
     // popstate イベントも監視
-    window.addEventListener('popstate', (event) => {
+    window.addEventListener('popstate', () => {
       const changeEvent = new CustomEvent('historyChange', {
         detail: {
           method: 'popstate',
@@ -40,4 +40,3 @@
       window.dispatchEvent(changeEvent);
     });
   })();
-  

--- a/test/backgroundAuth.test.js
+++ b/test/backgroundAuth.test.js
@@ -1,0 +1,331 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  saveExtensionAuthTokenInBackground,
+  unlinkExtensionInBackground,
+} from '../src/background/authState.js';
+import { openLoginTab, syncPendingQueue } from '../src/background/sync.js';
+import { checkAndRefreshToken } from '../src/background/tokenRefresh.js';
+import { saveExtensionAuthToken } from '../src/content/extensionSync.js';
+
+async function withChromeState(state, { createTab } = {}, task) {
+  const originalChrome = globalThis.chrome;
+  const runtime = { lastError: null };
+  globalThis.chrome = {
+    runtime,
+    storage: {
+      local: {
+        get(keys, callback) {
+          const keyList = Array.isArray(keys) ? keys : [keys];
+          callback(Object.fromEntries(
+            keyList
+              .filter((key) => Object.hasOwn(state, key))
+              .map((key) => [key, state[key]])
+          ));
+        },
+        set(items, callback) {
+          Object.assign(state, items);
+          callback();
+        },
+        remove(keys, callback) {
+          const keyList = Array.isArray(keys) ? keys : [keys];
+          for (const key of keyList) delete state[key];
+          callback();
+        },
+      },
+    },
+    tabs: {
+      create: createTab || ((_options, callback) => callback({ id: 1 })),
+    },
+  };
+
+  try {
+    await task({ runtime });
+  } finally {
+    if (originalChrome === undefined) {
+      delete globalThis.chrome;
+    } else {
+      globalThis.chrome = originalChrome;
+    }
+  }
+}
+
+test('background auth save validates instance and token before writing', async () => {
+  const state = { extensionInstanceId: 'instance-id' };
+
+  await withChromeState(state, {}, async () => {
+    assert.deepEqual(await saveExtensionAuthTokenInBackground({
+      extensionInstanceId: 'another-instance',
+      extensionAuthToken: 'token',
+    }), { ok: false, reason: 'instance_mismatch' });
+    assert.deepEqual(await saveExtensionAuthTokenInBackground({
+      extensionInstanceId: 'instance-id',
+      extensionAuthToken: '   ',
+    }), { ok: false, reason: 'invalid_token' });
+  });
+
+  assert.equal(Object.hasOwn(state, 'extensionAuthToken'), false);
+});
+
+test('background auth save normalizes expiry and clears old refresh backoff', async () => {
+  const state = {
+    extensionInstanceId: 'instance-id',
+    extensionTokenRefreshBackoff: { failureCount: 2 },
+  };
+
+  await withChromeState(state, {}, async () => {
+    assert.deepEqual(await saveExtensionAuthTokenInBackground({
+      extensionInstanceId: 'instance-id',
+      extensionAuthToken: 'new-token',
+      expiresAt: '2099-01-01T00:00:00Z',
+    }), { ok: true });
+  });
+
+  assert.equal(state.extensionAuthToken, 'new-token');
+  assert.equal(state.extensionTokenExpiresAt, '2099-01-01T00:00:00.000Z');
+  assert.equal(state.extensionLinked, true);
+  assert.equal(Object.hasOwn(state, 'extensionTokenRefreshBackoff'), false);
+});
+
+test('unlink and re-link operations are applied in mutex call order', async () => {
+  const state = {
+    extensionInstanceId: 'instance-id',
+    extensionAuthToken: 'old-token',
+    extensionLinked: true,
+  };
+
+  await withChromeState(state, {}, async () => {
+    const unlinkFirst = unlinkExtensionInBackground({
+      extensionInstanceId: 'instance-id',
+    });
+    const saveSecond = saveExtensionAuthTokenInBackground({
+      extensionInstanceId: 'instance-id',
+      extensionAuthToken: 'new-token',
+    });
+    assert.deepEqual(await unlinkFirst, { ok: true });
+    assert.deepEqual(await saveSecond, { ok: true });
+    assert.equal(state.extensionAuthToken, 'new-token');
+    assert.equal(state.extensionLinked, true);
+
+    const saveFirst = saveExtensionAuthTokenInBackground({
+      extensionInstanceId: 'instance-id',
+      extensionAuthToken: 'newer-token',
+    });
+    const unlinkSecond = unlinkExtensionInBackground({
+      extensionInstanceId: 'instance-id',
+    });
+    assert.deepEqual(await saveFirst, { ok: true });
+    assert.deepEqual(await unlinkSecond, { ok: true });
+  });
+
+  assert.equal(Object.hasOwn(state, 'extensionAuthToken'), false);
+  assert.equal(state.extensionLinked, false);
+});
+
+test('all login callers share one tab creation and then observe cooldown', async () => {
+  const state = {};
+  let createCalls = 0;
+  let finishCreate;
+  let markCreateStarted;
+  const createStarted = new Promise((resolve) => {
+    markCreateStarted = resolve;
+  });
+
+  await withChromeState(state, {
+    createTab(_options, callback) {
+      createCalls += 1;
+      finishCreate = callback;
+      markCreateStarted();
+    },
+  }, async () => {
+    const first = openLoginTab();
+    const second = openLoginTab();
+    assert.equal(first, second);
+    await createStarted;
+    finishCreate({ id: 42 });
+
+    assert.deepEqual(await first, { ok: true, tabId: 42 });
+    assert.deepEqual(await second, { ok: true, tabId: 42 });
+    assert.equal(createCalls, 1);
+    assert.equal(typeof state.extensionLoginPromptLastOpenedAt, 'number');
+
+    assert.deepEqual(await openLoginTab(), {
+      ok: true,
+      skipped: true,
+      reason: 'cooldown',
+    });
+    assert.equal(createCalls, 1);
+  });
+});
+
+test('failed login tab creation does not start cooldown and can retry', async () => {
+  const state = {};
+  let createCalls = 0;
+
+  await withChromeState(state, {
+    createTab(_options, callback) {
+      createCalls += 1;
+      if (createCalls === 1) {
+        chrome.runtime.lastError = { message: 'tab failed' };
+        callback();
+        chrome.runtime.lastError = null;
+        return;
+      }
+      callback({ id: 43 });
+    },
+  }, async () => {
+    assert.deepEqual(await openLoginTab(), {
+      ok: false,
+      reason: 'tab_create_failed',
+      error: 'tab failed',
+    });
+    assert.equal(Object.hasOwn(state, 'extensionLoginPromptLastOpenedAt'), false);
+
+    assert.deepEqual(await openLoginTab(), { ok: true, tabId: 43 });
+    assert.equal(createCalls, 2);
+    assert.equal(typeof state.extensionLoginPromptLastOpenedAt, 'number');
+  });
+});
+
+test('content auth bridge forwards writes and surfaces runtime errors', async () => {
+  const originalChrome = globalThis.chrome;
+  let sentMessage;
+  globalThis.chrome = {
+    runtime: {
+      lastError: null,
+      sendMessage(message, callback) {
+        sentMessage = message;
+        callback({ ok: true });
+      },
+    },
+  };
+
+  try {
+    assert.equal(await saveExtensionAuthToken(
+      'instance-id',
+      'token',
+      '2099-01-01T00:00:00.000Z'
+    ), true);
+    assert.deepEqual(sentMessage, {
+      type: 'SAVE_EXTENSION_AUTH_TOKEN',
+      extensionInstanceId: 'instance-id',
+      extensionAuthToken: 'token',
+      expiresAt: '2099-01-01T00:00:00.000Z',
+    });
+
+    chrome.runtime.sendMessage = (_message, callback) => {
+      chrome.runtime.lastError = { message: 'service worker unavailable' };
+      callback();
+      chrome.runtime.lastError = null;
+    };
+    await assert.rejects(
+      saveExtensionAuthToken('instance-id', 'token'),
+      /service worker unavailable/
+    );
+  } finally {
+    if (originalChrome === undefined) {
+      delete globalThis.chrome;
+    } else {
+      globalThis.chrome = originalChrome;
+    }
+  }
+});
+
+async function withStalledFetch(task) {
+  const originalFetch = globalThis.fetch;
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  let abortRequest;
+  let markFetchStarted;
+  const fetchStarted = new Promise((resolve) => {
+    markFetchStarted = resolve;
+  });
+
+  globalThis.setTimeout = (callback) => {
+    abortRequest = callback;
+    return 1;
+  };
+  globalThis.clearTimeout = () => {};
+  globalThis.fetch = async (_url, options) => {
+    markFetchStarted();
+    return new Promise((_resolve, reject) => {
+      options.signal.addEventListener('abort', () => {
+        const error = new Error('aborted');
+        error.name = 'AbortError';
+        reject(error);
+      }, { once: true });
+    });
+  };
+
+  try {
+    await task({ fetchStarted, abort: () => abortRequest() });
+  } finally {
+    globalThis.fetch = originalFetch;
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+  }
+}
+
+test('a stalled clip sync times out and releases the auth mutex', async () => {
+  const state = {
+    extensionInstanceId: 'instance-id',
+    extensionAuthToken: 'token',
+    extensionLinked: true,
+    pendingClips: [{
+      clientItemId: 'client-item',
+      url: 'https://www.netflix.com/watch/1',
+      startTime: 1,
+      endTime: 2,
+    }],
+  };
+
+  await withChromeState(state, {}, async () => {
+    await withStalledFetch(async ({ fetchStarted, abort }) => {
+      const syncPromise = syncPendingQueue();
+      await fetchStarted;
+      abort();
+      assert.deepEqual(await syncPromise, {
+        ok: false,
+        queued: true,
+        reason: 'timeout',
+      });
+    });
+
+    assert.deepEqual(await saveExtensionAuthTokenInBackground({
+      extensionInstanceId: 'instance-id',
+      extensionAuthToken: 'new-token',
+    }), { ok: true });
+  });
+
+  assert.equal(state.extensionAuthToken, 'new-token');
+  assert.equal(state.pendingClips.length, 1);
+});
+
+test('a stalled token refresh times out and releases the auth mutex', async () => {
+  const state = {
+    extensionInstanceId: 'instance-id',
+    extensionAuthToken: 'token',
+    extensionLinked: true,
+    extensionTokenExpiresAt: '2020-01-01T00:00:00.000Z',
+  };
+
+  await withChromeState(state, {}, async () => {
+    await withStalledFetch(async ({ fetchStarted, abort }) => {
+      const refreshPromise = checkAndRefreshToken();
+      await fetchStarted;
+      abort();
+      const result = await refreshPromise;
+      assert.equal(result.ok, false);
+      assert.equal(result.reason, 'timeout');
+    });
+
+    assert.deepEqual(await saveExtensionAuthTokenInBackground({
+      extensionInstanceId: 'instance-id',
+      extensionAuthToken: 'new-token',
+    }), { ok: true });
+  });
+
+  assert.equal(state.extensionAuthToken, 'new-token');
+  assert.equal(state.extensionLinked, true);
+});

--- a/test/backgroundRequest.test.js
+++ b/test/backgroundRequest.test.js
@@ -78,3 +78,17 @@ test('fetchJsonWithTimeout aborts while consuming the response JSON body', async
     }
   );
 });
+
+test('a completed response is accepted until the abort timer actually fires', async () => {
+  await withManualTimeout(
+    async () => ({
+      status: 200,
+      json: async () => ({ ok: true, token: 'rotated-token' }),
+    }),
+    async () => {
+      const result = await fetchJsonWithTimeout('/complete', {}, 0);
+      assert.equal(result.ok, true);
+      assert.equal(result.data.token, 'rotated-token');
+    }
+  );
+});

--- a/test/backgroundRequest.test.js
+++ b/test/backgroundRequest.test.js
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { fetchJsonWithTimeout } from '../src/background/request.js';
+
+async function withManualTimeout(fetchImpl, task) {
+  const originalFetch = globalThis.fetch;
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  let fireTimeout;
+
+  globalThis.fetch = fetchImpl;
+  globalThis.setTimeout = (callback) => {
+    fireTimeout = callback;
+    return 1;
+  };
+  globalThis.clearTimeout = () => {};
+
+  try {
+    await task(() => fireTimeout());
+  } finally {
+    globalThis.fetch = originalFetch;
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+  }
+}
+
+function rejectOnAbort(signal, markStarted) {
+  markStarted();
+  return new Promise((_resolve, reject) => {
+    signal.addEventListener('abort', () => {
+      const error = new Error('aborted');
+      error.name = 'AbortError';
+      reject(error);
+    }, { once: true });
+  });
+}
+
+test('fetchJsonWithTimeout aborts while waiting for response headers', async () => {
+  let markStarted;
+  const started = new Promise((resolve) => {
+    markStarted = resolve;
+  });
+
+  await withManualTimeout(
+    async (_url, options) => rejectOnAbort(options.signal, markStarted),
+    async (fireTimeout) => {
+      const request = fetchJsonWithTimeout('/headers');
+      await started;
+      fireTimeout();
+      const result = await request;
+      assert.equal(result.ok, false);
+      assert.equal(result.timedOut, true);
+      assert.equal(result.error.name, 'AbortError');
+    }
+  );
+});
+
+test('fetchJsonWithTimeout aborts while consuming the response JSON body', async () => {
+  let markBodyStarted;
+  const bodyStarted = new Promise((resolve) => {
+    markBodyStarted = resolve;
+  });
+
+  await withManualTimeout(
+    async (_url, options) => ({
+      status: 200,
+      json: () => rejectOnAbort(options.signal, markBodyStarted),
+    }),
+    async (fireTimeout) => {
+      const request = fetchJsonWithTimeout('/body');
+      await bodyStarted;
+      fireTimeout();
+      const result = await request;
+      assert.equal(result.ok, false);
+      assert.equal(result.timedOut, true);
+      assert.equal(result.error.name, 'AbortError');
+    }
+  );
+});

--- a/test/commentPanel.test.js
+++ b/test/commentPanel.test.js
@@ -92,6 +92,31 @@ test('playmode が無い旧状態では mode key をフォールバック利用�
   );
 });
 
+test('プレイリスト再生は残留した単体再生の clip を参照しない', () => {
+  assert.equal(
+    resolveCurrentClipIdFromState({
+      playmode: 'playlist',
+      clip: { clipId: 555 },
+      currentClipOrder: 1,
+      playQueue: [
+        { order: 0, id: 100 },
+        { order: 1, id: 101 },
+      ],
+    }),
+    101
+  );
+});
+
+test('clipId cookie が失効した単体再生は null にする', () => {
+  assert.equal(
+    resolveCurrentClipIdFromState({
+      playmode: 'clip',
+      clip: { title: 'タイトル', starttime: '10', endtime: '20' },
+    }),
+    null
+  );
+});
+
 test('再生モードが無い通常視聴では null にする', () => {
   assert.equal(
     resolveCurrentClipIdFromState({

--- a/test/commentPanel.test.js
+++ b/test/commentPanel.test.js
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { resolveCurrentClipIdFromState } from '../src/content/commentPanel.js';
+
+test('単体再生は clipId を id より優先する', () => {
+  assert.equal(
+    resolveCurrentClipIdFromState({
+      playmode: 'clip',
+      clip: { clipId: 123, id: 999 },
+    }),
+    123
+  );
+});
+
+test('単体再生は id と数値文字列を後方互換として受け付ける', () => {
+  assert.equal(
+    resolveCurrentClipIdFromState({
+      playmode: 'clip',
+      clip: { id: '456' },
+    }),
+    456
+  );
+});
+
+test('プレイリスト再生は currentClipOrder に一致する項目を解決する', () => {
+  assert.equal(
+    resolveCurrentClipIdFromState({
+      playmode: 'playlist',
+      currentClipOrder: '2',
+      playQueue: [
+        { order: 0, id: 100 },
+        { order: 2, clipId: '102', id: 999 },
+      ],
+    }),
+    102
+  );
+});
+
+test('プレイリストの currentClipId は正として利用しない', () => {
+  assert.equal(
+    resolveCurrentClipIdFromState({
+      playmode: 'playlist',
+      currentClipOrder: 3,
+      currentClipId: 777,
+      playQueue: [{ order: 2, id: 100 }],
+    }),
+    null
+  );
+});
+
+test('サーバーIDが無いローカル録画クリップは null にする', () => {
+  assert.equal(
+    resolveCurrentClipIdFromState({
+      playmode: 'clip',
+      clip: {
+        clientItemId: 'local-only',
+        title: 'ローカル録画',
+      },
+    }),
+    null
+  );
+});
+
+test('0・負数・非整数・unsafe integer はクリップIDとして拒否する', () => {
+  for (const clipId of [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, 'abc']) {
+    assert.equal(
+      resolveCurrentClipIdFromState({
+        playmode: 'clip',
+        clip: { clipId },
+      }),
+      null
+    );
+  }
+});
+
+test('playmode が無い旧状態では mode key をフォールバック利用する', () => {
+  assert.equal(
+    resolveCurrentClipIdFromState({
+      playClipSystemKey: 1,
+      clip: { clipId: 88 },
+    }),
+    88
+  );
+  assert.equal(
+    resolveCurrentClipIdFromState({
+      playlistSystemKey: 1,
+      currentClipOrder: 0,
+      playQueue: [{ order: 0, id: 89 }],
+    }),
+    89
+  );
+});
+
+test('再生モードが無い通常視聴では null にする', () => {
+  assert.equal(
+    resolveCurrentClipIdFromState({
+      clip: { clipId: 123 },
+      currentClipId: 123,
+    }),
+    null
+  );
+});

--- a/test/commentPanel.test.js
+++ b/test/commentPanel.test.js
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { resolveCurrentClipIdFromState } from '../src/content/commentPanel.js';
+import {
+  isAmbiguousPostFailure,
+  resolveCurrentClipIdFromState,
+  shouldClearSubmittedDraft,
+} from '../src/content/commentPanel.js';
 
 test('単体再生は clipId を id より優先する', () => {
   assert.equal(
@@ -125,4 +129,23 @@ test('再生モードが無い通常視聴では null にする', () => {
     }),
     null
   );
+});
+
+test('投稿待ちの間に書き換えた次の下書きは消さない', () => {
+  assert.equal(shouldClearSubmittedDraft('送信した本文', '送信した本文'), true);
+  assert.equal(shouldClearSubmittedDraft('次のコメント', '送信した本文'), false);
+});
+
+test('投稿済みか不明な失敗は一覧で確認する', () => {
+  for (const reason of [
+    'invalid_response',
+    'network_error',
+    'timeout',
+    'background_unavailable',
+    'request_failed',
+  ]) {
+    assert.equal(isAmbiguousPostFailure(reason), true);
+  }
+  assert.equal(isAmbiguousPostFailure('validation_error'), false);
+  assert.equal(isAmbiguousPostFailure('unauthorized'), false);
 });

--- a/test/comments.test.js
+++ b/test/comments.test.js
@@ -154,8 +154,20 @@ test('コメント本文を trim し、1〜500文字だけ許可する', () => {
     clipId: 7,
     body: 'a'.repeat(500),
   }).ok, true);
+  assert.equal(validatePostClipCommentInput({
+    clipId: 7,
+    body: '😀'.repeat(500),
+  }).ok, true);
 
-  for (const body of [undefined, null, 123, '', '   ', 'a'.repeat(501)]) {
+  for (const body of [
+    undefined,
+    null,
+    123,
+    '',
+    '   ',
+    'a'.repeat(501),
+    '😀'.repeat(501),
+  ]) {
     const result = validatePostClipCommentInput({ clipId: 7, body });
     assert.equal(result.ok, false);
     assert.equal(result.field, 'body');
@@ -207,6 +219,13 @@ test('successful GET and POST responses require their expected JSON shape', () =
     postResponseFixture(1),
     1
   ), true);
+  assert.equal(isValidCommentsSuccessResponse('GET', getResponseFixture(1, {
+    comments: [commentFixture(1, {
+      userId: null,
+      username: null,
+      body: '😀'.repeat(500),
+    })],
+  }), 1), true);
 
   assert.equal(isValidCommentsSuccessResponse('GET', {}, 1), false);
   assert.equal(isValidCommentsSuccessResponse('GET', getResponseFixture(1, {
@@ -230,6 +249,7 @@ test('comment responses require every field in the API contract', () => {
     { clipId: undefined },
     { clipId: 2 },
     { userId: undefined },
+    { userId: 0 },
     { username: undefined },
     { body: undefined },
     { body: '' },

--- a/test/comments.test.js
+++ b/test/comments.test.js
@@ -3,10 +3,99 @@ import { test } from 'node:test';
 
 import {
   buildCommentsApiUrl,
+  fetchClipComments,
   getCommentsResponseReason,
+  isValidCommentsSuccessResponse,
+  postClipComment,
   validateFetchClipCommentsInput,
   validatePostClipCommentInput,
 } from '../src/background/comments.js';
+import { saveExtensionAuthTokenInBackground } from '../src/background/authState.js';
+import { runExclusive } from '../src/background/sync.js';
+
+function commentFixture(clipId = 1, overrides = {}) {
+  return {
+    id: 10,
+    clipId,
+    userId: 7,
+    username: 'alice',
+    body: 'hello',
+    createdAt: '2026-07-18T09:30:00.000Z',
+    ...overrides,
+  };
+}
+
+function getResponseFixture(clipId = 1, overrides = {}) {
+  return {
+    ok: true,
+    clipId,
+    comments: [commentFixture(clipId)],
+    hasNext: false,
+    nextCursor: null,
+    ...overrides,
+  };
+}
+
+function postResponseFixture(clipId = 1, overrides = {}) {
+  return {
+    ok: true,
+    comment: commentFixture(clipId),
+    ...overrides,
+  };
+}
+
+function jsonResponse(status, data) {
+  return {
+    status,
+    json: async () => data,
+  };
+}
+
+async function withCommentRequestMocks({ state, fetchImpl }, task) {
+  const originalChrome = globalThis.chrome;
+  const originalFetch = globalThis.fetch;
+
+  globalThis.chrome = {
+    runtime: { lastError: null },
+    storage: {
+      local: {
+        get(keys, callback) {
+          const keyList = Array.isArray(keys) ? keys : [keys];
+          callback(Object.fromEntries(
+            keyList
+              .filter((key) => Object.hasOwn(state, key))
+              .map((key) => [key, state[key]])
+          ));
+        },
+        remove(keys, callback) {
+          const keyList = Array.isArray(keys) ? keys : [keys];
+          for (const key of keyList) delete state[key];
+          callback();
+        },
+        set(items, callback) {
+          Object.assign(state, items);
+          callback();
+        },
+      },
+    },
+  };
+  globalThis.fetch = fetchImpl;
+
+  try {
+    await task();
+  } finally {
+    if (originalChrome === undefined) {
+      delete globalThis.chrome;
+    } else {
+      globalThis.chrome = originalChrome;
+    }
+    if (originalFetch === undefined) {
+      delete globalThis.fetch;
+    } else {
+      globalThis.fetch = originalFetch;
+    }
+  }
+}
 
 test('コメント一覧入力を正規化し、limit の既定値を設定する', () => {
   assert.deepEqual(validateFetchClipCommentsInput({ clipId: ' 42 ' }), {
@@ -97,4 +186,338 @@ test('HTTP statusをコメントUI向けreasonへ変換する', () => {
   assert.equal(getCommentsResponseReason(403), 'forbidden');
   assert.equal(getCommentsResponseReason(404), 'not_found');
   assert.equal(getCommentsResponseReason(500), 'request_failed');
+});
+
+test('successful GET and POST responses require their expected JSON shape', () => {
+  assert.equal(isValidCommentsSuccessResponse(
+    'GET',
+    getResponseFixture(1),
+    1
+  ), true);
+  assert.equal(isValidCommentsSuccessResponse('GET', getResponseFixture(1, {
+    comments: [
+      commentFixture(1, { id: 11 }),
+      commentFixture(1, { id: 10, username: null }),
+    ],
+    hasNext: true,
+    nextCursor: 10,
+  }), 1), true);
+  assert.equal(isValidCommentsSuccessResponse(
+    'POST',
+    postResponseFixture(1),
+    1
+  ), true);
+
+  assert.equal(isValidCommentsSuccessResponse('GET', {}, 1), false);
+  assert.equal(isValidCommentsSuccessResponse('GET', getResponseFixture(1, {
+    ok: false,
+  }), 1), false);
+  assert.equal(isValidCommentsSuccessResponse('GET', getResponseFixture(2), 1), false);
+  assert.equal(isValidCommentsSuccessResponse('GET', getResponseFixture(1, {
+    hasNext: true,
+    nextCursor: null,
+  }), 1), false);
+  assert.equal(isValidCommentsSuccessResponse('GET', getResponseFixture(1, {
+    nextCursor: 10,
+  }), 1), false);
+  assert.equal(isValidCommentsSuccessResponse('POST', { ok: true, comment: {} }, 1), false);
+  assert.equal(isValidCommentsSuccessResponse('POST', null, 1), false);
+});
+
+test('comment responses require every field in the API contract', () => {
+  const invalidOverrides = [
+    { id: undefined },
+    { clipId: undefined },
+    { clipId: 2 },
+    { userId: undefined },
+    { username: undefined },
+    { body: undefined },
+    { body: '' },
+    { body: '   ' },
+    { body: 'a'.repeat(501) },
+    { createdAt: undefined },
+    { createdAt: 'not-a-date' },
+    { createdAt: '01/02/2026' },
+  ];
+
+  for (const override of invalidOverrides) {
+    assert.equal(isValidCommentsSuccessResponse('POST', postResponseFixture(1, {
+      comment: commentFixture(1, override),
+    }), 1), false, JSON.stringify(override));
+  }
+});
+
+test('malformed success JSON is returned as invalid_response', async () => {
+  const state = {
+    extensionInstanceId: 'instance-id',
+    extensionAuthToken: 'token',
+  };
+
+  await withCommentRequestMocks({
+    state,
+    fetchImpl: async () => jsonResponse(200, {}),
+  }, async () => {
+    assert.deepEqual(await fetchClipComments({ clipId: 1 }), {
+      ok: false,
+      reason: 'invalid_response',
+      status: 200,
+    });
+  });
+
+  await withCommentRequestMocks({
+    state,
+    fetchImpl: async () => jsonResponse(201, { comment: {} }),
+  }, async () => {
+    assert.deepEqual(await postClipComment({ clipId: 1, body: 'hello' }), {
+      ok: false,
+      reason: 'invalid_response',
+      status: 201,
+    });
+  });
+});
+
+test('GET accepts only 200 and POST accepts only 201', async () => {
+  const state = {
+    extensionInstanceId: 'instance-id',
+    extensionAuthToken: 'token',
+  };
+
+  await withCommentRequestMocks({
+    state,
+    fetchImpl: async () => jsonResponse(201, getResponseFixture(1)),
+  }, async () => {
+    assert.deepEqual(await fetchClipComments({ clipId: 1 }), {
+      ok: false,
+      reason: 'request_failed',
+      status: 201,
+    });
+  });
+
+  await withCommentRequestMocks({
+    state,
+    fetchImpl: async () => jsonResponse(200, postResponseFixture(1)),
+  }, async () => {
+    assert.deepEqual(await postClipComment({ clipId: 1, body: 'hello' }), {
+      ok: false,
+      reason: 'request_failed',
+      status: 200,
+    });
+  });
+});
+
+test('a stale 401 does not clear a newly stored auth token', async () => {
+  const state = {
+    extensionInstanceId: 'instance-id',
+    extensionAuthToken: 'old-token',
+    extensionTokenExpiresAt: '2099-01-01T00:00:00.000Z',
+    extensionLinked: true,
+  };
+
+  await withCommentRequestMocks({
+    state,
+    fetchImpl: async () => {
+      state.extensionAuthToken = 'new-token';
+      return jsonResponse(401, { message: 'expired' });
+    },
+  }, async () => {
+    const result = await fetchClipComments({ clipId: 1 });
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, 'stale_unauthorized');
+    assert.equal(result.message, 'expired');
+  });
+
+  assert.equal(state.extensionAuthToken, 'new-token');
+  assert.equal(state.extensionLinked, true);
+  assert.equal(state.extensionTokenExpiresAt, '2099-01-01T00:00:00.000Z');
+});
+
+test('a 401 for the current token clears auth state', async () => {
+  const state = {
+    extensionInstanceId: 'instance-id',
+    extensionAuthToken: 'current-token',
+    extensionTokenExpiresAt: '2099-01-01T00:00:00.000Z',
+    extensionTokenRefreshBackoff: { failureCount: 1 },
+    extensionLinked: true,
+  };
+
+  await withCommentRequestMocks({
+    state,
+    fetchImpl: async () => jsonResponse(401, null),
+  }, async () => {
+    const result = await fetchClipComments({ clipId: 1 });
+    assert.equal(result.reason, 'unauthorized');
+  });
+
+  assert.equal(Object.hasOwn(state, 'extensionAuthToken'), false);
+  assert.equal(Object.hasOwn(state, 'extensionTokenExpiresAt'), false);
+  assert.equal(Object.hasOwn(state, 'extensionTokenRefreshBackoff'), false);
+  assert.equal(state.extensionLinked, false);
+});
+
+test('a re-link queued during an old-token 401 is saved after the clear', async () => {
+  const state = {
+    extensionInstanceId: 'instance-id',
+    extensionAuthToken: 'old-token',
+    extensionLinked: true,
+  };
+  let resolveFetch;
+  let markFetchStarted;
+  const fetchStarted = new Promise((resolve) => {
+    markFetchStarted = resolve;
+  });
+
+  await withCommentRequestMocks({
+    state,
+    fetchImpl: async () => {
+      markFetchStarted();
+      return new Promise((resolve) => {
+        resolveFetch = resolve;
+      });
+    },
+  }, async () => {
+    const commentsPromise = fetchClipComments({ clipId: 1 });
+    await fetchStarted;
+
+    const savePromise = saveExtensionAuthTokenInBackground({
+      extensionInstanceId: 'instance-id',
+      extensionAuthToken: 'new-token',
+      expiresAt: '2099-01-01T00:00:00.000Z',
+    });
+    await Promise.resolve();
+    assert.equal(state.extensionAuthToken, 'old-token');
+
+    resolveFetch(jsonResponse(401, { message: 'expired' }));
+    const [commentsResult, saveResult] = await Promise.all([
+      commentsPromise,
+      savePromise,
+    ]);
+    assert.equal(commentsResult.reason, 'unauthorized');
+    assert.deepEqual(saveResult, { ok: true });
+  });
+
+  assert.equal(state.extensionAuthToken, 'new-token');
+  assert.equal(state.extensionLinked, true);
+  assert.equal(state.extensionTokenExpiresAt, '2099-01-01T00:00:00.000Z');
+});
+
+test('a re-link queued first is visible to the following comments request', async () => {
+  const state = {
+    extensionInstanceId: 'instance-id',
+    extensionAuthToken: 'old-token',
+    extensionLinked: true,
+  };
+  let authorization;
+
+  await withCommentRequestMocks({
+    state,
+    fetchImpl: async (_url, options) => {
+      authorization = options.headers.Authorization;
+      return jsonResponse(401, null);
+    },
+  }, async () => {
+    const savePromise = saveExtensionAuthTokenInBackground({
+      extensionInstanceId: 'instance-id',
+      extensionAuthToken: 'new-token',
+    });
+    const commentsPromise = fetchClipComments({ clipId: 1 });
+    const [saveResult, commentsResult] = await Promise.all([
+      savePromise,
+      commentsPromise,
+    ]);
+    assert.deepEqual(saveResult, { ok: true });
+    assert.equal(commentsResult.reason, 'unauthorized');
+  });
+
+  assert.equal(authorization, 'Bearer new-token');
+  assert.equal(Object.hasOwn(state, 'extensionAuthToken'), false);
+  assert.equal(state.extensionLinked, false);
+});
+
+test('a stalled comments request is aborted and returned as timeout', async () => {
+  const state = {
+    extensionInstanceId: 'instance-id',
+    extensionAuthToken: 'token',
+  };
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  const originalWarn = console.warn;
+
+  globalThis.setTimeout = (callback) => {
+    queueMicrotask(callback);
+    return 1;
+  };
+  globalThis.clearTimeout = () => {};
+  console.warn = () => {};
+
+  try {
+    await withCommentRequestMocks({
+      state,
+      fetchImpl: async (_url, options) => new Promise((_resolve, reject) => {
+        const rejectAsAborted = () => {
+          const error = new Error('aborted');
+          error.name = 'AbortError';
+          reject(error);
+        };
+        if (options.signal.aborted) {
+          rejectAsAborted();
+        } else {
+          options.signal.addEventListener('abort', rejectAsAborted, { once: true });
+        }
+      }),
+    }, async () => {
+      assert.deepEqual(await fetchClipComments({ clipId: 1 }), {
+        ok: false,
+        reason: 'timeout',
+      });
+    });
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+    console.warn = originalWarn;
+  }
+});
+
+test('the comments deadline includes time waiting for the exclusive queue', async () => {
+  const state = {
+    extensionInstanceId: 'instance-id',
+    extensionAuthToken: 'token',
+  };
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  let releaseBlocker;
+  const blocker = runExclusive(() => new Promise((resolve) => {
+    releaseBlocker = resolve;
+  }));
+  let fetchCalls = 0;
+
+  globalThis.setTimeout = (callback) => {
+    queueMicrotask(callback);
+    return 1;
+  };
+  globalThis.clearTimeout = () => {};
+
+  try {
+    await withCommentRequestMocks({
+      state,
+      fetchImpl: async () => {
+        fetchCalls += 1;
+        return jsonResponse(200, getResponseFixture(1));
+      },
+    }, async () => {
+      assert.deepEqual(await fetchClipComments({ clipId: 1 }), {
+        ok: false,
+        reason: 'timeout',
+      });
+      assert.equal(fetchCalls, 0);
+
+      releaseBlocker();
+      await blocker;
+      await Promise.resolve();
+      assert.equal(fetchCalls, 0);
+    });
+  } finally {
+    releaseBlocker?.();
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+  }
 });

--- a/test/comments.test.js
+++ b/test/comments.test.js
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  buildCommentsApiUrl,
+  getCommentsResponseReason,
+  validateFetchClipCommentsInput,
+  validatePostClipCommentInput,
+} from '../src/background/comments.js';
+
+test('コメント一覧入力を正規化し、limit の既定値を設定する', () => {
+  assert.deepEqual(validateFetchClipCommentsInput({ clipId: ' 42 ' }), {
+    ok: true,
+    value: {
+      clipId: 42,
+      limit: 20,
+    },
+  });
+
+  assert.deepEqual(validateFetchClipCommentsInput({
+    clipId: 42,
+    cursor: '9',
+    limit: '100',
+  }), {
+    ok: true,
+    value: {
+      clipId: 42,
+      cursor: 9,
+      limit: 100,
+    },
+  });
+});
+
+test('コメント一覧入力の不正な整数と limit を拒否する', () => {
+  for (const clipId of [undefined, null, true, 0, -1, 1.5, '1.5', 'abc']) {
+    const result = validateFetchClipCommentsInput({ clipId });
+    assert.equal(result.ok, false);
+    assert.equal(result.field, 'clipId');
+  }
+
+  for (const limit of [0, 101, 1.5, 'abc', null]) {
+    const result = validateFetchClipCommentsInput({ clipId: 1, limit });
+    assert.equal(result.ok, false);
+    assert.equal(result.field, 'limit');
+  }
+
+  const cursorResult = validateFetchClipCommentsInput({ clipId: 1, cursor: 0 });
+  assert.equal(cursorResult.ok, false);
+  assert.equal(cursorResult.field, 'cursor');
+});
+
+test('コメント本文を trim し、1〜500文字だけ許可する', () => {
+  assert.deepEqual(validatePostClipCommentInput({
+    clipId: '7',
+    body: '  hello  ',
+  }), {
+    ok: true,
+    value: {
+      clipId: 7,
+      body: 'hello',
+    },
+  });
+
+  assert.equal(validatePostClipCommentInput({
+    clipId: 7,
+    body: 'a'.repeat(500),
+  }).ok, true);
+
+  for (const body of [undefined, null, 123, '', '   ', 'a'.repeat(501)]) {
+    const result = validatePostClipCommentInput({ clipId: 7, body });
+    assert.equal(result.ok, false);
+    assert.equal(result.field, 'body');
+  }
+});
+
+test('コメントAPI URLは認証instanceIdとページネーションだけをqueryに含める', () => {
+  const url = new URL(buildCommentsApiUrl({
+    clipId: 123,
+    cursor: 456,
+    limit: 20,
+  }, '11111111-1111-4111-8111-111111111111'));
+
+  assert.equal(url.pathname, '/api/extension/clips/123/comments');
+  assert.equal(
+    url.searchParams.get('extensionInstanceId'),
+    '11111111-1111-4111-8111-111111111111'
+  );
+  assert.equal(url.searchParams.get('cursor'), '456');
+  assert.equal(url.searchParams.get('limit'), '20');
+});
+
+test('HTTP statusをコメントUI向けreasonへ変換する', () => {
+  assert.equal(getCommentsResponseReason(200), null);
+  assert.equal(getCommentsResponseReason(201), null);
+  assert.equal(getCommentsResponseReason(400), 'validation_error');
+  assert.equal(getCommentsResponseReason(401), 'unauthorized');
+  assert.equal(getCommentsResponseReason(403), 'forbidden');
+  assert.equal(getCommentsResponseReason(404), 'not_found');
+  assert.equal(getCommentsResponseReason(500), 'request_failed');
+});

--- a/test/content/common.test.mjs
+++ b/test/content/common.test.mjs
@@ -25,6 +25,11 @@ class FakeEventTarget {
       listener(event);
     }
   }
+
+  dispatchEvent(event) {
+    this.dispatch(event);
+    return true;
+  }
 }
 
 class FakeElement extends FakeEventTarget {
@@ -39,6 +44,8 @@ class FakeElement extends FakeEventTarget {
       transition: '',
       width: '',
     };
+    this.dataset = {};
+    this.className = '';
     this.id = '';
     this.textContent = '';
     this.value = '';
@@ -99,8 +106,22 @@ class FakeDocument extends FakeEventTarget {
     return visit(this.body);
   }
 
-  querySelector() {
-    return null;
+  querySelector(selector) {
+    const visit = (element) => {
+      if (
+        selector.startsWith('.') &&
+        element.className.split(/\s+/).includes(selector.slice(1))
+      ) {
+        return element;
+      }
+      if (selector === element.tagName.toLowerCase()) return element;
+      for (const child of element.children) {
+        const match = visit(child);
+        if (match) return match;
+      }
+      return null;
+    };
+    return visit(this.body);
   }
 }
 
@@ -113,10 +134,15 @@ function createKeyboardEvent(target) {
     repeat: false,
     defaultPrevented: false,
     propagationStopped: false,
+    immediatePropagationStopped: false,
     preventDefault() {
       this.defaultPrevented = true;
     },
     stopPropagation() {
+      this.propagationStopped = true;
+    },
+    stopImmediatePropagation() {
+      this.immediatePropagationStopped = true;
       this.propagationStopped = true;
     },
   };
@@ -253,4 +279,96 @@ test('Enter submits only from the name input', async () => {
 
   assert.equal(saveCount, 1);
   assert.equal(inputEnter.defaultPrevented, true);
+  assert.equal(inputEnter.immediatePropagationStopped, true);
+});
+
+test('closeMemoSidebar fully tears down the active session', async () => {
+  const { document, window } = installDom();
+  const { closeMemoSidebar, MEMO_SIDEBAR_ID, openMemoSidebar } =
+    await loadCommonModule();
+  const player = document.createElement('video');
+  player.style.width = '70%';
+  let closeCount = 0;
+
+  openMemoSidebar({
+    videoPlayer: player,
+    onClose: () => {
+      closeCount += 1;
+    },
+  });
+
+  assert.equal(player.style.width, 'calc(100% - 20%)');
+  assert.equal(window.listeners.get('keydown')?.size, 1);
+  assert.equal(document.listeners.get('focusin')?.size, 1);
+
+  assert.equal(closeMemoSidebar(), true);
+  assert.equal(document.getElementById(MEMO_SIDEBAR_ID), null);
+  assert.equal(player.style.width, '70%');
+  assert.equal(window.listeners.get('keydown')?.size, 0);
+  assert.equal(document.listeners.get('focusin')?.size, 0);
+  assert.equal(closeCount, 1);
+  assert.equal(closeMemoSidebar(), false);
+});
+
+test('superseding a memo session does not call its close callback', async () => {
+  const { document } = installDom();
+  const { closeMemoSidebar, openMemoSidebar } = await loadCommonModule();
+  const player = document.createElement('video');
+  let firstCloseCount = 0;
+
+  openMemoSidebar({
+    videoPlayer: player,
+    onClose: () => {
+      firstCloseCount += 1;
+    },
+  });
+  openMemoSidebar({ videoPlayer: player });
+
+  assert.equal(firstCloseCount, 0);
+  closeMemoSidebar();
+});
+
+test('opening a memo requests that the comment panel close', async () => {
+  const { document, window } = installDom();
+  const {
+    CLOSE_COMMENT_PANEL_EVENT,
+    closeMemoSidebar,
+    openMemoSidebar,
+  } = await loadCommonModule();
+  const player = document.createElement('video');
+  let closeRequestCount = 0;
+  window.addEventListener(CLOSE_COMMENT_PANEL_EVENT, () => {
+    closeRequestCount += 1;
+  });
+
+  openMemoSidebar({ videoPlayer: player });
+
+  assert.equal(closeRequestCount, 1);
+  closeMemoSidebar();
+});
+
+test('opening a memo after the Netflix clip list preserves the true player width', async () => {
+  const { document } = installDom();
+  const { closeMemoSidebar, MEMO_SIDEBAR_ID, openMemoSidebar } =
+    await loadCommonModule();
+  const player = document.createElement('div');
+  player.className = 'watch-video--player-view';
+  player.style.width = '65%';
+  document.body.appendChild(player);
+
+  const clipList = document.createElement('div');
+  clipList.id = MEMO_SIDEBAR_ID;
+  clipList.dataset.sidebarType = 'clip-list';
+  clipList.dataset.originalPlayerWidth = player.style.width;
+  document.body.appendChild(clipList);
+  player.style.width = 'calc(100% - 30%)';
+
+  const memo = openMemoSidebar({ videoPlayer: player });
+
+  assert.notEqual(memo, null);
+  assert.equal(clipList.parentElement, null);
+  assert.equal(player.style.width, 'calc(100% - 20%)');
+
+  closeMemoSidebar();
+  assert.equal(player.style.width, '65%');
 });

--- a/test/content/integrationHelpers.test.mjs
+++ b/test/content/integrationHelpers.test.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { setTextContentIfChanged } from '../../src/content/domUpdates.js';
+import { commitSelectedClip } from '../../src/content/netflixClipSelection.js';
+
+test('unchanged Disney+ button labels do not rewrite their text node', () => {
+  let textContent = 'コメント';
+  let writeCount = 0;
+  const label = {
+    get textContent() {
+      return textContent;
+    },
+    set textContent(value) {
+      textContent = value;
+      writeCount += 1;
+    },
+  };
+
+  assert.equal(setTextContentIfChanged(label, 'コメント'), false);
+  assert.equal(writeCount, 0);
+  assert.equal(setTextContentIfChanged(label, 'コメントを見る'), true);
+  assert.equal(writeCount, 1);
+  assert.equal(textContent, 'コメントを見る');
+});
+
+test('Netflix selection stores one complete mode update before opening', async () => {
+  let finishStorage;
+  const events = [];
+  const writes = [];
+  const storage = {
+    set(value) {
+      events.push('storage:start');
+      writes.push(value);
+      return new Promise((resolve) => {
+        finishStorage = () => {
+          events.push('storage:end');
+          resolve();
+        };
+      });
+    },
+  };
+
+  const committing = commitSelectedClip({
+    data: { id: 42, title: 'Example' },
+    requestedClipId: 99,
+    ownerNonce: 'owner-nonce-42',
+    storage,
+    setCookies: () => events.push('cookies'),
+    openClip: () => events.push('open'),
+  });
+
+  assert.deepEqual(events, ['storage:start']);
+  assert.deepEqual(writes, [
+    {
+      clip: { id: 42, title: 'Example', clipId: 42 },
+      currentClipId: 42,
+      currentClipOrder: 0,
+      playClipSystemKey: 1,
+      playlistSystemKey: 0,
+      playmode: 'clip',
+      playbackOwnerNonce: 'owner-nonce-42',
+    },
+  ]);
+
+  finishStorage();
+  const selectedClip = await committing;
+
+  assert.deepEqual(events, ['storage:start', 'storage:end', 'cookies', 'open']);
+  assert.deepEqual(selectedClip, { id: 42, title: 'Example', clipId: 42 });
+});

--- a/test/content/integrationHelpers.test.mjs
+++ b/test/content/integrationHelpers.test.mjs
@@ -42,7 +42,15 @@ test('Netflix selection stores one complete mode update before opening', async (
   };
 
   const committing = commitSelectedClip({
-    data: { id: 42, title: 'Example' },
+    data: {
+      id: 42,
+      title: 'Example',
+      service: 'netflix',
+      url: '/watch/42',
+      StartTime: 10,
+      EndTime: 20,
+      ignored: 'not persisted',
+    },
     requestedClipId: 99,
     ownerNonce: 'owner-nonce-42',
     storage,
@@ -53,7 +61,14 @@ test('Netflix selection stores one complete mode update before opening', async (
   assert.deepEqual(events, ['storage:start']);
   assert.deepEqual(writes, [
     {
-      clip: { id: 42, title: 'Example', clipId: 42 },
+      clip: {
+        clipId: 42,
+        service: 'netflix',
+        url: 'https://www.netflix.com/watch/42',
+        startTime: 10,
+        endTime: 20,
+        title: 'Example',
+      },
       currentClipId: 42,
       currentClipOrder: 0,
       playClipSystemKey: 1,
@@ -67,5 +82,12 @@ test('Netflix selection stores one complete mode update before opening', async (
   const selectedClip = await committing;
 
   assert.deepEqual(events, ['storage:start', 'storage:end', 'cookies', 'open']);
-  assert.deepEqual(selectedClip, { id: 42, title: 'Example', clipId: 42 });
+  assert.deepEqual(selectedClip, {
+    clipId: 42,
+    service: 'netflix',
+    url: 'https://www.netflix.com/watch/42',
+    startTime: 10,
+    endTime: 20,
+    title: 'Example',
+  });
 });

--- a/test/getClipData.test.js
+++ b/test/getClipData.test.js
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const listeners = {};
+const postedMessages = [];
+const runtimeMessages = [];
+const scheduledTasks = [];
+let storedQueue = null;
+let runtimeResponse = { ok: true };
+
+globalThis.window = {
+  location: {
+    origin: 'http://localhost:3000',
+    href: 'http://localhost:3000/clips',
+  },
+  addEventListener(type, listener) {
+    listeners[type] = listener;
+  },
+  postMessage(message, targetOrigin) {
+    postedMessages.push({ message, targetOrigin });
+  },
+};
+globalThis.document = { cookie: '' };
+globalThis.localStorage = {
+  getItem(key) {
+    return key === 'playQueue' ? storedQueue : null;
+  },
+};
+globalThis.chrome = {
+  runtime: {
+    lastError: null,
+    sendMessage(message, callback) {
+      runtimeMessages.push(message);
+      callback(runtimeResponse);
+    },
+  },
+};
+globalThis.setTimeout = (callback, delay) => {
+  scheduledTasks.push({ callback, delay });
+  return scheduledTasks.length;
+};
+
+await import('../src/content/getClipData.js');
+
+function resetObservations() {
+  postedMessages.length = 0;
+  runtimeMessages.length = 0;
+  scheduledTasks.length = 0;
+  storedQueue = null;
+  runtimeResponse = { ok: true };
+  window.location.href = 'http://localhost:3000/clips';
+}
+
+function messageEvent(data) {
+  return {
+    source: window,
+    origin: window.location.origin,
+    data,
+  };
+}
+
+test('SET_CLIP_DATA rejects a missing payload without contacting background', async () => {
+  resetObservations();
+
+  await listeners.message(messageEvent({
+    type: 'SET_CLIP_DATA',
+    requestId: 'missing-payload',
+  }));
+
+  assert.equal(runtimeMessages.length, 0);
+  assert.equal(scheduledTasks.length, 0);
+  assert.deepEqual(postedMessages.at(-1), {
+    targetOrigin: 'http://localhost:3000',
+    message: {
+      type: 'EXTENSION_PLAYBACK_HANDOFF_RESULT',
+      source: 'SET_CLIP_DATA',
+      ok: false,
+      reason: 'invalid_payload',
+      field: 'clip',
+      requestId: 'missing-payload',
+    },
+  });
+});
+
+test('invalid playlist data never reaches background or navigation', async () => {
+  resetObservations();
+  storedQueue = JSON.stringify([{ id: 1, service: 'youtube' }]);
+
+  await listeners.message(messageEvent({ type: 'PLAY_PLAYLIST_START' }));
+
+  assert.equal(runtimeMessages.length, 0);
+  assert.equal(scheduledTasks.length, 0);
+  assert.equal(window.location.href, 'http://localhost:3000/clips');
+  assert.equal(postedMessages.at(-1).message.ok, false);
+});
+
+test('failed BEGIN_PLAYBACK_HANDOFF reports failure and does not navigate', async () => {
+  resetObservations();
+  storedQueue = JSON.stringify([
+    {
+      id: 1,
+      service: 'netflix',
+      url: '/watch/1',
+      startTime: 10,
+      endTime: 20,
+    },
+  ]);
+  runtimeResponse = { ok: false, reason: 'invalid_handoff' };
+
+  await listeners.message(messageEvent({
+    type: 'PLAY_PLAYLIST_START',
+    requestId: 'handoff-failure',
+  }));
+
+  assert.equal(runtimeMessages.length, 1);
+  assert.equal(runtimeMessages[0].type, 'BEGIN_PLAYBACK_HANDOFF');
+  assert.equal(scheduledTasks.length, 0);
+  assert.equal(window.location.href, 'http://localhost:3000/clips');
+  assert.deepEqual(postedMessages.at(-1).message, {
+    type: 'EXTENSION_PLAYBACK_HANDOFF_RESULT',
+    source: 'PLAY_PLAYLIST_START',
+    ok: false,
+    reason: 'handoff_failed',
+    requestId: 'handoff-failure',
+  });
+});

--- a/test/icons.test.js
+++ b/test/icons.test.js
@@ -8,8 +8,8 @@ import { test } from "node:test";
 
 import { ICON_NAMES, createIcon, isIconName } from "../src/ui/icons.js";
 
-test("ICON_NAMES は統合した 3 アイコンを含む", () => {
-  assert.deepEqual([...ICON_NAMES].sort(), ["list", "loop", "record"]);
+test("ICON_NAMES は統合した 4 アイコンを含む", () => {
+  assert.deepEqual([...ICON_NAMES].sort(), ["comment", "list", "loop", "record"]);
 });
 
 test("ICON_NAMES は凍結されている", () => {
@@ -17,14 +17,12 @@ test("ICON_NAMES は凍結されている", () => {
 });
 
 test("isIconName は既知のアイコン名を true にする", () => {
-  for (const name of ["record", "loop", "list"]) {
+  for (const name of ["record", "loop", "list", "comment"]) {
     assert.equal(isIconName(name), true);
   }
 });
 
 test("isIconName は未知のアイコン名を false にする", () => {
-  // comment は Phase 2 で追加予定。現時点では未知扱い。
-  assert.equal(isIconName("comment"), false);
   assert.equal(isIconName("bogus"), false);
   assert.equal(isIconName(""), false);
   assert.equal(isIconName("toString"), false); // プロトタイプ経由で誤検知しない

--- a/test/manifest.test.mjs
+++ b/test/manifest.test.mjs
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const manifest = JSON.parse(
+  await readFile(new URL('../manifest.json', import.meta.url), 'utf8')
+);
+
+test('Disney+ installs the history hook in the page MAIN world before the content bundle', () => {
+  const historyHook = manifest.content_scripts.find(
+    (entry) =>
+      entry.matches?.includes('https://www.disneyplus.com/*') &&
+      entry.js?.includes('src/util/history_change.js')
+  );
+
+  assert.ok(historyHook);
+  assert.equal(historyHook.world, 'MAIN');
+  assert.equal(historyHook.run_at, 'document_start');
+
+  const disneyBundle = manifest.content_scripts.find((entry) =>
+    entry.js?.includes('dist/content_disney.js')
+  );
+  assert.ok(disneyBundle);
+  assert.equal(disneyBundle.run_at, 'document_idle');
+});

--- a/test/playbackBridgeValidation.test.js
+++ b/test/playbackBridgeValidation.test.js
@@ -1,0 +1,257 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  MAX_PLAYBACK_PAYLOAD_BYTES,
+  MAX_PLAYLIST_ITEMS,
+  normalizeClipInput,
+  normalizeClipSelectedInput,
+  normalizePlaybackSnapshot,
+  normalizePlaylistInput,
+  normalizePlaylistJson,
+  parsePlaybackCookies,
+} from '../src/shared/playbackBridgeValidation.js';
+
+function clipInput(overrides = {}) {
+  return {
+    id: 123,
+    service: 'Netflix',
+    url: '/watch/8001?track=abc',
+    startTime: 10,
+    endTime: 20,
+    title: ' Sample title ',
+    ...overrides,
+  };
+}
+
+test('playback cookies use a whitelist and preserve equals signs in values', () => {
+  const parsed = parsePlaybackCookies(
+    'title=Example; sessionToken=secret; url=%2Fwatch%2F1%3Fsig%3Da%3Db; service=netflix'
+  );
+
+  assert.deepEqual(parsed, {
+    values: {
+      title: 'Example',
+      url: '/watch/1?sig=a=b',
+      service: 'netflix',
+    },
+    invalidKeys: [],
+  });
+  assert.equal('sessionToken' in parsed.values, false);
+});
+
+test('malformed percent encoding invalidates only its whitelisted cookie', () => {
+  const parsed = parsePlaybackCookies(
+    'title=%E0%A4%A; sessionToken=%E0%A4%A; service=netflix'
+  );
+
+  assert.deepEqual(parsed.values, { service: 'netflix' });
+  assert.deepEqual(parsed.invalidKeys, ['title']);
+});
+
+test('clipSelected normalizes legacy cookies and uses detail clipId as authority', () => {
+  const result = normalizeClipSelectedInput(
+    [
+      'title=%20Example%20',
+      'starttime=10.5',
+      'endtime=20',
+      'url=%2Fwatch%2F8001',
+      'service=Netflix',
+      'clipId=123',
+      'unrelated=secret',
+    ].join('; '),
+    { clipId: '123' }
+  );
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.value, {
+    clipId: 123,
+    service: 'netflix',
+    url: 'https://www.netflix.com/watch/8001',
+    startTime: 10.5,
+    endTime: 20,
+    title: 'Example',
+  });
+  assert.equal('unrelated' in result.value, false);
+  assert.equal('starttime' in result.value, false);
+});
+
+test('clipSelected rejects a missing or mismatched detail clipId', () => {
+  const cookies = 'clipId=123; service=netflix; url=%2Fwatch%2F1; starttime=1; endtime=2';
+
+  assert.deepEqual(normalizeClipSelectedInput(cookies, {}), {
+    ok: false,
+    reason: 'invalid_clip_id',
+    field: 'clipId',
+  });
+  assert.deepEqual(normalizeClipSelectedInput(cookies, { clipId: 456 }), {
+    ok: false,
+    reason: 'clip_id_mismatch',
+    field: 'clipId',
+  });
+  assert.equal(
+    normalizeClipSelectedInput(
+      'clipId=%E0%A4%A; service=netflix; url=%2Fwatch%2F1; starttime=1; endtime=2',
+      { clipId: 123 }
+    ).reason,
+    'invalid_clip_id'
+  );
+});
+
+test('single clip input rejects missing payload and invalid clip IDs', () => {
+  assert.equal(normalizeClipInput(undefined).reason, 'invalid_payload');
+  assert.equal(normalizeClipInput(new Date()).reason, 'invalid_payload');
+  for (const clipId of [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, '1.5', 'abc', '']) {
+    const result = normalizeClipInput(clipInput({ id: undefined, clipId }));
+    assert.equal(result.reason, 'invalid_clip_id', String(clipId));
+  }
+});
+
+test('single clip input rejects unsupported services and cross-service URLs', () => {
+  assert.equal(
+    normalizeClipInput(clipInput({ service: 'youtube' })).reason,
+    'invalid_service'
+  );
+  for (const url of [
+    'http://www.netflix.com/watch/1',
+    'https://evil.example/watch/1',
+    'https://user:pass@www.netflix.com/watch/1',
+  ]) {
+    assert.equal(normalizeClipInput(clipInput({ url })).reason, 'invalid_url');
+  }
+});
+
+test('single clip input accepts the localhost Disney+ service code', () => {
+  const result = normalizeClipInput(clipInput({
+    service: 'DISNEY_PLUS',
+    url: 'https://www.disneyplus.com/ja-jp/play/example',
+  }));
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.service, 'disneyplus');
+});
+
+test('single clip input requires a finite increasing time range', () => {
+  for (const overrides of [
+    { startTime: Number.NaN },
+    { startTime: Number.POSITIVE_INFINITY },
+    { startTime: -1 },
+    { startTime: 20, endTime: 20 },
+    { startTime: 21, endTime: 20 },
+    { startTime: '', endTime: 20 },
+  ]) {
+    assert.equal(
+      normalizeClipInput(clipInput(overrides)).reason,
+      'invalid_time_range'
+    );
+  }
+});
+
+test('playlist fills only missing order and removes unknown item fields', () => {
+  const result = normalizePlaylistInput([
+    clipInput({ id: 1, Subtitles: 'not persisted' }),
+    clipInput({ id: 2, order: '7', service: 'disney+', url: '/video/example' }),
+  ]);
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value[0].order, 0);
+  assert.equal(result.value[1].order, 7);
+  assert.equal(result.value[1].service, 'disneyplus');
+  assert.equal(result.value[1].url, 'https://www.disneyplus.com/video/example');
+  assert.equal('Subtitles' in result.value[0], false);
+  assert.equal(result.value[0].id, result.value[0].clipId);
+});
+
+test('playlist rejects invalid and duplicate explicit order values', () => {
+  assert.equal(
+    normalizePlaylistInput([clipInput({ id: 1, order: -1 })]).reason,
+    'invalid_order'
+  );
+  assert.equal(
+    normalizePlaylistInput([clipInput({ id: 1, order: null })]).reason,
+    'invalid_order'
+  );
+  const duplicate = normalizePlaylistInput([
+    clipInput({ id: 1, order: 2 }),
+    clipInput({ id: 2, order: 2 }),
+  ]);
+  assert.deepEqual(duplicate, {
+    ok: false,
+    reason: 'duplicate_order',
+    field: 'order',
+    index: 1,
+  });
+});
+
+test('playlist rejects empty, excessive count, malformed JSON, and raw byte excess', () => {
+  assert.equal(normalizePlaylistInput([]).reason, 'empty_playlist');
+  assert.equal(
+    normalizePlaylistInput(
+      Array.from({ length: MAX_PLAYLIST_ITEMS + 1 }, (_, index) =>
+        clipInput({ id: index + 1 })
+      )
+    ).reason,
+    'queue_too_large'
+  );
+  assert.equal(normalizePlaylistJson('{').reason, 'invalid_payload');
+  assert.equal(
+    normalizePlaylistJson('x'.repeat(MAX_PLAYBACK_PAYLOAD_BYTES + 1)).reason,
+    'payload_too_large'
+  );
+});
+
+test('playlist rejects normalized data larger than the byte limit', () => {
+  const longPath = `/watch/${'a'.repeat(4000)}`;
+  const queue = Array.from({ length: MAX_PLAYLIST_ITEMS }, (_, index) =>
+    clipInput({
+      id: index + 1,
+      url: longPath,
+      title: 't'.repeat(500),
+      clipname: 'c'.repeat(500),
+      user: 'u'.repeat(200),
+      username: 'n'.repeat(200),
+      epnumber: 'e'.repeat(200),
+    })
+  );
+
+  assert.equal(normalizePlaylistInput(queue).reason, 'payload_too_large');
+});
+
+test('background snapshot normalization keeps only canonical clip data', () => {
+  const result = normalizePlaybackSnapshot({
+    context: { mode: 'clip', clipId: 123 },
+    ownerNonce: 'nonce-canonical',
+    snapshot: {
+      clip: clipInput({ privateCookie: 'must not persist' }),
+      playQueue: [{ secret: true }],
+      nextClip: { secret: true },
+      unexpected: 'discarded',
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.value.clip.clipId, 123);
+  assert.equal('privateCookie' in result.value.clip, false);
+  assert.equal('unexpected' in result.value, false);
+  assert.equal(result.value.playQueue, null);
+  assert.equal(result.value.nextClip, null);
+});
+
+test('background snapshot normalization rejects nested invalid data and context mismatch', () => {
+  assert.equal(
+    normalizePlaybackSnapshot({
+      context: { mode: 'clip', clipId: 123 },
+      ownerNonce: 'nonce-invalid',
+      snapshot: { clip: clipInput({ service: 'youtube' }) },
+    }).reason,
+    'invalid_service'
+  );
+  assert.equal(
+    normalizePlaybackSnapshot({
+      context: { mode: 'clip', clipId: 999 },
+      ownerNonce: 'nonce-mismatch',
+      snapshot: { clip: clipInput() },
+    }).reason,
+    'clip_id_mismatch'
+  );
+});

--- a/test/playbackContext.test.js
+++ b/test/playbackContext.test.js
@@ -108,7 +108,7 @@ test('invalid contexts are rejected instead of leaking global playback state', (
   }
 });
 
-test('comment resolution falls back globally only before local initialization', async () => {
+test('comment resolution fails closed before local initialization', async () => {
   const previousChrome = globalThis.chrome;
   let globalReads = 0;
   Object.defineProperty(globalThis, 'chrome', {
@@ -130,10 +130,10 @@ test('comment resolution falls back globally only before local initialization', 
   });
 
   try {
-    assert.equal(await resolveCurrentClipId(), 91);
+    assert.equal(await resolveCurrentClipId(), null);
     clearPlaybackContext();
     assert.equal(await resolveCurrentClipId(), null);
-    assert.equal(globalReads, 1);
+    assert.equal(globalReads, 0);
   } finally {
     Object.defineProperty(globalThis, 'chrome', {
       configurable: true,

--- a/test/playbackContext.test.js
+++ b/test/playbackContext.test.js
@@ -1,0 +1,180 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, test } from 'node:test';
+
+import {
+  PLAYBACK_CONTEXT_CHANGED_EVENT,
+  clearPlaybackContext,
+  ensurePlaybackContext,
+  readPlaybackContext,
+  setPlaybackContext,
+} from '../src/content/playbackContext.js';
+import { resolveCurrentClipId } from '../src/content/commentPanel.js';
+
+class MemorySessionStorage {
+  constructor() {
+    this.values = new Map();
+  }
+
+  getItem(key) {
+    return this.values.has(key) ? this.values.get(key) : null;
+  }
+
+  setItem(key, value) {
+    this.values.set(key, String(value));
+  }
+}
+
+let previousSessionStorage;
+let previousWindow;
+
+beforeEach(() => {
+  previousSessionStorage = globalThis.sessionStorage;
+  previousWindow = globalThis.window;
+  Object.defineProperty(globalThis, 'sessionStorage', {
+    configurable: true,
+    value: new MemorySessionStorage(),
+  });
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: new EventTarget(),
+  });
+});
+
+afterEach(() => {
+  Object.defineProperty(globalThis, 'sessionStorage', {
+    configurable: true,
+    value: previousSessionStorage,
+  });
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: previousWindow,
+  });
+});
+
+test('initialization records an explicit tab-local null context', () => {
+  assert.deepEqual(readPlaybackContext(), {
+    initialized: false,
+    context: null,
+  });
+
+  assert.deepEqual(ensurePlaybackContext(), {
+    initialized: true,
+    context: null,
+  });
+  assert.deepEqual(readPlaybackContext(), {
+    initialized: true,
+    context: null,
+  });
+});
+
+test('set and clear preserve a normalized, initialized tab-local context', () => {
+  assert.deepEqual(setPlaybackContext({ mode: 'playlist', clipId: '42' }), {
+    initialized: true,
+    context: { mode: 'playlist', clipId: 42 },
+  });
+
+  assert.deepEqual(clearPlaybackContext(), {
+    initialized: true,
+    context: null,
+  });
+  assert.deepEqual(readPlaybackContext(), {
+    initialized: true,
+    context: null,
+  });
+});
+
+test('changes notify this tab once and identical writes are coalesced', () => {
+  let changes = 0;
+  window.addEventListener(PLAYBACK_CONTEXT_CHANGED_EVENT, () => {
+    changes += 1;
+  });
+
+  ensurePlaybackContext();
+  setPlaybackContext({ mode: 'clip', clipId: 7 });
+  setPlaybackContext({ mode: 'clip', clipId: 7 });
+  clearPlaybackContext();
+  clearPlaybackContext();
+
+  assert.equal(changes, 3);
+});
+
+test('invalid contexts are rejected instead of leaking global playback state', () => {
+  for (const context of [
+    { mode: 'other', clipId: 1 },
+    { mode: 'clip', clipId: 0 },
+    { mode: 'playlist', clipId: 'abc' },
+  ]) {
+    assert.throws(() => setPlaybackContext(context), TypeError);
+  }
+});
+
+test('comment resolution falls back globally only before local initialization', async () => {
+  const previousChrome = globalThis.chrome;
+  let globalReads = 0;
+  Object.defineProperty(globalThis, 'chrome', {
+    configurable: true,
+    value: {
+      runtime: { lastError: null },
+      storage: {
+        local: {
+          get(_keys, callback) {
+            globalReads += 1;
+            callback({
+              playmode: 'clip',
+              clip: { clipId: 91 },
+            });
+          },
+        },
+      },
+    },
+  });
+
+  try {
+    assert.equal(await resolveCurrentClipId(), 91);
+    clearPlaybackContext();
+    assert.equal(await resolveCurrentClipId(), null);
+    assert.equal(globalReads, 1);
+  } finally {
+    Object.defineProperty(globalThis, 'chrome', {
+      configurable: true,
+      value: previousChrome,
+    });
+  }
+});
+
+test('a blocked sessionStorage write still keeps the tab isolated in memory', () => {
+  const storage = globalThis.sessionStorage;
+  storage.setItem = () => {
+    throw new Error('blocked');
+  };
+
+  assert.deepEqual(ensurePlaybackContext(), {
+    initialized: true,
+    context: null,
+  });
+  assert.deepEqual(readPlaybackContext(), {
+    initialized: true,
+    context: null,
+  });
+
+  storage.setItem = MemorySessionStorage.prototype.setItem;
+  clearPlaybackContext();
+});
+
+test('memory fallback wins over an older value left in sessionStorage', () => {
+  const storage = globalThis.sessionStorage;
+  setPlaybackContext({ mode: 'clip', clipId: 10 });
+
+  storage.setItem = () => {
+    throw new Error('blocked');
+  };
+  setPlaybackContext({ mode: 'clip', clipId: 11 });
+
+  assert.deepEqual(readPlaybackContext(), {
+    initialized: true,
+    context: { mode: 'clip', clipId: 11 },
+  });
+
+  storage.setItem = MemorySessionStorage.prototype.setItem;
+  clearPlaybackContext();
+});

--- a/test/playbackOwnership.test.js
+++ b/test/playbackOwnership.test.js
@@ -1,0 +1,456 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  PLAYBACK_HANDOFF_TTL_MS,
+  PLAYBACK_OWNER_STORAGE_KEY,
+  PLAYBACK_REGISTRY_STORAGE_KEY,
+  createPlaybackOwnershipManager,
+} from '../src/background/playbackOwnership.js';
+
+class MemoryStorageArea {
+  constructor(initial = {}) {
+    this.data = { ...initial };
+  }
+
+  async get(keys) {
+    if (typeof keys === 'string') return { [keys]: this.data[keys] };
+    const selected = {};
+    for (const key of keys || Object.keys(this.data)) selected[key] = this.data[key];
+    return selected;
+  }
+
+  async set(items) {
+    Object.assign(this.data, items);
+  }
+}
+
+function clipSnapshot(
+  nonce,
+  clipId,
+  url = `https://www.netflix.com/watch/${clipId}`
+) {
+  return {
+    clip: { id: clipId, title: `clip-${clipId}`, url },
+    playClipSystemKey: 1,
+    playlistSystemKey: 0,
+    playmode: 'clip',
+    [PLAYBACK_OWNER_STORAGE_KEY]: nonce,
+  };
+}
+
+function createHarness() {
+  let currentTime = 1_000;
+  const sessionStorage = new MemoryStorageArea();
+  const localStorage = new MemoryStorageArea();
+  const manager = createPlaybackOwnershipManager({
+    sessionStorage,
+    localStorage,
+    now: () => currentTime,
+  });
+  return {
+    manager,
+    sessionStorage,
+    localStorage,
+    advance(ms) {
+      currentTime += ms;
+    },
+  };
+}
+
+async function beginAndClaim(harness, {
+  nonce,
+  sourceTabId,
+  tabId = sourceTabId,
+  openerTabId,
+  clipId,
+}) {
+  const snapshot = clipSnapshot(nonce, clipId);
+  await harness.manager.beginHandoff({
+    nonce,
+    sourceTabId,
+    context: { mode: 'clip', clipId },
+    snapshot,
+  });
+  return harness.manager.claim({
+    tabId,
+    openerTabId,
+    nonce,
+  });
+}
+
+test('a handoff can be claimed by its source tab or an opener child only', async () => {
+  const sourceHarness = createHarness();
+  assert.equal(
+    (await beginAndClaim(sourceHarness, {
+      nonce: 'nonce-source',
+      sourceTabId: 10,
+      clipId: 1,
+    })).ok,
+    true
+  );
+
+  const childHarness = createHarness();
+  assert.equal(
+    (await beginAndClaim(childHarness, {
+      nonce: 'nonce-child',
+      sourceTabId: 20,
+      tabId: 21,
+      openerTabId: 20,
+      clipId: 2,
+    })).ok,
+    true
+  );
+
+  const unrelatedHarness = createHarness();
+  const snapshot = clipSnapshot('nonce-private', 3);
+  await unrelatedHarness.manager.beginHandoff({
+    nonce: 'nonce-private',
+    sourceTabId: 30,
+    context: { mode: 'clip', clipId: 3 },
+    snapshot,
+  });
+  assert.deepEqual(
+    await unrelatedHarness.manager.claim({
+      tabId: 31,
+      openerTabId: 999,
+      nonce: 'nonce-private',
+    }),
+    { ok: false, reason: 'handoff_not_found' }
+  );
+});
+
+test('a nonce-less legacy child claims exactly one opener-bound handoff', async () => {
+  const harness = createHarness();
+  const snapshot = clipSnapshot('nonce-legacy', 61);
+  await harness.manager.beginHandoff({
+    nonce: 'nonce-legacy',
+    sourceTabId: 60,
+    context: { mode: 'clip', clipId: 61 },
+    snapshot,
+  });
+
+  const claim = await harness.manager.claim({ tabId: 61, openerTabId: 60 });
+  assert.equal(claim.ok, true);
+  assert.equal(claim.nonce, 'nonce-legacy');
+  assert.equal(claim.snapshot.clip.id, 61);
+});
+
+test('a nonce-less legacy claim can retry after BEGIN arrives', async () => {
+  const harness = createHarness();
+  assert.deepEqual(
+    await harness.manager.claim({ tabId: 66, openerTabId: 65 }),
+    { ok: false, reason: 'handoff_not_found' }
+  );
+  await harness.manager.beginHandoff({
+    nonce: 'nonce-late-begin',
+    sourceTabId: 65,
+    context: { mode: 'clip', clipId: 66 },
+    snapshot: clipSnapshot('nonce-late-begin', 66),
+  });
+  const claim = await harness.manager.claim({ tabId: 66, openerTabId: 65 });
+  assert.equal(claim.ok, true);
+  assert.equal(claim.nonce, 'nonce-late-begin');
+});
+
+test('a nonce-less legacy claim rejects ambiguous opener handoffs', async () => {
+  const harness = createHarness();
+  for (const [nonce, clipId] of [['nonce-legacy-a', 71], ['nonce-legacy-b', 72]]) {
+    await harness.manager.beginHandoff({
+      nonce,
+      sourceTabId: 70,
+      context: { mode: 'clip', clipId },
+      snapshot: clipSnapshot(nonce, clipId),
+    });
+  }
+
+  assert.deepEqual(
+    await harness.manager.claim({ tabId: 71, openerTabId: 70 }),
+    { ok: false, reason: 'ambiguous_handoff' }
+  );
+});
+
+test('releasing one active tab restores the latest remaining snapshot', async () => {
+  const harness = createHarness();
+  await beginAndClaim(harness, {
+    nonce: 'nonce-active-a',
+    sourceTabId: 1,
+    clipId: 11,
+  });
+  harness.advance(10);
+  await beginAndClaim(harness, {
+    nonce: 'nonce-active-b',
+    sourceTabId: 2,
+    clipId: 22,
+  });
+
+  assert.deepEqual(
+    await harness.manager.release({ tabId: 2, nonce: 'nonce-active-b' }),
+    { ok: true, cleared: false }
+  );
+  assert.equal(harness.localStorage.data.playbackOwnerNonce, 'nonce-active-a');
+  assert.equal(harness.localStorage.data.clip.id, 11);
+
+  assert.deepEqual(
+    await harness.manager.release({ tabId: 1, nonce: 'nonce-active-a' }),
+    { ok: true, cleared: true }
+  );
+  assert.equal(harness.localStorage.data.playmode, null);
+  assert.equal(harness.localStorage.data.playbackOwnerNonce, null);
+});
+
+test('an owner transition and another tab release are serialized without rollback', async () => {
+  for (const releaseFirst of [false, true]) {
+    const harness = createHarness();
+    await beginAndClaim(harness, {
+      nonce: 'nonce-serial-a',
+      sourceTabId: 81,
+      clipId: 811,
+    });
+    await beginAndClaim(harness, {
+      nonce: 'nonce-serial-b',
+      sourceTabId: 82,
+      clipId: 821,
+    });
+
+    const update = () => harness.manager.update({
+      tabId: 81,
+      nonce: 'nonce-serial-a',
+      context: { mode: 'clip', clipId: 812 },
+      patch: clipSnapshot('nonce-serial-a', 812),
+    });
+    const release = () => harness.manager.release({
+      tabId: 82,
+      nonce: 'nonce-serial-b',
+    });
+    const first = releaseFirst ? release() : update();
+    const second = releaseFirst ? update() : release();
+    await Promise.all([first, second]);
+
+    assert.equal(harness.localStorage.data.playbackOwnerNonce, 'nonce-serial-a');
+    assert.equal(harness.localStorage.data.clip.id, 812);
+  }
+});
+
+test('reload keeps a route owner, manual navigation releases it, and prepared navigation survives', async () => {
+  const reloadHarness = createHarness();
+  const nonce = 'nonce-route-reload';
+  const firstRoute = 'https://www.netflix.com/watch/901?t=3';
+  await reloadHarness.manager.beginHandoff({
+    nonce,
+    sourceTabId: 90,
+    context: { mode: 'clip', clipId: 901 },
+    snapshot: clipSnapshot(nonce, 901),
+  });
+  assert.equal((await reloadHarness.manager.claim({
+    tabId: 90,
+    nonce,
+    route: firstRoute,
+  })).ok, true);
+  assert.equal((await reloadHarness.manager.claim({
+    tabId: 90,
+    nonce,
+    route: firstRoute,
+  })).ok, true);
+
+  assert.deepEqual(
+    await reloadHarness.manager.handleTabNavigation({
+      tabId: 90,
+      url: 'https://www.netflix.com/browse',
+    }),
+    { ok: true, released: true, cleared: true }
+  );
+
+  const autoHarness = createHarness();
+  const autoNonce = 'nonce-route-auto';
+  await beginAndClaim(autoHarness, {
+    nonce: autoNonce,
+    sourceTabId: 91,
+    clipId: 911,
+  });
+  await autoHarness.manager.update({
+    tabId: 91,
+    nonce: autoNonce,
+    context: { mode: 'clip', clipId: 912 },
+    patch: clipSnapshot(autoNonce, 912),
+    route: 'https://www.netflix.com/watch/911',
+  });
+  assert.deepEqual(
+    await autoHarness.manager.prepareNavigation({
+      tabId: 91,
+      nonce: autoNonce,
+      nextUrl: 'https://www.netflix.com/watch/912?t=4',
+    }),
+    { ok: true }
+  );
+  assert.deepEqual(
+    await autoHarness.manager.handleTabNavigation({
+      tabId: 91,
+      url: 'https://www.netflix.com/watch/912?t=4',
+    }),
+    { ok: true, released: false }
+  );
+  assert.equal((await autoHarness.manager.claim({
+    tabId: 91,
+    nonce: autoNonce,
+    route: 'https://www.netflix.com/watch/912?t=4',
+  })).ok, true);
+});
+
+test('claim rejects a stale owner when the document route no longer matches its clip', async () => {
+  const harness = createHarness();
+  const nonce = 'nonce-claim-route';
+  await harness.manager.beginHandoff({
+    nonce,
+    sourceTabId: 92,
+    context: { mode: 'clip', clipId: 921 },
+    snapshot: clipSnapshot(nonce, 921),
+  });
+  assert.equal((await harness.manager.claim({
+    tabId: 92,
+    nonce,
+    route: 'https://www.netflix.com/watch/921',
+  })).ok, true);
+
+  assert.deepEqual(
+    await harness.manager.claim({
+      tabId: 92,
+      nonce,
+      route: 'https://www.netflix.com/watch/999',
+    }),
+    { ok: false, reason: 'route_mismatch' }
+  );
+  assert.equal(harness.localStorage.data.playbackOwnerNonce, null);
+});
+
+test('rapid handoffs retain nonce-bound snapshots and can be claimed independently', async () => {
+  const harness = createHarness();
+  const firstSnapshot = clipSnapshot('nonce-fast-1', 101);
+  const secondSnapshot = clipSnapshot('nonce-fast-2', 202);
+  await harness.manager.beginHandoff({
+    nonce: 'nonce-fast-1',
+    sourceTabId: 7,
+    context: { mode: 'clip', clipId: 101 },
+    snapshot: firstSnapshot,
+  });
+  await harness.manager.beginHandoff({
+    nonce: 'nonce-fast-2',
+    sourceTabId: 7,
+    context: { mode: 'clip', clipId: 202 },
+    snapshot: secondSnapshot,
+  });
+
+  const firstClaim = await harness.manager.claim({
+      tabId: 8,
+      openerTabId: 7,
+      nonce: 'nonce-fast-1',
+    });
+  assert.equal(firstClaim.ok, true);
+  assert.equal(firstClaim.snapshot.clip.id, 101);
+  const secondClaim = await harness.manager.claim({
+      tabId: 9,
+      openerTabId: 7,
+      nonce: 'nonce-fast-2',
+    });
+  assert.equal(secondClaim.ok, true);
+  assert.equal(secondClaim.snapshot.clip.id, 202);
+});
+
+test('expired pending handoffs are cleaned and reset stale global playback', async () => {
+  const harness = createHarness();
+  await harness.manager.beginHandoff({
+    nonce: 'nonce-expired',
+    sourceTabId: 4,
+    context: { mode: 'clip', clipId: 44 },
+    snapshot: clipSnapshot('nonce-expired', 44),
+  });
+  harness.advance(PLAYBACK_HANDOFF_TTL_MS + 1);
+
+  assert.deepEqual(await harness.manager.cleanupExpired(), {
+    ok: true,
+    cleared: true,
+  });
+  const registry = harness.sessionStorage.data[PLAYBACK_REGISTRY_STORAGE_KEY];
+  assert.deepEqual(registry.active, {});
+  assert.deepEqual(registry.pending, {});
+  assert.equal(harness.localStorage.data.playmode, null);
+});
+
+test('expiring the global pending owner restores the latest active snapshot', async () => {
+  const harness = createHarness();
+  await beginAndClaim(harness, {
+    nonce: 'nonce-still-active',
+    sourceTabId: 40,
+    clipId: 401,
+  });
+  await harness.manager.beginHandoff({
+    nonce: 'nonce-will-expire',
+    sourceTabId: 41,
+    context: { mode: 'clip', clipId: 402 },
+    snapshot: clipSnapshot('nonce-will-expire', 402),
+  });
+  harness.advance(PLAYBACK_HANDOFF_TTL_MS + 1);
+
+  assert.deepEqual(await harness.manager.cleanupExpired(), {
+    ok: true,
+    cleared: false,
+  });
+  assert.equal(harness.localStorage.data.playbackOwnerNonce, 'nonce-still-active');
+  assert.equal(harness.localStorage.data.clip.id, 401);
+});
+
+test('release ignores a missing or mismatched nonce', async () => {
+  const harness = createHarness();
+  await beginAndClaim(harness, {
+    nonce: 'nonce-protected',
+    sourceTabId: 50,
+    clipId: 501,
+  });
+
+  assert.deepEqual(await harness.manager.release({ tabId: 50 }), {
+    ok: true,
+    cleared: false,
+  });
+  assert.deepEqual(
+    await harness.manager.release({ tabId: 50, nonce: 'nonce-other' }),
+    { ok: true, cleared: false }
+  );
+  const registry = harness.sessionStorage.data[PLAYBACK_REGISTRY_STORAGE_KEY];
+  assert.equal(registry.active['50'].nonce, 'nonce-protected');
+  assert.equal(harness.localStorage.data.playbackOwnerNonce, 'nonce-protected');
+});
+
+test('removing a source tab releases active ownership but preserves a pending child handoff', async () => {
+  const harness = createHarness();
+  await beginAndClaim(harness, {
+    nonce: 'nonce-remove-active',
+    sourceTabId: 5,
+    clipId: 55,
+  });
+  await harness.manager.beginHandoff({
+    nonce: 'nonce-remove-pending',
+    sourceTabId: 5,
+    context: { mode: 'clip', clipId: 56 },
+    snapshot: clipSnapshot('nonce-remove-pending', 56),
+  });
+  assert.deepEqual(
+    await harness.manager.bindTarget({ tabId: 6, openerTabId: 5 }),
+    { ok: true }
+  );
+
+  assert.deepEqual(await harness.manager.removeTab(5), {
+    ok: true,
+    cleared: false,
+  });
+  const registry = harness.sessionStorage.data[PLAYBACK_REGISTRY_STORAGE_KEY];
+  assert.deepEqual(registry.active, {});
+  assert.equal(registry.pending['nonce-remove-pending'].sourceTabId, 5);
+  assert.equal(harness.localStorage.data.playbackOwnerNonce, 'nonce-remove-pending');
+
+  const childClaim = await harness.manager.claim({
+    tabId: 6,
+    nonce: 'nonce-remove-pending',
+  });
+  assert.equal(childClaim.ok, true);
+  assert.equal(childClaim.snapshot.clip.id, 56);
+});

--- a/test/playbackOwnership.test.js
+++ b/test/playbackOwnership.test.js
@@ -31,7 +31,14 @@ function clipSnapshot(
   url = `https://www.netflix.com/watch/${clipId}`
 ) {
   return {
-    clip: { id: clipId, title: `clip-${clipId}`, url },
+    clip: {
+      clipId,
+      title: `clip-${clipId}`,
+      service: 'netflix',
+      url,
+      startTime: 10,
+      endTime: 20,
+    },
     playClipSystemKey: 1,
     playlistSystemKey: 0,
     playmode: 'clip',
@@ -116,7 +123,7 @@ test('a handoff can be claimed by its source tab or an opener child only', async
       openerTabId: 999,
       nonce: 'nonce-private',
     }),
-    { ok: false, reason: 'handoff_not_found' }
+    { ok: false, reason: 'handoff_not_found', retryable: true }
   );
 });
 
@@ -133,14 +140,14 @@ test('a nonce-less legacy child claims exactly one opener-bound handoff', async 
   const claim = await harness.manager.claim({ tabId: 61, openerTabId: 60 });
   assert.equal(claim.ok, true);
   assert.equal(claim.nonce, 'nonce-legacy');
-  assert.equal(claim.snapshot.clip.id, 61);
+  assert.equal(claim.snapshot.clip.clipId, 61);
 });
 
 test('a nonce-less legacy claim can retry after BEGIN arrives', async () => {
   const harness = createHarness();
   assert.deepEqual(
     await harness.manager.claim({ tabId: 66, openerTabId: 65 }),
-    { ok: false, reason: 'handoff_not_found' }
+    { ok: false, reason: 'handoff_not_found', retryable: true }
   );
   await harness.manager.beginHandoff({
     nonce: 'nonce-late-begin',
@@ -189,7 +196,7 @@ test('releasing one active tab restores the latest remaining snapshot', async ()
     { ok: true, cleared: false }
   );
   assert.equal(harness.localStorage.data.playbackOwnerNonce, 'nonce-active-a');
-  assert.equal(harness.localStorage.data.clip.id, 11);
+  assert.equal(harness.localStorage.data.clip.clipId, 11);
 
   assert.deepEqual(
     await harness.manager.release({ tabId: 1, nonce: 'nonce-active-a' }),
@@ -228,7 +235,7 @@ test('an owner transition and another tab release are serialized without rollbac
     await Promise.all([first, second]);
 
     assert.equal(harness.localStorage.data.playbackOwnerNonce, 'nonce-serial-a');
-    assert.equal(harness.localStorage.data.clip.id, 812);
+    assert.equal(harness.localStorage.data.clip.clipId, 812);
   }
 });
 
@@ -242,11 +249,13 @@ test('reload keeps a route owner, manual navigation releases it, and prepared na
     context: { mode: 'clip', clipId: 901 },
     snapshot: clipSnapshot(nonce, 901),
   });
-  assert.equal((await reloadHarness.manager.claim({
+  const reloadClaim = await reloadHarness.manager.claim({
     tabId: 90,
     nonce,
     route: firstRoute,
-  })).ok, true);
+  });
+  assert.equal(reloadClaim.ok, true);
+  assert.equal(reloadClaim.autoNavigation, false);
   assert.equal((await reloadHarness.manager.claim({
     tabId: 90,
     nonce,
@@ -290,11 +299,13 @@ test('reload keeps a route owner, manual navigation releases it, and prepared na
     }),
     { ok: true, released: false }
   );
-  assert.equal((await autoHarness.manager.claim({
+  const autoClaim = await autoHarness.manager.claim({
     tabId: 91,
     nonce: autoNonce,
     route: 'https://www.netflix.com/watch/912?t=4',
-  })).ok, true);
+  });
+  assert.equal(autoClaim.ok, true);
+  assert.equal(autoClaim.autoNavigation, true);
 });
 
 test('claim rejects a stale owner when the document route no longer matches its clip', async () => {
@@ -318,7 +329,7 @@ test('claim rejects a stale owner when the document route no longer matches its 
       nonce,
       route: 'https://www.netflix.com/watch/999',
     }),
-    { ok: false, reason: 'route_mismatch' }
+    { ok: false, reason: 'route_mismatch', retryable: false }
   );
   assert.equal(harness.localStorage.data.playbackOwnerNonce, null);
 });
@@ -346,14 +357,14 @@ test('rapid handoffs retain nonce-bound snapshots and can be claimed independent
       nonce: 'nonce-fast-1',
     });
   assert.equal(firstClaim.ok, true);
-  assert.equal(firstClaim.snapshot.clip.id, 101);
+  assert.equal(firstClaim.snapshot.clip.clipId, 101);
   const secondClaim = await harness.manager.claim({
       tabId: 9,
       openerTabId: 7,
       nonce: 'nonce-fast-2',
     });
   assert.equal(secondClaim.ok, true);
-  assert.equal(secondClaim.snapshot.clip.id, 202);
+  assert.equal(secondClaim.snapshot.clip.clipId, 202);
 });
 
 test('expired pending handoffs are cleaned and reset stale global playback', async () => {
@@ -374,6 +385,9 @@ test('expired pending handoffs are cleaned and reset stale global playback', asy
   assert.deepEqual(registry.active, {});
   assert.deepEqual(registry.pending, {});
   assert.equal(harness.localStorage.data.playmode, null);
+  assert.equal(harness.localStorage.data.clip, null);
+  assert.equal(harness.localStorage.data.playQueue, null);
+  assert.equal(harness.localStorage.data.nextClip, null);
 });
 
 test('expiring the global pending owner restores the latest active snapshot', async () => {
@@ -396,7 +410,7 @@ test('expiring the global pending owner restores the latest active snapshot', as
     cleared: false,
   });
   assert.equal(harness.localStorage.data.playbackOwnerNonce, 'nonce-still-active');
-  assert.equal(harness.localStorage.data.clip.id, 401);
+  assert.equal(harness.localStorage.data.clip.clipId, 401);
 });
 
 test('release ignores a missing or mismatched nonce', async () => {
@@ -452,5 +466,71 @@ test('removing a source tab releases active ownership but preserves a pending ch
     nonce: 'nonce-remove-pending',
   });
   assert.equal(childClaim.ok, true);
-  assert.equal(childClaim.snapshot.clip.id, 56);
+  assert.equal(childClaim.snapshot.clip.clipId, 56);
+});
+
+test('invalid nested handoff data is rejected without any storage mutation', async () => {
+  const harness = createHarness();
+  harness.localStorage.data = { preserved: 'local' };
+  harness.sessionStorage.data = { preserved: 'session' };
+
+  const result = await harness.manager.beginHandoff({
+    nonce: 'nonce-invalid-nested',
+    sourceTabId: 70,
+    context: { mode: 'clip', clipId: 701 },
+    snapshot: {
+      ...clipSnapshot('nonce-invalid-nested', 701),
+      clip: {
+        ...clipSnapshot('nonce-invalid-nested', 701).clip,
+        service: 'youtube',
+      },
+    },
+  });
+
+  assert.deepEqual(result, { ok: false, reason: 'invalid_handoff' });
+  assert.deepEqual(harness.localStorage.data, { preserved: 'local' });
+  assert.deepEqual(harness.sessionStorage.data, { preserved: 'session' });
+});
+
+test('invalid ownership update leaves the active snapshot unchanged', async () => {
+  const harness = createHarness();
+  await beginAndClaim(harness, {
+    nonce: 'nonce-invalid-update',
+    sourceTabId: 71,
+    clipId: 711,
+  });
+  const beforeLocal = structuredClone(harness.localStorage.data);
+  const beforeRegistry = structuredClone(harness.sessionStorage.data);
+
+  const result = await harness.manager.update({
+    tabId: 71,
+    nonce: 'nonce-invalid-update',
+    context: { mode: 'clip', clipId: 711 },
+    patch: {
+      clip: {
+        ...clipSnapshot('nonce-invalid-update', 711).clip,
+        endTime: 5,
+      },
+    },
+  });
+
+  assert.deepEqual(result, { ok: false, reason: 'snapshot_mismatch' });
+  assert.deepEqual(harness.localStorage.data, beforeLocal);
+  assert.deepEqual(harness.sessionStorage.data, beforeRegistry);
+});
+
+test('reset erases retained clip and playlist payloads', async () => {
+  const harness = createHarness();
+  harness.localStorage.data = {
+    clip: { privateCookie: 'secret' },
+    playQueue: [{ title: 'old' }],
+    nextClip: { title: 'old' },
+    unrelated: 'preserved',
+  };
+
+  assert.deepEqual(await harness.manager.reset(), { ok: true });
+  assert.equal(harness.localStorage.data.clip, null);
+  assert.equal(harness.localStorage.data.playQueue, null);
+  assert.equal(harness.localStorage.data.nextClip, null);
+  assert.equal(harness.localStorage.data.unrelated, 'preserved');
 });

--- a/test/playbackOwnershipClient.test.js
+++ b/test/playbackOwnershipClient.test.js
@@ -113,3 +113,19 @@ test('an ambiguous legacy handoff fails without retrying', async () => {
   assert.deepEqual(result, { ok: false, reason: 'ambiguous_handoff' });
   assert.equal(messages.length, 1);
 });
+
+test('a normal page stops after a non-retryable missing handoff', async () => {
+  const { messages } = installGlobals({
+    href: 'https://www.netflix.com/browse',
+    respond: () => ({
+      ok: false,
+      reason: 'handoff_not_found',
+      retryable: false,
+    }),
+  });
+
+  const result = await claimPlaybackOwnership({ nonce: null });
+  assert.equal(result.ok, false);
+  assert.equal(result.retryable, false);
+  assert.equal(messages.length, 1);
+});

--- a/test/playbackOwnershipClient.test.js
+++ b/test/playbackOwnershipClient.test.js
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  PLAYBACK_OWNER_TAB_KEY,
+  claimPlaybackOwnership,
+} from '../src/content/playbackOwnership.js';
+
+class MemorySessionStorage {
+  constructor(initial = {}) {
+    this.data = { ...initial };
+  }
+
+  getItem(key) {
+    return Object.hasOwn(this.data, key) ? this.data[key] : null;
+  }
+
+  setItem(key, value) {
+    this.data[key] = String(value);
+  }
+
+  removeItem(key) {
+    delete this.data[key];
+  }
+}
+
+function installGlobals({ href, storedNonce = null, respond }) {
+  const sessionStorage = new MemorySessionStorage(
+    storedNonce ? { [PLAYBACK_OWNER_TAB_KEY]: storedNonce } : {}
+  );
+  const messages = [];
+  globalThis.location = { href };
+  globalThis.sessionStorage = sessionStorage;
+  globalThis.chrome = {
+    runtime: {
+      lastError: null,
+      sendMessage(message, callback) {
+        messages.push(message);
+        callback(respond(message, messages.length));
+      },
+    },
+  };
+  return { messages, sessionStorage };
+}
+
+test('an explicit URL nonce never falls back to an opener handoff', async () => {
+  const { messages } = installGlobals({
+    href: 'https://www.netflix.com/watch/1?dextPlaybackOwner=url-nonce-1',
+    respond: () => ({ ok: false, reason: 'handoff_not_found' }),
+  });
+
+  const result = await claimPlaybackOwnership({ nonce: 'url-nonce-1' });
+  assert.deepEqual(result, { ok: false, reason: 'handoff_not_found' });
+  assert.equal(messages.length, 1);
+  assert.equal(messages[0].nonce, 'url-nonce-1');
+});
+
+test('a stale tab-local nonce falls back to a late legacy handoff', async () => {
+  const { messages, sessionStorage } = installGlobals({
+    href: 'https://www.netflix.com/watch/2?t=5',
+    storedNonce: 'stale-tab-nonce',
+    respond: (message) => message.nonce
+      ? { ok: false, reason: 'handoff_not_found' }
+      : {
+          ok: true,
+          nonce: 'fresh-legacy-nonce',
+          context: { mode: 'clip', clipId: 2 },
+          snapshot: {},
+        },
+  });
+
+  const result = await claimPlaybackOwnership({ nonce: 'stale-tab-nonce' });
+  assert.equal(result.ok, true);
+  assert.deepEqual(messages.map((message) => message.nonce), [
+    'stale-tab-nonce',
+    null,
+  ]);
+  assert.equal(
+    sessionStorage.getItem(PLAYBACK_OWNER_TAB_KEY),
+    'fresh-legacy-nonce'
+  );
+});
+
+test('a stale owner rejected on a new route falls back to the new handoff', async () => {
+  const { messages } = installGlobals({
+    href: 'https://www.netflix.com/watch/3?t=5',
+    storedNonce: 'previous-route-nonce',
+    respond: (message) => message.nonce
+      ? { ok: false, reason: 'route_mismatch' }
+      : {
+          ok: true,
+          nonce: 'new-route-nonce',
+          context: { mode: 'clip', clipId: 3 },
+          snapshot: {},
+        },
+  });
+
+  const result = await claimPlaybackOwnership({ nonce: 'previous-route-nonce' });
+  assert.equal(result.nonce, 'new-route-nonce');
+  assert.deepEqual(messages.map((message) => message.nonce), [
+    'previous-route-nonce',
+    null,
+  ]);
+});
+
+test('an ambiguous legacy handoff fails without retrying', async () => {
+  const { messages } = installGlobals({
+    href: 'https://www.disneyplus.com/video/example?t=4',
+    respond: () => ({ ok: false, reason: 'ambiguous_handoff' }),
+  });
+
+  const result = await claimPlaybackOwnership({ nonce: null });
+  assert.deepEqual(result, { ok: false, reason: 'ambiguous_handoff' });
+  assert.equal(messages.length, 1);
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,4 @@
-const path = require("path");
+const path = require("node:path");
 
 module.exports = {
   mode: "production",
@@ -6,6 +6,7 @@ module.exports = {
     content: "./src/content/content_netflix.js",
     content_disney: "./src/content/content_disney.js",
     extension_link: "./src/content/extension_link.js",
+    getClipData: "./src/content/getClipData.js",
     background: "./src/background/background.js",
   },
   output: {


### PR DESCRIPTION
## 概要

- コメントAPIの認証競合、timeout、成功レスポンス検証、Unicode 500文字境界を修正
- 再生contextをtab単位に分離し、background ownershipを単一writer化
- localhost playback bridgeへcookie whitelist、clip/playlist schema、URL・件数・size検証を追加
- Netflix / Disney+のSPA遷移、reload、複数tab、controls再生成、入力キー伝播を修正
- Disney+のhistory監視をMAIN worldのdocument_start hookへ移行
- manifest / webpack / 契約資料 / 回帰テストを更新

## 検証

- `npm test`: 98/98 pass
- `npm run lint`: error 0
- `npm run build`: success（5 bundles）
- `git diff --check`: success
- Chrome 151.0.7922.138でNetflix / Disney+ / localhostを実機smoke済み

詳細: `documentation/comment-feature-review-fixes-2026-08-21.md`

## Merge blocker

localhost site側の`service` cookie追加とhandoff結果UIがremote revisionにまだ含まれていません。
[FigFingers/react--site#62](https://github.com/FigFingers/react--site/pull/62)へ必要差分をcommit・pushし、remote HEADへの包含を確認するまではこのPRをmergeしないでください。

レビュー自体は可能なため通常PRとして作成しています。