### PR TITLE
[codex] PR #129 のレビュー指摘を修正

### DIFF
--- a/documentation/comment-feature-review-fixes-2026-08-21.md
+++ b/documentation/comment-feature-review-fixes-2026-08-21.md
@@ -333,7 +333,7 @@ Disney+でも`src/util/history_change.js`を`document_start`のMAIN world conten
 - [x] 不正データは一部採用せず、handoff全体を拒否する方針に統一する
 - [x] 拒否時のconsole warningとユーザー通知方針を決める
 
-完了条件: localhost site側の実データ例と矛盾しない入力契約が文章化されている。  
+完了条件: localhost site側の実データ例と矛盾しない入力契約が文章化されている。
 完了資料: [Localhost playback bridge input contract v1](./localhost-playback-bridge-contract-v1.md)
 
 ### Phase 2: localhost bridgeを修正する
@@ -522,3 +522,40 @@ Disney+でも`src/util/history_change.js`を`document_start`のMAIN world conten
 仕様判断として、playback bridge v1はNetflix / Disney+限定を維持する。Prime / YouTubeを含むplaylistの部分再生互換は今回のmerge blockerに含めず、必要なら契約versionを更新する別変更として扱う。
 
 site側の`service` cookie追加はローカル作業ツリーにのみ存在するため、site commit・pushとremote branch包含確認が完了するまではmerge blockerとして残る。
+
+## 13. PR #129詳細再レビュー（2026-08-24）
+
+Phase 6以降のPR全差分を、`documentation/pr-129-detailed-review-plan-2026-08-23.md`のP-01〜P-10に沿って再監査した。本節はPhase 6に記録した98/98件および「新たなコード上のmerge blockerなし」という時点情報を、追加修正後の結果で更新する。
+
+追加で修正した主な不変条件違反:
+
+- Netflix / Disney+のauto-navigation markerをtab-localなnonce・正規化route・有効期限へ束縛し、一度だけconsumeするよう変更した。共有`localStorage`やclaim後の無条件boolean cacheを使わない。
+- syncの200 responseを`{ok:true, acceptedItemIds}`へ厳密化し、不正responseでpending clipを削除しない。enqueueとaccepted item削除はbackgroundの短い専用排他区間へ集約し、interleavingで新規clipを消失させない。
+- syncの400 responseが対象item IDを示さない場合はattempted batchを全件保持し、明示されたIDだけを削除する。productionの一般400でvalid clipまで失わない。
+- playback ownershipのnonce validationとown-property lookupを強化し、session/localの二重書込みを補償transaction化した。明示的な不正nonceはlegacy claimへfallbackせず、PREPARE routeは現在のowned snapshotと一致する場合だけ受理する。
+- instance IDとauth tokenを共有validatorで検証し、破損storageはfetch前に修復またはfail closedする。stale 401、malformed refresh success、unsafe header tokenで現在の連携状態を壊さない。
+- commentsの429を`rate_limited`へ固定し、完了済みresponseを壁時計だけでtimeout扱いしない。POST中のauth storage changeは成功response処理後までrefreshを延期する。
+- memo DOMの外部切断、Netflix video待機Observer、metadata/error listener、background fire-and-forget rejectionを明示的にcleanupする。
+- raw location URL、nonce付きURL、background responseをconsoleへ出す不要なloggingを除去した。
+- Netflix history hookのisolated-world重複登録を除去し、MAIN-world注入へ一本化した。これによりnative `popstate`の二重通知を防ぐ。
+
+追加した決定的な回帰試験には、syncのqueue RMW競合、storage片側write failure、malicious nonce、stale 401/relink、invalid instance ID、malformed refresh/sync response、POST pending中のauth変更、detached memo、route teardown中のvideo wait、およびMAIN-world history hookのpush/replace/popstateが含まれる。
+
+2026-08-24時点の自動検証:
+
+- extension: `npm test` 143/143、`npm run lint` 37 files pass、`npm run build`成功（5 bundles）、worktree `git diff --check`成功
+- localhost site: 分離対象7ファイルを含む現作業ツリーで`npm run codex:quick`成功（tests 141/141、lint、typecheck、Next type generation）
+
+site側の必要差分は、ユーザー判断によりPR #62へ追加しない。`origin/develop`起点の独立PRへ次の9ファイルを分離し、確定remote SHAを本資料へ追記する。追加監査で、自動linkの並行実行をinstance単位でcoalesceする修正と、明示port/credentials付き再生URLをpopup前に拒否する修正も同PRの必須項目とした。
+
+- `src/app/layout.tsx`
+- `src/components/ExtensionLinker.tsx`
+- `src/components/ExtensionPlaybackHandoffStatus.tsx`
+- `src/lib/extension/client.ts`
+- `src/lib/clips/playback.ts`
+- `tests/clips/playback.test.mjs`
+- `tests/extension/extension-client.test.mjs`
+- `tests/extension/extension-linker-mount.test.mjs`
+- `tests/extension/extension-handoff-status.test.mjs`
+
+残るmerge gateは、独立site PRのremote SHA確定、修正後extensionでの最終Chrome smoke、commit後の`git diff --check origin/develop...HEAD`、および最終HEADのCIである。友人reviewerのapprovalとGitHub review thread操作は、ユーザー指示により今回の作業範囲から除外する。

--- a/documentation/localhost-playback-bridge-contract-v1.md
+++ b/documentation/localhost-playback-bridge-contract-v1.md
@@ -1,7 +1,7 @@
 # Localhost playback bridge input contract v1
 
 Status: Phase 1確定・Phase 2実装済み・Phase 4ローカル検証済み（site依存commit待ち）
-Date: 2026-08-21  
+Date: 2026-08-21
 Scope: `http://localhost:3000` / `http://127.0.0.1:3000` から拡張へ渡す単体clip・playlist再生handoff
 
 ## 1. 目的

--- a/manifest.json
+++ b/manifest.json
@@ -27,8 +27,7 @@
     {
       "matches": ["https://www.netflix.com/*"],
       "run_at": "document_end",
-      "js": ["src/inject/inject_script.js",
-             "src/util/history_change.js"]
+      "js": ["src/inject/inject_script.js"]
     },
     {
       "matches": ["https://www.netflix.com/*"],

--- a/src/background/authMutex.js
+++ b/src/background/authMutex.js
@@ -1,0 +1,15 @@
+let exclusiveChain = Promise.resolve();
+
+/**
+ * Serialize all background operations that can read and then mutate auth
+ * state. Rejections are absorbed only for the queue tail so the caller still
+ * receives its original failure.
+ */
+export function runExclusive(task) {
+  const run = exclusiveChain.then(() => task());
+  exclusiveChain = run.then(
+    () => {},
+    () => {}
+  );
+  return run;
+}

--- a/src/background/authState.js
+++ b/src/background/authState.js
@@ -5,14 +5,12 @@ import {
   storageRemove,
   storageSet,
 } from './../shared/storage.js';
-import { runExclusive } from './sync.js';
-
-function normalizeExpiresAt(expiresAt) {
-  const expiresAtMs = Date.parse(expiresAt || '');
-  return Number.isFinite(expiresAtMs)
-    ? new Date(expiresAtMs).toISOString()
-    : null;
-}
+import {
+  isValidExtensionAuthToken,
+  isValidExtensionInstanceId,
+  normalizeExtensionTokenExpiry,
+} from './../shared/authValidation.js';
+import { runExclusive } from './authMutex.js';
 
 async function performSaveExtensionAuthToken({
   extensionInstanceId,
@@ -21,25 +19,23 @@ async function performSaveExtensionAuthToken({
 }) {
   const stored = await storageGet([STORAGE_KEYS.extensionInstanceId]);
   const currentInstanceId = stored[STORAGE_KEYS.extensionInstanceId];
-  if (!currentInstanceId || extensionInstanceId !== currentInstanceId) {
-    console.warn('[extension-sync] ignored auth token for mismatched extensionInstanceId', {
-      expected: currentInstanceId,
-      received: extensionInstanceId,
-    });
+  if (
+    !isValidExtensionInstanceId(currentInstanceId)
+    || !isValidExtensionInstanceId(extensionInstanceId)
+    || extensionInstanceId !== currentInstanceId
+  ) {
+    console.warn('[extension-sync] ignored auth token for mismatched extensionInstanceId');
     return { ok: false, reason: 'instance_mismatch' };
   }
 
-  if (
-    typeof extensionAuthToken !== 'string'
-    || extensionAuthToken.trim().length === 0
-  ) {
-    console.warn('[extension-sync] ignored empty auth token');
+  if (!isValidExtensionAuthToken(extensionAuthToken)) {
+    console.warn('[extension-sync] ignored invalid auth token');
     return { ok: false, reason: 'invalid_token' };
   }
 
   await storageSet({
     [STORAGE_KEYS.extensionAuthToken]: extensionAuthToken,
-    [STORAGE_KEYS.extensionTokenExpiresAt]: normalizeExpiresAt(expiresAt),
+    [STORAGE_KEYS.extensionTokenExpiresAt]: normalizeExtensionTokenExpiry(expiresAt),
     [STORAGE_KEYS.extensionLinked]: true,
   });
   await storageRemove([STORAGE_KEYS.extensionTokenRefreshBackoff]);
@@ -58,11 +54,12 @@ export function saveExtensionAuthTokenInBackground(input) {
 async function performUnlinkExtension({ extensionInstanceId }) {
   const stored = await storageGet([STORAGE_KEYS.extensionInstanceId]);
   const currentInstanceId = stored[STORAGE_KEYS.extensionInstanceId];
-  if (!currentInstanceId || extensionInstanceId !== currentInstanceId) {
-    console.warn('[extension-sync] ignored unlink for mismatched extensionInstanceId', {
-      expected: currentInstanceId,
-      received: extensionInstanceId,
-    });
+  if (
+    !isValidExtensionInstanceId(currentInstanceId)
+    || !isValidExtensionInstanceId(extensionInstanceId)
+    || extensionInstanceId !== currentInstanceId
+  ) {
+    console.warn('[extension-sync] ignored unlink for mismatched extensionInstanceId');
     return { ok: false, reason: 'instance_mismatch' };
   }
 

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -7,8 +7,18 @@ import {
   saveExtensionAuthTokenInBackground,
   unlinkExtensionInBackground,
 } from './authState.js';
-import { openLoginTab, syncPendingQueue } from './sync.js';
+import {
+  PLAYBACK_CLEANUP_RETRY_DELAY_MINUTES,
+  runDetachedTask,
+  runPlaybackCleanupTask,
+} from './detachedTasks.js';
+import {
+  enqueuePendingClipInBackground,
+  openLoginTab,
+  syncPendingQueue,
+} from './sync.js';
 import { checkAndRefreshToken } from './tokenRefresh.js';
+import { getOrCreateInstanceId } from './instanceId.js';
 
 const DEMO_BASE_URL = 'http://localhost:3000/';
 const WELCOME_VERSION_KEY = 'lastSeenWelcomeVersion';
@@ -43,12 +53,6 @@ function createTab(url) {
   });
 }
 
-chrome.runtime.onMessage.addListener((message) => {
-  if (message.type === 'HISTORY_CHANGE') {
-    console.log('URLが変更されました:', message.data.url);
-  }
-});
-
 // クリップ同期は background で fetch する(content の fetch はページオリジンの CORS で
 // サイト API に弾かれるため)。ログインタブ起動も sync 側(openLoginTab)が直接行う。
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
@@ -79,6 +83,14 @@ function respondToAsyncRequest(promise, sendResponse, reason = 'request_failed')
 }
 
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (message?.type === 'ENQUEUE_PENDING_CLIP') {
+    return respondToAsyncRequest(
+      enqueuePendingClipInBackground(message.clip),
+      sendResponse,
+      'enqueue_failed'
+    );
+  }
+
   if (message?.type === 'FETCH_CLIP_COMMENTS') {
     return respondToAsyncRequest(fetchClipComments({
       clipId: message.clipId,
@@ -117,29 +129,47 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   }
 });
 
-function scheduleAlarms() {
-  chrome.alarms.create(TOKEN_REFRESH_ALARM, { periodInMinutes: TOKEN_REFRESH_PERIOD_MINUTES });
-  chrome.alarms.create(SYNC_RETRY_ALARM, { periodInMinutes: SYNC_RETRY_PERIOD_MINUTES });
+async function scheduleAlarms() {
+  await Promise.all([
+    chrome.alarms.create(TOKEN_REFRESH_ALARM, {
+      periodInMinutes: TOKEN_REFRESH_PERIOD_MINUTES,
+    }),
+    chrome.alarms.create(SYNC_RETRY_ALARM, {
+      periodInMinutes: SYNC_RETRY_PERIOD_MINUTES,
+    }),
+  ]);
 }
 
 chrome.alarms.onAlarm.addListener((alarm) => {
   if (alarm.name.startsWith(PLAYBACK_HANDOFF_ALARM_PREFIX)) {
-    void playbackOwnership.cleanupExpired();
+    void runPlaybackCleanupTask({
+      cleanup: () => playbackOwnership.cleanupExpired(),
+      alarmName: alarm.name,
+      scheduleAlarm: (name, options) => chrome.alarms.create(name, options),
+    });
     return;
   }
   if (alarm.name === TOKEN_REFRESH_ALARM) {
-    void checkAndRefreshToken();
+    void runDetachedTask(() => checkAndRefreshToken(), {
+      label: 'token refresh alarm',
+    });
     return;
   }
   if (alarm.name === SYNC_RETRY_ALARM) {
     // キューが空なら storage を1回読むだけで即終了するので低コスト。
-    void syncPendingQueue();
+    void runDetachedTask(() => syncPendingQueue(), {
+      label: 'sync retry alarm',
+    });
   }
 });
 
 chrome.runtime.onStartup.addListener(() => {
-  scheduleAlarms();
-  void playbackOwnership.reset();
+  void runDetachedTask(() => scheduleAlarms(), {
+    label: 'startup alarm scheduling',
+  });
+  void runDetachedTask(() => playbackOwnership.reset(), {
+    label: 'startup playback reset',
+  });
 });
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
@@ -151,9 +181,15 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       snapshot: message.snapshot,
     }).then((result) => {
       if (result?.ok) {
-        chrome.alarms.create(
-          `${PLAYBACK_HANDOFF_ALARM_PREFIX}${message.nonce}`,
-          { delayInMinutes: 0.5 }
+        const alarmName = `${PLAYBACK_HANDOFF_ALARM_PREFIX}${message.nonce}`;
+        void runDetachedTask(
+          () => chrome.alarms.create(alarmName, { delayInMinutes: 0.5 }),
+          {
+            label: 'playback cleanup alarm scheduling',
+            onError: () => chrome.alarms.create(alarmName, {
+              delayInMinutes: PLAYBACK_CLEANUP_RETRY_DELAY_MINUTES,
+            }),
+          }
         );
       }
       return result;
@@ -217,29 +253,44 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 });
 
 chrome.tabs.onRemoved.addListener((tabId) => {
-  void playbackOwnership.removeTab(tabId);
+  void runDetachedTask(() => playbackOwnership.removeTab(tabId), {
+    label: 'playback tab removal',
+  });
 });
 
 chrome.tabs.onCreated.addListener((tab) => {
   if (Number.isInteger(tab?.openerTabId)) {
-    void playbackOwnership.bindTarget({
+    void runDetachedTask(() => playbackOwnership.bindTarget({
       tabId: tab.id,
       openerTabId: tab.openerTabId,
+    }), {
+      label: 'playback target binding',
     });
   }
 });
 
 chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
   if (changeInfo.url) {
-    void playbackOwnership.handleTabNavigation({ tabId, url: changeInfo.url });
+    void runDetachedTask(
+      () => playbackOwnership.handleTabNavigation({
+        tabId,
+        url: changeInfo.url,
+      }),
+      { label: 'playback tab navigation' }
+    );
   }
 });
 
 // SW が起きたタイミングで期限チェックと積み残しの再送を行う(どちらも未連携・空キュー
 // なら即終了)。refresh を先に済ませ、旧トークンでの sync 401 を避ける。
-checkAndRefreshToken().finally(() => {
-  void syncPendingQueue();
-});
+void runDetachedTask(async () => {
+  await runDetachedTask(() => checkAndRefreshToken(), {
+    label: 'service worker token refresh',
+  });
+  await runDetachedTask(() => syncPendingQueue(), {
+    label: 'service worker pending sync',
+  });
+}, { label: 'service worker initialization' });
 
 async function handleInstalledDemo(details) {
   try {
@@ -290,52 +341,13 @@ async function handleInstalledDemo(details) {
 }
 
 chrome.runtime.onInstalled.addListener((details) => {
-  scheduleAlarms();
-  void handleInstalledDemo(details);
-});
-
-function readOrCreateInstanceId() {
-  return new Promise((resolve, reject) => {
-    chrome.storage.local.get('extensionInstanceId', (result) => {
-      if (chrome.runtime.lastError) {
-        reject(new Error(chrome.runtime.lastError.message));
-        return;
-      }
-
-      if (result.extensionInstanceId) {
-        resolve(result.extensionInstanceId);
-        return;
-      }
-
-      // 初回リンク時は生成した ID の永続化を待ってから解決する。
-      // 先に応答すると、ページがトークンを往復させた際に saveExtensionAuthToken() 側の
-      // getOrCreateExtensionInstanceId() が書き込み前の storage を読んで別 ID を生成し、
-      // instanceId 不一致でトークンが拒否される競合が起きるため。
-      const extensionInstanceId = crypto.randomUUID();
-      chrome.storage.local.set({ extensionInstanceId }, () => {
-        if (chrome.runtime.lastError) {
-          reject(new Error(chrome.runtime.lastError.message));
-          return;
-        }
-        resolve(extensionInstanceId);
-      });
-    });
+  void runDetachedTask(() => scheduleAlarms(), {
+    label: 'installed alarm scheduling',
   });
-}
-
-// instanceId 生成を 1 経路に直列化する。port 接続(GET_EXTENSION_INSTANCE_ID)と
-// content script からの auth-status 経路が空 storage に同時アクセスしても、同一の
-// in-flight Promise を共有して同じ ID に解決させ、二重生成による不一致を防ぐ。
-let instanceIdPromise = null;
-function getOrCreateInstanceId() {
-  if (!instanceIdPromise) {
-    instanceIdPromise = readOrCreateInstanceId().catch((error) => {
-      instanceIdPromise = null; // 失敗時は次回再試行できるようリセット
-      throw error;
-    });
-  }
-  return instanceIdPromise;
-}
+  void runDetachedTask(() => handleInstalledDemo(details), {
+    label: 'installed demo flow',
+  });
+});
 
 chrome.runtime.onConnect.addListener((port) => {
   if (port.name !== 'extensionInstanceId') return;

--- a/src/background/comments.js
+++ b/src/background/comments.js
@@ -4,7 +4,12 @@ import {
   clearExtensionAuthState,
   storageGet,
 } from './../shared/storage.js';
-import { runExclusive } from './sync.js';
+import {
+  isValidExtensionAuthToken,
+  isValidExtensionInstanceId,
+} from './../shared/authValidation.js';
+import { runExclusive } from './authMutex.js';
+import { getOrCreateInstanceIdWhileExclusive } from './instanceId.js';
 import { isValidCommentBody } from '../shared/commentText.js';
 
 const DEFAULT_COMMENT_LIMIT = 20;
@@ -90,6 +95,7 @@ export function getCommentsResponseReason(status) {
   if (status === 401) return 'unauthorized';
   if (status === 403) return 'forbidden';
   if (status === 404) return 'not_found';
+  if (status === 429) return 'rate_limited';
   return 'request_failed';
 }
 
@@ -192,6 +198,7 @@ async function requestCommentsApi({ method, value, signal, deadline }) {
   const stored = await storageGet([
     STORAGE_KEYS.extensionInstanceId,
     STORAGE_KEYS.extensionAuthToken,
+    STORAGE_KEYS.extensionLinked,
   ]);
   const extensionInstanceId = stored[STORAGE_KEYS.extensionInstanceId];
   const extensionAuthToken = stored[STORAGE_KEYS.extensionAuthToken];
@@ -200,12 +207,20 @@ async function requestCommentsApi({ method, value, signal, deadline }) {
   // storage. Never start a stale network request after the caller timed out.
   if (signal.aborted || Date.now() >= deadline) return timeoutResult();
 
-  if (
-    typeof extensionInstanceId !== 'string' ||
-    extensionInstanceId.length === 0 ||
-    typeof extensionAuthToken !== 'string' ||
-    extensionAuthToken.length === 0
-  ) {
+  if (!isValidExtensionInstanceId(extensionInstanceId)) {
+    await getOrCreateInstanceIdWhileExclusive();
+    if (signal.aborted || Date.now() >= deadline) return timeoutResult();
+    return { ok: false, reason: 'missing_token' };
+  }
+
+  if (!isValidExtensionAuthToken(extensionAuthToken)) {
+    if (
+      extensionAuthToken !== undefined
+      || stored[STORAGE_KEYS.extensionLinked] === true
+    ) {
+      await clearExtensionAuthState();
+      if (signal.aborted || Date.now() >= deadline) return timeoutResult();
+    }
     return { ok: false, reason: 'missing_token' };
   }
 
@@ -245,7 +260,10 @@ async function requestCommentsApi({ method, value, signal, deadline }) {
     return { ok: false, reason: timedOut ? 'timeout' : 'network_error' };
   }
 
-  if (signal.aborted || Date.now() >= deadline) return timeoutResult();
+  // Once fetch and JSON consumption have completed, wall-clock drift alone is
+  // not a timeout. Only the timer actually aborting this request can discard a
+  // completed response (matching fetchJsonWithTimeout semantics).
+  if (signal.aborted) return timeoutResult();
 
   const expectedSuccessStatus = method === 'GET' ? 200 : 201;
   const successfulStatus = response.status === expectedSuccessStatus;

--- a/src/background/detachedTasks.js
+++ b/src/background/detachedTasks.js
@@ -1,0 +1,54 @@
+export const PLAYBACK_CLEANUP_RETRY_DELAY_MINUTES = 1;
+
+function reportFailure(logger, label, phase, error) {
+  try {
+    logger(`[background] ${label} ${phase}`, {
+      message: typeof error?.message === 'string'
+        ? error.message.slice(0, 500)
+        : 'unknown error',
+    });
+  } catch {
+    // A diagnostic sink must never turn a handled background failure back into
+    // an unhandled rejection.
+  }
+}
+
+/** Run a fire-and-forget task while guaranteeing that its Promise resolves. */
+export async function runDetachedTask(
+  task,
+  {
+    label = 'detached task',
+    onError,
+    logger = (...args) => console.error(...args),
+  } = {}
+) {
+  try {
+    return { ok: true, value: await task() };
+  } catch (error) {
+    reportFailure(logger, label, 'failed', error);
+    if (typeof onError === 'function') {
+      try {
+        await onError(error);
+      } catch (recoveryError) {
+        reportFailure(logger, label, 'recovery failed', recoveryError);
+      }
+    }
+    return { ok: false, reason: 'task_failed' };
+  }
+}
+
+export function runPlaybackCleanupTask({
+  cleanup,
+  alarmName,
+  scheduleAlarm,
+  retryDelayInMinutes = PLAYBACK_CLEANUP_RETRY_DELAY_MINUTES,
+  logger,
+}) {
+  return runDetachedTask(cleanup, {
+    label: 'playback cleanup',
+    logger,
+    onError: () => scheduleAlarm(alarmName, {
+      delayInMinutes: retryDelayInMinutes,
+    }),
+  });
+}

--- a/src/background/instanceId.js
+++ b/src/background/instanceId.js
@@ -1,0 +1,69 @@
+import {
+  STORAGE_KEYS,
+  clearExtensionAuthState,
+  storageGet,
+  storageSet,
+} from './../shared/storage.js';
+import { isValidExtensionInstanceId } from './../shared/authValidation.js';
+import { runExclusive } from './authMutex.js';
+
+async function readOrCreateInstanceId() {
+  const stored = await storageGet([STORAGE_KEYS.extensionInstanceId]);
+  const existingId = stored[STORAGE_KEYS.extensionInstanceId];
+  if (isValidExtensionInstanceId(existingId)) {
+    return existingId;
+  }
+
+  // An auth token is bound to its instance ID. If the ID is missing or
+  // malformed, keeping the old token would expose a false linked state and
+  // make every API request fail until a later 401 happens to clean it up.
+  await clearExtensionAuthState();
+
+  const extensionInstanceId = crypto.randomUUID();
+  await storageSet({ [STORAGE_KEYS.extensionInstanceId]: extensionInstanceId });
+  return extensionInstanceId;
+}
+
+async function readValidInstanceIdOrRepair() {
+  const stored = await storageGet([STORAGE_KEYS.extensionInstanceId]);
+  const existingId = stored[STORAGE_KEYS.extensionInstanceId];
+  if (isValidExtensionInstanceId(existingId)) {
+    return existingId;
+  }
+
+  // Re-read under the mutex before mutating. Valid-ID lookups stay responsive
+  // while a comments/sync request is in flight, but repair remains ordered with
+  // every auth writer.
+  return runExclusive(readOrCreateInstanceId);
+}
+
+let instanceIdPromise = null;
+
+// Callers already running under the auth mutex use this entry point to avoid
+// reacquiring the non-reentrant lock.
+export function getOrCreateInstanceIdWhileExclusive() {
+  return readOrCreateInstanceId();
+}
+
+/**
+ * Share only the currently running read/create operation. Re-reading storage
+ * after it settles lets the extension recover if local storage is cleared or
+ * corrupted while the service worker remains alive.
+ */
+export function getOrCreateInstanceId() {
+  if (!instanceIdPromise) {
+    const pending = readValidInstanceIdOrRepair();
+    const shared = pending.then(
+      (extensionInstanceId) => {
+        if (instanceIdPromise === shared) instanceIdPromise = null;
+        return extensionInstanceId;
+      },
+      (error) => {
+        if (instanceIdPromise === shared) instanceIdPromise = null;
+        throw error;
+      }
+    );
+    instanceIdPromise = shared;
+  }
+  return instanceIdPromise;
+}

--- a/src/background/playbackOwnership.js
+++ b/src/background/playbackOwnership.js
@@ -35,7 +35,16 @@ const SNAPSHOT_KEYS = [
 ];
 
 function isNonce(value) {
-  return typeof value === 'string' && value.length >= 8 && value.length <= 200;
+  return typeof value === 'string' &&
+    /^[a-z\d-]{8,200}$/i.test(value);
+}
+
+function getOwnEntry(record, key) {
+  return key !== undefined &&
+    key !== null &&
+    Object.hasOwn(record, key)
+    ? record[key]
+    : undefined;
 }
 
 function getOwnerNonceFromUrl(value) {
@@ -83,6 +92,7 @@ export function createPlaybackOwnershipManager({
   now = () => Date.now(),
 }) {
   let operation = Promise.resolve();
+  const NO_LOCAL_UPDATE = Symbol('no-local-update');
 
   const exclusive = (task) => {
     const next = operation.then(task, task);
@@ -97,22 +107,27 @@ export function createPlaybackOwnershipManager({
     const pending = raw?.pending && typeof raw.pending === 'object' ? raw.pending : {};
     const currentTime = now();
     const retainedPending = Object.fromEntries(
-      Object.entries(pending).filter(([, handoff]) =>
-        Number(handoff?.expiresAt ?? handoff) > currentTime
-      )
+      Object.entries(pending)
+        .filter(([, handoff]) =>
+          Number(handoff?.expiresAt ?? handoff) > currentTime
+        )
+        .map(([nonce, handoff]) => [
+          nonce,
+          handoff && typeof handoff === 'object' ? { ...handoff } : handoff,
+        ])
     );
     const registry = {
-      active: { ...active },
+      active: Object.fromEntries(
+        Object.entries(active).map(([tabId, entry]) => [
+          tabId,
+          entry && typeof entry === 'object' ? { ...entry } : entry,
+        ])
+      ),
       pending: retainedPending,
       revision: Number.isSafeInteger(raw?.revision) && raw.revision >= 0
         ? raw.revision
         : 0,
     };
-    if (Object.keys(retainedPending).length !== Object.keys(pending).length) {
-      await writeRegistry(registry);
-      await reconcileGlobalOwner(registry);
-      await clearGlobalIfIdle(registry);
-    }
     return registry;
   }
 
@@ -120,45 +135,89 @@ export function createPlaybackOwnershipManager({
     await sessionStorage.set({ [PLAYBACK_REGISTRY_STORAGE_KEY]: registry });
   }
 
-  async function clearGlobalIfIdle(registry) {
-    if (
-      Object.keys(registry.active).length === 0 &&
-      Object.keys(registry.pending).length === 0
-    ) {
-      const current = await localStorage.get(SNAPSHOT_KEYS);
-      const alreadyReset = SNAPSHOT_KEYS.every((key) => {
-        const value = current?.[key];
-        const resetValue = GLOBAL_PLAYBACK_RESET[key];
-        return value === resetValue || (value === undefined && resetValue !== undefined);
-      });
-      if (!alreadyReset) await localStorage.set(GLOBAL_PLAYBACK_RESET);
-      return true;
+  function isRegistryIdle(registry) {
+    return Object.keys(registry.active).length === 0 &&
+      Object.keys(registry.pending).length === 0;
+  }
+
+  async function captureStorageValues(area, keys) {
+    const stored = await area.get(keys);
+    return Object.fromEntries(
+      keys
+        .filter(
+          (key) => Object.hasOwn(stored || {}, key) && stored[key] !== undefined
+        )
+        .map((key) => [key, stored[key]])
+    );
+  }
+
+  async function restoreStorageValues(area, keys, previous) {
+    const values = Object.fromEntries(
+      keys
+        .filter((key) => Object.hasOwn(previous, key))
+        .map((key) => [key, previous[key]])
+    );
+    const missing = keys.filter((key) => !Object.hasOwn(previous, key));
+    if (Object.keys(values).length > 0) await area.set(values);
+    if (missing.length > 0) {
+      if (typeof area.remove !== 'function') {
+        throw new Error('Storage rollback is unavailable');
+      }
+      await area.remove(missing);
     }
-    return false;
   }
 
-  async function restoreLatestOwnedSnapshot(registry, removedNonce) {
-    const globalState = await localStorage.get(PLAYBACK_OWNER_STORAGE_KEY);
-    if (globalState?.[PLAYBACK_OWNER_STORAGE_KEY] !== removedNonce) return false;
-    const latest = latestOwnedSnapshot(registry);
-    if (!latest?.snapshot) return false;
-    await localStorage.set(latest.snapshot);
-    return true;
+  async function commitOwnershipState(registry, localUpdate = NO_LOCAL_UPDATE) {
+    if (localUpdate === NO_LOCAL_UPDATE) {
+      const registryKeys = [PLAYBACK_REGISTRY_STORAGE_KEY];
+      const previousRegistry = await captureStorageValues(
+        sessionStorage,
+        registryKeys
+      );
+      try {
+        await writeRegistry(registry);
+      } catch (error) {
+        await Promise.allSettled([
+          restoreStorageValues(sessionStorage, registryKeys, previousRegistry),
+        ]);
+        throw error;
+      }
+      return;
+    }
+
+    const registryKeys = [PLAYBACK_REGISTRY_STORAGE_KEY];
+    const localKeys = Object.keys(localUpdate);
+    const [previousRegistry, previousLocal] = await Promise.all([
+      captureStorageValues(sessionStorage, registryKeys),
+      captureStorageValues(localStorage, localKeys),
+    ]);
+
+    try {
+      await writeRegistry(registry);
+      await localStorage.set(localUpdate);
+    } catch (error) {
+      await Promise.allSettled([
+        restoreStorageValues(sessionStorage, registryKeys, previousRegistry),
+        restoreStorageValues(localStorage, localKeys, previousLocal),
+      ]);
+      throw error;
+    }
   }
 
-  async function reconcileGlobalOwner(registry) {
+  async function getReconciledLocalUpdate(registry) {
+    if (isRegistryIdle(registry)) return GLOBAL_PLAYBACK_RESET;
     const globalState = await localStorage.get(PLAYBACK_OWNER_STORAGE_KEY);
     const globalOwner = globalState?.[PLAYBACK_OWNER_STORAGE_KEY];
-    if (
-      Object.values(registry.active).some((entry) => entry?.nonce === globalOwner) ||
-      registry.pending[globalOwner]
-    ) {
-      return false;
-    }
-    const latest = latestOwnedSnapshot(registry);
-    if (!latest?.snapshot) return false;
-    await localStorage.set(latest.snapshot);
-    return true;
+    const ownerStillExists = Object.values(registry.active)
+      .some((entry) => entry?.nonce === globalOwner) ||
+      Boolean(getOwnEntry(registry.pending, globalOwner));
+    if (ownerStillExists) return NO_LOCAL_UPDATE;
+    return latestOwnedSnapshot(registry)?.snapshot || GLOBAL_PLAYBACK_RESET;
+  }
+
+  async function persistReconciledRegistry(registry) {
+    const localUpdate = await getReconciledLocalUpdate(registry);
+    await commitOwnershipState(registry, localUpdate);
   }
 
   function compareActiveRecency(a, b) {
@@ -209,8 +268,7 @@ export function createPlaybackOwnershipManager({
         revision: takeRevision(registry),
         updatedAt: now(),
       };
-      await localStorage.set(normalizedSnapshot);
-      await writeRegistry(registry);
+      await commitOwnershipState(registry, normalizedSnapshot);
       return {
         ok: true,
         context: normalizedContext,
@@ -222,6 +280,9 @@ export function createPlaybackOwnershipManager({
   function claim({ tabId, openerTabId, nonce, route }) {
     return exclusive(async () => {
       if (!Number.isInteger(tabId)) {
+        return { ok: false, reason: 'invalid_claim' };
+      }
+      if (nonce !== undefined && nonce !== null && !isNonce(nonce)) {
         return { ok: false, reason: 'invalid_claim' };
       }
 
@@ -243,14 +304,14 @@ export function createPlaybackOwnershipManager({
             }
           );
           if (eligiblePending.length > 1) {
-            await writeRegistry(registry);
+            await persistReconciledRegistry(registry);
             return { ok: false, reason: 'ambiguous_handoff' };
           }
           resolvedNonce = eligiblePending[0]?.[0];
         }
       }
       if (!isNonce(resolvedNonce)) {
-        await clearGlobalIfIdle(registry);
+        await persistReconciledRegistry(registry);
         return {
           ok: false,
           reason: 'handoff_not_found',
@@ -258,7 +319,7 @@ export function createPlaybackOwnershipManager({
         };
       }
       const existing = registry.active[tabKey];
-      const handoff = registry.pending[resolvedNonce];
+      const handoff = getOwnEntry(registry.pending, resolvedNonce);
       const sourceTabId = Number(handoff?.sourceTabId);
       const mayClaim =
         existing?.nonce === resolvedNonce ||
@@ -269,7 +330,7 @@ export function createPlaybackOwnershipManager({
             Number(handoff?.targetTabId) === tabId
           ));
       if (!mayClaim) {
-        await clearGlobalIfIdle(registry);
+        await persistReconciledRegistry(registry);
         return {
           ok: false,
           reason: 'handoff_not_found',
@@ -283,7 +344,7 @@ export function createPlaybackOwnershipManager({
         ? normalizeSnapshot(source?.snapshot, resolvedNonce, normalizedContext)
         : null;
       if (!normalizedContext || !normalizedSnapshot) {
-        await writeRegistry(registry);
+        await persistReconciledRegistry(registry);
         return { ok: false, reason: 'snapshot_mismatch' };
       }
 
@@ -296,12 +357,8 @@ export function createPlaybackOwnershipManager({
       if (claimRoute && !snapshotMatchesRoute(normalizedSnapshot, normalizedContext, claimRoute)) {
         if (existing?.nonce === resolvedNonce) {
           delete registry.active[tabKey];
-          await writeRegistry(registry);
-          await restoreLatestOwnedSnapshot(registry, existing.nonce);
-          await clearGlobalIfIdle(registry);
-        } else {
-          await writeRegistry(registry);
         }
+        await persistReconciledRegistry(registry);
         return {
           ok: false,
           reason: 'route_mismatch',
@@ -316,9 +373,7 @@ export function createPlaybackOwnershipManager({
         claimRoute !== existing.expectedRoute
       ) {
         delete registry.active[tabKey];
-        await writeRegistry(registry);
-        await restoreLatestOwnedSnapshot(registry, existing.nonce);
-        await clearGlobalIfIdle(registry);
+        await persistReconciledRegistry(registry);
         return {
           ok: false,
           reason: 'route_mismatch',
@@ -326,7 +381,6 @@ export function createPlaybackOwnershipManager({
         };
       }
 
-      await localStorage.set(normalizedSnapshot);
       registry.active[tabKey] = {
         nonce: resolvedNonce,
         context: normalizedContext,
@@ -338,7 +392,7 @@ export function createPlaybackOwnershipManager({
         updatedAt: now(),
       };
       delete registry.pending[resolvedNonce];
-      await writeRegistry(registry);
+      await commitOwnershipState(registry, normalizedSnapshot);
       return {
         ok: true,
         nonce: resolvedNonce,
@@ -366,7 +420,7 @@ export function createPlaybackOwnershipManager({
       const tabKey = String(tabId);
       const existing = registry.active[tabKey];
       if (existing?.nonce !== nonce) {
-        await writeRegistry(registry);
+        await persistReconciledRegistry(registry);
         return { ok: false, reason: 'not_owner' };
       }
 
@@ -389,7 +443,6 @@ export function createPlaybackOwnershipManager({
         return { ok: false, reason: 'snapshot_mismatch' };
       }
 
-      await localStorage.set(normalizedSnapshot);
       registry.active[tabKey] = {
         nonce,
         context: normalizedContext,
@@ -400,7 +453,7 @@ export function createPlaybackOwnershipManager({
         revision: takeRevision(registry),
         updatedAt: now(),
       };
-      await writeRegistry(registry);
+      await commitOwnershipState(registry, normalizedSnapshot);
       return {
         ok: true,
         context: normalizedContext,
@@ -419,12 +472,20 @@ export function createPlaybackOwnershipManager({
       const registry = await readRegistry();
       const existing = registry.active[String(tabId)];
       if (existing?.nonce !== nonce) {
-        await writeRegistry(registry);
+        await persistReconciledRegistry(registry);
         return { ok: false, reason: 'not_owner' };
+      }
+      if (!snapshotMatchesRoute(
+        existing.snapshot,
+        existing.context,
+        nextRoute
+      )) {
+        await persistReconciledRegistry(registry);
+        return { ok: false, reason: 'route_mismatch' };
       }
       existing.expectedRoute = nextRoute;
       existing.autoNavigationRoute = null;
-      await writeRegistry(registry);
+      await persistReconciledRegistry(registry);
       return { ok: true };
     });
   }
@@ -441,14 +502,14 @@ export function createPlaybackOwnershipManager({
           !Number.isInteger(handoff?.targetTabId)
       );
       if (eligible.length !== 1) {
-        await writeRegistry(registry);
+        await persistReconciledRegistry(registry);
         return {
           ok: false,
           reason: eligible.length > 1 ? 'ambiguous_handoff' : 'handoff_not_found',
         };
       }
       eligible[0].targetTabId = tabId;
-      await writeRegistry(registry);
+      await persistReconciledRegistry(registry);
       return { ok: true };
     });
   }
@@ -461,30 +522,33 @@ export function createPlaybackOwnershipManager({
       const existing = registry.active[tabKey];
       if (!existing) {
         const pendingNonce = getOwnerNonceFromUrl(url);
-        if (isNonce(pendingNonce) && registry.pending[pendingNonce]) {
-          if (registry.pending[pendingNonce].targetTabId !== tabId) {
-            registry.pending[pendingNonce].targetTabId = tabId;
-            await writeRegistry(registry);
+        const pending = isNonce(pendingNonce)
+          ? getOwnEntry(registry.pending, pendingNonce)
+          : null;
+        if (pending) {
+          if (pending.targetTabId !== tabId) {
+            pending.targetTabId = tabId;
           }
         }
+        await persistReconciledRegistry(registry);
         return { ok: true, released: false };
       }
       const nextRoute = normalizeRoute(url);
       if (nextRoute && nextRoute === existing.route) {
+        await persistReconciledRegistry(registry);
         return { ok: true, released: false };
       }
       if (nextRoute && nextRoute === existing.expectedRoute) {
         existing.route = nextRoute;
         existing.expectedRoute = null;
         existing.autoNavigationRoute = nextRoute;
-        await writeRegistry(registry);
+        await persistReconciledRegistry(registry);
         return { ok: true, released: false };
       }
 
       delete registry.active[tabKey];
-      await writeRegistry(registry);
-      await restoreLatestOwnedSnapshot(registry, existing.nonce);
-      const cleared = await clearGlobalIfIdle(registry);
+      await persistReconciledRegistry(registry);
+      const cleared = isRegistryIdle(registry);
       return { ok: true, released: true, cleared };
     });
   }
@@ -495,16 +559,11 @@ export function createPlaybackOwnershipManager({
       const registry = await readRegistry();
       const tabKey = String(tabId);
       const existing = registry.active[tabKey];
-      let removed = null;
       if (existing && isNonce(nonce) && existing.nonce === nonce) {
-        removed = existing;
         delete registry.active[tabKey];
       }
-      await writeRegistry(registry);
-      if (removed) {
-        await restoreLatestOwnedSnapshot(registry, removed.nonce);
-      }
-      const cleared = await clearGlobalIfIdle(registry);
+      await persistReconciledRegistry(registry);
+      const cleared = isRegistryIdle(registry);
       return { ok: true, cleared };
     });
   }
@@ -513,13 +572,9 @@ export function createPlaybackOwnershipManager({
     return exclusive(async () => {
       if (!Number.isInteger(tabId)) return { ok: false, reason: 'invalid_tab' };
       const registry = await readRegistry();
-      const existing = registry.active[String(tabId)];
       delete registry.active[String(tabId)];
-      await writeRegistry(registry);
-      if (existing) {
-        await restoreLatestOwnedSnapshot(registry, existing.nonce);
-      }
-      const cleared = await clearGlobalIfIdle(registry);
+      await persistReconciledRegistry(registry);
+      const cleared = isRegistryIdle(registry);
       return { ok: true, cleared };
     });
   }
@@ -527,9 +582,8 @@ export function createPlaybackOwnershipManager({
   function cleanupExpired() {
     return exclusive(async () => {
       const registry = await readRegistry();
-      await writeRegistry(registry);
-      await reconcileGlobalOwner(registry);
-      const cleared = await clearGlobalIfIdle(registry);
+      await persistReconciledRegistry(registry);
+      const cleared = isRegistryIdle(registry);
       return { ok: true, cleared };
     });
   }
@@ -537,8 +591,7 @@ export function createPlaybackOwnershipManager({
   function reset() {
     return exclusive(async () => {
       const registry = { active: {}, pending: {}, revision: 0 };
-      await writeRegistry(registry);
-      await localStorage.set(GLOBAL_PLAYBACK_RESET);
+      await commitOwnershipState(registry, GLOBAL_PLAYBACK_RESET);
       return { ok: true };
     });
   }

--- a/src/background/sync.js
+++ b/src/background/sync.js
@@ -6,6 +6,12 @@ import {
   normalizePendingClips,
   clearExtensionAuthState,
 } from './../shared/storage.js';
+import {
+  isValidExtensionAuthToken,
+  isValidExtensionInstanceId,
+} from './../shared/authValidation.js';
+import { runExclusive } from './authMutex.js';
+import { getOrCreateInstanceIdWhileExclusive } from './instanceId.js';
 import { fetchJsonWithTimeout } from './request.js';
 
 // 同期 fetch は background(service worker)で実行する。content script の fetch は
@@ -18,14 +24,50 @@ const LOGIN_PROMPT_COOLDOWN_MS = 60 * 1000;
 
 // sync とトークンリフレッシュを直列化するミューテックス。ローテーション中に旧トークンで
 // sync が走ると 401 → トークン誤クリアになるため、両者は必ずこれを通す。
-let exclusiveChain = Promise.resolve();
-export function runExclusive(task) {
-  const run = exclusiveChain.then(() => task());
-  exclusiveChain = run.then(
+export { runExclusive } from './authMutex.js';
+
+// Keep queue read-modify-write operations in one background context. This is
+// deliberately separate from the auth mutex: sync holds that mutex across the
+// network request, while recording a new clip must not wait up to 15 seconds.
+let pendingQueueMutationChain = Promise.resolve();
+function runPendingQueueMutation(task) {
+  const run = pendingQueueMutationChain.then(() => task());
+  pendingQueueMutationChain = run.then(
     () => {},
     () => {}
   );
   return run;
+}
+
+function isValidPendingClipForEnqueue(clip) {
+  return clip !== null
+    && typeof clip === 'object'
+    && !Array.isArray(clip)
+    && typeof clip.clientItemId === 'string'
+    && clip.clientItemId.length > 0
+    && typeof clip.url === 'string'
+    && clip.url.length > 0
+    && Number.isFinite(clip.startTime)
+    && Number.isFinite(clip.endTime);
+}
+
+export function enqueuePendingClipInBackground(clip) {
+  if (!isValidPendingClipForEnqueue(clip)) {
+    return Promise.resolve({ ok: false, reason: 'invalid_clip' });
+  }
+
+  return runPendingQueueMutation(async () => {
+    const stored = await storageGet([STORAGE_KEYS.pendingClips]);
+    const pendingClips = normalizePendingClips(stored[STORAGE_KEYS.pendingClips]);
+    const queueById = new Map(
+      pendingClips.map((pendingClip) => [pendingClip.clientItemId, pendingClip])
+    );
+    queueById.set(clip.clientItemId, clip);
+    await storageSet({
+      [STORAGE_KEYS.pendingClips]: Array.from(queueById.values()),
+    });
+    return { ok: true };
+  });
 }
 
 function toExtensionSyncItem(clip) {
@@ -77,13 +119,42 @@ async function removePendingClipIds(clientItemIds) {
   const ids = new Set(clientItemIds.filter(Boolean));
   if (ids.size === 0) return;
 
-  const stored = await storageGet([STORAGE_KEYS.pendingClips]);
-  const pendingClips = normalizePendingClips(stored[STORAGE_KEYS.pendingClips]);
-  await storageSet({
-    [STORAGE_KEYS.pendingClips]: pendingClips.filter(
-      (clip) => !ids.has(clip.clientItemId)
-    ),
+  await runPendingQueueMutation(async () => {
+    const stored = await storageGet([STORAGE_KEYS.pendingClips]);
+    const pendingClips = normalizePendingClips(stored[STORAGE_KEYS.pendingClips]);
+    await storageSet({
+      [STORAGE_KEYS.pendingClips]: pendingClips.filter(
+        (clip) => !ids.has(clip.clientItemId)
+      ),
+    });
   });
+}
+
+function validateSyncSuccessResponse(data, pendingClips) {
+  if (
+    data === null
+    || typeof data !== 'object'
+    || Array.isArray(data)
+    || data.ok !== true
+    || !Array.isArray(data.acceptedItemIds)
+  ) {
+    return null;
+  }
+
+  const attemptedIds = new Set(pendingClips.map((clip) => clip.clientItemId));
+  const acceptedIds = new Set();
+  for (const clientItemId of data.acceptedItemIds) {
+    if (
+      typeof clientItemId !== 'string'
+      || !attemptedIds.has(clientItemId)
+      || acceptedIds.has(clientItemId)
+    ) {
+      return null;
+    }
+    acceptedIds.add(clientItemId);
+  }
+
+  return Array.from(acceptedIds);
 }
 
 async function performOpenLoginTab({ force = false } = {}) {
@@ -132,17 +203,33 @@ async function performSyncPendingQueue({ openLoginIfMissingToken = false } = {})
   const stored = await storageGet([
     STORAGE_KEYS.extensionInstanceId,
     STORAGE_KEYS.extensionAuthToken,
+    STORAGE_KEYS.extensionLinked,
     STORAGE_KEYS.pendingClips,
   ]);
   const extensionInstanceId = stored[STORAGE_KEYS.extensionInstanceId];
-  const extensionAuthToken = stored[STORAGE_KEYS.extensionAuthToken] || null;
+  const extensionAuthToken = stored[STORAGE_KEYS.extensionAuthToken];
   const pendingClips = normalizePendingClips(stored[STORAGE_KEYS.pendingClips]);
 
   if (pendingClips.length === 0) {
     return { ok: true, skipped: true, reason: 'empty_queue' };
   }
 
-  if (!extensionAuthToken || !extensionInstanceId) {
+  if (!isValidExtensionInstanceId(extensionInstanceId)) {
+    await getOrCreateInstanceIdWhileExclusive();
+  } else if (
+    !isValidExtensionAuthToken(extensionAuthToken)
+    && (
+      extensionAuthToken !== undefined
+      || stored[STORAGE_KEYS.extensionLinked] === true
+    )
+  ) {
+    await clearExtensionAuthState();
+  }
+
+  if (
+    !isValidExtensionAuthToken(extensionAuthToken)
+    || !isValidExtensionInstanceId(extensionInstanceId)
+  ) {
     console.log('[extension-sync] sync start', {
       clipCount: pendingClips.length,
       hasToken: false,
@@ -192,12 +279,12 @@ async function performSyncPendingQueue({ openLoginIfMissingToken = false } = {})
   });
 
   if (response.status === 200) {
-    // フィールドが存在すればそれが権威的（空配列＝受理ゼロなので何も削除しない）。
-    // フィールド自体が無いレガシー応答のときだけ、従来どおり全送信分を削除する。
-    const hasAcceptedField = Array.isArray(data?.acceptedItemIds);
-    const syncedItemIds = hasAcceptedField
-      ? data.acceptedItemIds
-      : pendingClips.map((clip) => clip.clientItemId);
+    const syncedItemIds = validateSyncSuccessResponse(data, pendingClips);
+    if (syncedItemIds === null) {
+      console.warn('[extension-sync] malformed success response; keeping clips queued');
+      return { ok: false, queued: true, reason: 'invalid_response' };
+    }
+
     await removePendingClipIds(syncedItemIds);
     await storageSet({ [STORAGE_KEYS.lastSyncAt]: new Date().toISOString() });
     return { ok: true, acceptedCount: syncedItemIds.length };
@@ -205,19 +292,30 @@ async function performSyncPendingQueue({ openLoginIfMissingToken = false } = {})
 
   if (response.status === 400) {
     const issueItemIds = Array.from(collectClientItemIds(data?.issues || data));
-    const dropItemIds = issueItemIds.length > 0
-      ? issueItemIds
-      : pendingClips.map((clip) => clip.clientItemId);
+    if (issueItemIds.length === 0) {
+      // Production validation responses intentionally omit schema details. A
+      // generic 400 cannot identify which item is bad, so deleting the whole
+      // attempted batch would also discard valid clips without an ack.
+      console.warn('[extension-sync] validation error without item IDs; keeping clips queued', {
+        clipCount: pendingClips.length,
+      });
+      return { ok: false, queued: true, reason: 'validation_error' };
+    }
 
-    console.warn('[extension-sync] validation error; dropping attempted clips', {
-      clipCount: dropItemIds.length,
-      issues: data?.issues || data?.error || data?.message,
+    console.warn('[extension-sync] validation error; dropping identified clips', {
+      clipCount: issueItemIds.length,
     });
-    await removePendingClipIds(dropItemIds);
+    await removePendingClipIds(issueItemIds);
     return { ok: false, queued: false, reason: 'validation_error' };
   }
 
   if (response.status === 401) {
+    const current = await storageGet([STORAGE_KEYS.extensionAuthToken]);
+    if (current[STORAGE_KEYS.extensionAuthToken] !== extensionAuthToken) {
+      console.log('[extension-sync] stale sync 401 for replaced token; keeping current token');
+      return { ok: false, queued: true, reason: 'stale_unauthorized' };
+    }
+
     await clearExtensionAuthState();
     console.warn('[extension-sync] auth token rejected; cleared token and kept queue');
     if (openLoginIfMissingToken) {

--- a/src/background/tokenRefresh.js
+++ b/src/background/tokenRefresh.js
@@ -6,7 +6,13 @@ import {
   storageRemove,
   clearExtensionAuthState,
 } from './../shared/storage.js';
-import { runExclusive } from './sync.js';
+import {
+  isValidExtensionInstanceId,
+  isValidExtensionAuthToken,
+  normalizeExtensionTokenExpiry,
+} from './../shared/authValidation.js';
+import { runExclusive } from './authMutex.js';
+import { getOrCreateInstanceIdWhileExclusive } from './instanceId.js';
 import { fetchJsonWithTimeout } from './request.js';
 
 // トークンはサーバ発行の不透明トークン(JWT ではない)。期限はサーバが link/refresh 応答の
@@ -69,6 +75,23 @@ function clearRefreshBackoff() {
   return storageRemove([STORAGE_KEYS.extensionTokenRefreshBackoff]);
 }
 
+function normalizeRefreshSuccess(data) {
+  const expiresAt = normalizeExtensionTokenExpiry(data?.expiresAt);
+  if (
+    data?.ok !== true
+    || !isValidExtensionAuthToken(data.extensionAuthToken)
+    || expiresAt === null
+    || Date.parse(expiresAt) <= Date.now()
+  ) {
+    return null;
+  }
+
+  return {
+    extensionAuthToken: data.extensionAuthToken,
+    expiresAt,
+  };
+}
+
 export function checkAndRefreshToken() {
   return runExclusive(performCheckAndRefreshToken);
 }
@@ -77,13 +100,25 @@ async function performCheckAndRefreshToken() {
   const stored = await storageGet([
     STORAGE_KEYS.extensionAuthToken,
     STORAGE_KEYS.extensionInstanceId,
+    STORAGE_KEYS.extensionLinked,
     STORAGE_KEYS.extensionTokenExpiresAt,
     STORAGE_KEYS.extensionTokenRefreshBackoff,
   ]);
   const token = stored[STORAGE_KEYS.extensionAuthToken];
   const extensionInstanceId = stored[STORAGE_KEYS.extensionInstanceId];
 
-  if (!token || !extensionInstanceId) {
+  if (!isValidExtensionInstanceId(extensionInstanceId)) {
+    await getOrCreateInstanceIdWhileExclusive();
+    return { ok: true, skipped: true, reason: 'not_linked' };
+  }
+
+  if (!isValidExtensionAuthToken(token)) {
+    if (
+      token !== undefined
+      || stored[STORAGE_KEYS.extensionLinked] === true
+    ) {
+      await clearExtensionAuthState();
+    }
     return { ok: true, skipped: true, reason: 'not_linked' };
   }
 
@@ -136,14 +171,21 @@ async function performCheckAndRefreshToken() {
   }
   const { response, data } = request;
 
-  if (response.status === 200 && typeof data?.extensionAuthToken === 'string') {
+  if (response.status === 200) {
+    const refreshed = normalizeRefreshSuccess(data);
+    if (!refreshed) {
+      console.warn('[extension-sync] malformed token refresh response; keeping current token');
+      await recordRefreshFailure(token, response.status);
+      return { ok: false, reason: 'invalid_response' };
+    }
+
     await storageSet({
-      [STORAGE_KEYS.extensionAuthToken]: data.extensionAuthToken,
-      [STORAGE_KEYS.extensionTokenExpiresAt]: data.expiresAt || null,
+      [STORAGE_KEYS.extensionAuthToken]: refreshed.extensionAuthToken,
+      [STORAGE_KEYS.extensionTokenExpiresAt]: refreshed.expiresAt,
       [STORAGE_KEYS.extensionLinked]: true,
     });
     await clearRefreshBackoff();
-    console.log('[extension-sync] token refreshed', { expiresAt: data.expiresAt });
+    console.log('[extension-sync] token refreshed', { expiresAt: refreshed.expiresAt });
     return { ok: true, refreshed: true };
   }
 

--- a/src/content/commentPanel.js
+++ b/src/content/commentPanel.js
@@ -453,6 +453,12 @@ export function isAmbiguousPostFailure(reason) {
     || reason === 'request_failed';
 }
 
+export function shouldClosePanelForKeyEvent(event) {
+  return event?.type === 'keydown'
+    && event.key === 'Escape'
+    && event.isComposing !== true;
+}
+
 async function openLoginPage(controller) {
   if (controller.closed || controller.openingLogin) return;
   controller.openingLogin = true;
@@ -647,6 +653,10 @@ async function performLoadComments(
 
 function refreshCurrentClip(controller, { queueIfBusy = false } = {}) {
   if (controller.closed) return Promise.resolve();
+  if (controller.posting && queueIfBusy) {
+    controller.refreshQueued = true;
+    return Promise.resolve();
+  }
   if (controller.refreshPromise) {
     if (queueIfBusy) controller.refreshQueued = true;
     return controller.refreshPromise;
@@ -857,6 +867,10 @@ async function postComment(controller) {
     if (!controller.closed) {
       controller.posting = false;
       updateSubmitState(controller);
+      if (controller.refreshQueued) {
+        controller.refreshQueued = false;
+        void refreshCurrentClip(controller, { queueIfBusy: true });
+      }
     }
   }
 }
@@ -971,8 +985,8 @@ function notifyOpenState(controller, open) {
   }
   try {
     controller.onOpenChange?.(open);
-  } catch (error) {
-    console.warn('[extension-comments] onOpenChange failed', error);
+  } catch {
+    console.warn('[extension-comments] onOpenChange failed');
   }
   dispatchPanelOpenState(open);
 }
@@ -992,7 +1006,7 @@ function addKeyGuard(controller) {
     if (controller.closed || !eventBelongsToPanel(event, controller)) return;
     // Capture on window before the event reaches document/player shortcuts.
     event.stopImmediatePropagation();
-    if (event.type === 'keydown' && event.key === 'Escape') {
+    if (shouldClosePanelForKeyEvent(event)) {
       event.preventDefault();
       closeController(controller);
     }
@@ -1241,7 +1255,7 @@ function createPanel({ mountEl, triggerEl, onOpenChange }) {
   }
   panel.addEventListener('keydown', (event) => {
     event.stopPropagation();
-    if (event.key === 'Escape') {
+    if (shouldClosePanelForKeyEvent(event)) {
       event.preventDefault();
       closeController(controller);
     }

--- a/src/content/common.js
+++ b/src/content/common.js
@@ -5,6 +5,7 @@ import {
 
 export const MEMO_SIDEBAR_ID = 'nf-memo-sidebar';
 export const AUTO_NAVIGATION_KEY = 'extAutoNavigation';
+export const AUTO_NAVIGATION_TTL_MS = 15000;
 export const CLOSE_COMMENT_PANEL_EVENT = 'ext:close-comment-panel';
 
 // 表示中サイドバーの状態。再オープン時に元のプレイヤー幅を引き継ぎつつ、
@@ -33,7 +34,10 @@ export function closeMemoSidebar() {
   const player =
     document.querySelector('.watch-video--player-view') ||
     document.querySelector('video')?.parentElement;
-  if (player) player.style.width = originalWidth || '100%';
+  if (player) {
+    player.style.width =
+      originalWidth === undefined ? '100%' : originalWidth;
+  }
   return true;
 }
 
@@ -114,6 +118,7 @@ export function openMemoSidebar({
     document.querySelector('.watch-video--player-view') ||
     document.querySelector('video')?.parentElement;
   if (!player) return null;
+  const focusTarget = document.activeElement;
 
   requestCloseCommentPanel();
 
@@ -131,7 +136,7 @@ export function openMemoSidebar({
       : player.style.width;
   if (previousSession) {
     previousSession.supersede();
-    previousSession.close({ notify: false });
+    previousSession.close({ notify: false, restoreFocus: false });
   }
   document.getElementById(MEMO_SIDEBAR_ID)?.remove();
 
@@ -140,12 +145,16 @@ export function openMemoSidebar({
 
   const sb = document.createElement('div');
   sb.id = MEMO_SIDEBAR_ID;
+  sb.setAttribute('role', 'dialog');
+  sb.setAttribute('aria-modal', 'false');
+  sb.setAttribute('aria-labelledby', `${MEMO_SIDEBAR_ID}-title`);
   sb.style.cssText = `
     position:fixed;top:0;right:0;width:${sidebarPct}%;
     height:100%;background:rgba(0,0,0,.85);padding:10px;
     box-sizing:border-box;z-index:9999;display:flex;flex-direction:column;gap:8px;`;
 
   let removeKeyGuard;
+  let removeMountObserver;
   let session;
   let closed = false;
   let superseded = false;
@@ -153,22 +162,29 @@ export function openMemoSidebar({
   const header = document.createElement('div');
   header.style.cssText = 'display:flex;justify-content:space-between;align-items:center;';
   const title = document.createElement('strong');
+  title.id = `${MEMO_SIDEBAR_ID}-title`;
   title.textContent = sidebarTitle;
   title.style.color = 'white';
   const closeBtn = document.createElement('button');
+  closeBtn.type = 'button';
   closeBtn.textContent = '×';
+  closeBtn.setAttribute('aria-label', '録画メモを閉じる');
   closeBtn.style.cssText = 'background:red;color:#fff;border:none;cursor:pointer;';
-  const closeSidebar = ({ notify = true } = {}) => {
+  const closeSidebar = ({ notify = true, restoreFocus = true } = {}) => {
     if (closed) return;
     closed = true;
     removeKeyGuard?.();
+    removeMountObserver?.();
     // 保存完了が遅れても、現在表示中のセッションだけがプレイヤー幅を変更できる。
     if (activeMemoSession === session) {
       activeMemoSession = null;
-      player.style.width = originalWidth || '100%';
+      player.style.width = originalWidth;
     }
     sb.remove();
     if (notify) onClose?.();
+    if (restoreFocus && focusTarget?.isConnected) {
+      focusTarget.focus?.();
+    }
   };
   closeBtn.onclick = closeSidebar;
   header.append(title, closeBtn);
@@ -219,10 +235,11 @@ export function openMemoSidebar({
     };
     const result = onSave ? onSave(enriched) : sendData(enriched);
     Promise.resolve(result)
-      .catch((error) => console.error('保存エラー:', error))
+      .catch(() => console.error('保存に失敗しました'))
       .finally(() => {
         // 再オープンで置き換えられた旧セッションは、新しい入力中の再生状態に触れない。
         if (
+          !closed &&
           !superseded &&
           (!activeMemoSession || activeMemoSession === session)
         ) {
@@ -235,7 +252,10 @@ export function openMemoSidebar({
   // パネル内キーはサイトへ渡さず入力欄で処理。Enter で保存（IME 変換確定・リピート除外）。
   const onPanelKey = (e) => {
     if (!sb.contains(e.target)) return;
-    if (
+    if (e.type === 'keydown' && e.key === 'Escape' && !e.isComposing) {
+      e.preventDefault();
+      closeSidebar();
+    } else if (
       e.target === nameInput &&
       e.type === 'keydown' &&
       e.key === 'Enter' &&
@@ -280,6 +300,7 @@ export function openMemoSidebar({
   };
 
   const saveBtn = document.createElement('button');
+  saveBtn.type = 'button';
   saveBtn.textContent = '保存';
   saveBtn.style.cssText = 'background:#00c853;border:none;color:#fff;padding:6px;cursor:pointer;';
   saveBtn.onclick = submit;
@@ -299,27 +320,156 @@ export function openMemoSidebar({
   };
   activeMemoSession = session;
 
+  const MutationObserverConstructor = globalThis.MutationObserver;
+  const observationRoot = document.documentElement || document.body;
+  if (
+    typeof MutationObserverConstructor === 'function' &&
+    observationRoot
+  ) {
+    const mountObserver = new MutationObserverConstructor(() => {
+      if (!closed && !sb.isConnected) {
+        closeSidebar({ restoreFocus: false });
+      }
+    });
+    mountObserver.observe(observationRoot, { childList: true, subtree: true });
+    removeMountObserver = () => mountObserver.disconnect();
+  }
+
   nameInput.focus();
   nameInput.select();
 
   return sb;
 }
 
-export function markAutoNavigation(reason = 'auto') {
-  sessionStorage.setItem(AUTO_NAVIGATION_KEY, reason);
-  localStorage.setItem(AUTO_NAVIGATION_KEY, reason);
+function readAutoNavigationMarker() {
+  try {
+    const rawMarker = globalThis.sessionStorage?.getItem(AUTO_NAVIGATION_KEY);
+    if (!rawMarker) return null;
+    const marker = JSON.parse(rawMarker);
+    if (!marker || typeof marker !== 'object') return null;
+    return marker;
+  } catch {
+    return null;
+  }
 }
 
-export function isAutoNavigation() {
+export function markAutoNavigation({
+  ownerNonce,
+  expectedRoute,
+  reason = 'auto',
+  now = Date.now(),
+} = {}) {
+  clearAutoNavigation();
+  if (
+    typeof ownerNonce !== 'string' ||
+    ownerNonce.length < 8 ||
+    typeof expectedRoute !== 'string' ||
+    expectedRoute.length === 0 ||
+    !Number.isFinite(now)
+  ) {
+    return false;
+  }
+
+  try {
+    globalThis.sessionStorage?.setItem(
+      AUTO_NAVIGATION_KEY,
+      JSON.stringify({ ownerNonce, expectedRoute, reason, createdAt: now }),
+    );
+    return Boolean(globalThis.sessionStorage);
+  } catch {
+    return false;
+  }
+}
+
+export function isAutoNavigation({
+  ownerNonce,
+  expectedRoute,
+  maxAgeMs = AUTO_NAVIGATION_TTL_MS,
+  now = Date.now(),
+} = {}) {
+  const marker = readAutoNavigationMarker();
+  const age = now - Number(marker?.createdAt);
   return Boolean(
-    sessionStorage.getItem(AUTO_NAVIGATION_KEY) ||
-      localStorage.getItem(AUTO_NAVIGATION_KEY)
+    marker &&
+      typeof ownerNonce === 'string' &&
+      marker.ownerNonce === ownerNonce &&
+      typeof expectedRoute === 'string' &&
+      marker.expectedRoute === expectedRoute &&
+      Number.isFinite(maxAgeMs) &&
+      maxAgeMs >= 0 &&
+      Number.isFinite(age) &&
+      age >= 0 &&
+      age <= maxAgeMs
   );
 }
 
 export function clearAutoNavigation() {
-  sessionStorage.removeItem(AUTO_NAVIGATION_KEY);
-  localStorage.removeItem(AUTO_NAVIGATION_KEY);
+  try {
+    globalThis.sessionStorage?.removeItem(AUTO_NAVIGATION_KEY);
+  } catch {
+    // The background ownership guard still rejects an unprepared route.
+  }
+}
+
+export function consumeAutoNavigation(options) {
+  const matched = isAutoNavigation(options);
+  clearAutoNavigation();
+  return matched;
+}
+
+export function handleOwnedPlaybackRouteChange({
+  ownerNonce,
+  currentRoute,
+  nextRoute,
+  onAutoNavigation,
+  onManualNavigation,
+}) {
+  if (!ownerNonce || nextRoute === currentRoute) return 'unchanged';
+  if (consumeAutoNavigation({ ownerNonce, expectedRoute: nextRoute })) {
+    onAutoNavigation?.(nextRoute);
+    return 'auto';
+  }
+  onManualNavigation?.();
+  return 'manual';
+}
+
+export function createElementWait(
+  selector,
+  {
+    documentRef = globalThis.document,
+    MutationObserverConstructor = globalThis.MutationObserver,
+  } = {},
+) {
+  let observer = null;
+  let settled = false;
+  let resolveWait;
+  const finish = (element) => {
+    if (settled) return;
+    settled = true;
+    observer?.disconnect();
+    resolveWait(element);
+  };
+  const promise = new Promise((resolve) => {
+    resolveWait = resolve;
+    const existing = documentRef?.querySelector?.(selector);
+    if (existing) {
+      finish(existing);
+      return;
+    }
+    if (!documentRef?.body || typeof MutationObserverConstructor !== 'function') {
+      finish(null);
+      return;
+    }
+    observer = new MutationObserverConstructor(() => {
+      const element = documentRef.querySelector(selector);
+      if (element) finish(element);
+    });
+    observer.observe(documentRef.body, { childList: true, subtree: true });
+  });
+  return {
+    promise,
+    cancel: () => finish(null),
+  };
 }
 
 // === タブ可視性に応じた拡張 UI の表示制御 ===

--- a/src/content/content_disney.js
+++ b/src/content/content_disney.js
@@ -1,6 +1,9 @@
 import {
+  clearAutoNavigation,
   detectService,
   EXT_UI_CLASS,
+  handleOwnedPlaybackRouteChange,
+  markAutoNavigation,
   markExtUi,
   openMemoSidebar,
   requestSeek,
@@ -31,8 +34,7 @@ import {
 
 (() => {
   ensurePlaybackContext();
-  const AUTO_NAV_TTL_MS = 15000;
-  let autoNavCache = null;
+  clearAutoNavigation();
   let activePlaybackOwnerNonce = null;
   let playbackLocation = null;
 
@@ -84,25 +86,11 @@ import {
     const ownerNonce = activePlaybackOwnerNonce;
     activePlaybackOwnerNonce = null;
     playbackLocation = null;
+    clearAutoNavigation();
     clearPlaybackContext();
     closeCommentPanel();
     releasePlaybackOwnership(ownerNonce);
     Mode.stop();
-  }
-
-  function isAutoNavValid(autoNav) {
-    if (!autoNav || typeof autoNav !== 'object') return false;
-    const ts = Number(autoNav.ts);
-    if (!Number.isFinite(ts)) return false;
-    return Date.now() - ts <= AUTO_NAV_TTL_MS;
-  }
-
-  function isAutoNavActive() {
-    return isAutoNavValid(autoNavCache);
-  }
-
-  function clearAutoNavState() {
-    autoNavCache = null;
   }
 
   async function beginAutoNavigation({ mode, nextUrl, nextOrder, nextId }) {
@@ -114,15 +102,15 @@ import {
       deactivatePlaybackContext();
       return false;
     }
-    const autoNav = {
-      ts: Date.now(),
-      mode,
-      nextUrl,
-      nextOrder,
-      nextId
-    };
-
-    autoNavCache = autoNav;
+    const marked = markAutoNavigation({
+      ownerNonce: activePlaybackOwnerNonce,
+      expectedRoute: routeIdentity(nextUrl),
+      reason: `${mode}:${nextOrder ?? ''}:${nextId ?? ''}`,
+    });
+    if (!marked) {
+      deactivatePlaybackContext();
+      return false;
+    }
     return true;
   }
 
@@ -952,7 +940,7 @@ import {
       if (!clipData) return;
       stopCurrent = Playlist.play([clipData], {
         loop: loopEnabled,
-        onStart: clearAutoNavState
+        onStart: clearAutoNavigation
       });
     }
 
@@ -988,7 +976,7 @@ async function startPlaylistMode(session) {
 
   function playPlaylistClip(clipData) {
     stopCurrent = Clip.play(clipData, {
-      onStart: clearAutoNavState,
+      onStart: clearAutoNavigation,
       onEnd: handlePlaylistEnd
     });
   }
@@ -1030,7 +1018,7 @@ async function startPlaylistMode(session) {
 
     const nextClipData = normalizeClipData(next);
     if (!nextClipData) {
-      console.warn('[Playlist] 次クリップのデータが不正です:', next);
+      console.warn('[Playlist] 次クリップのデータが不正です');
       return;
     }
 
@@ -1041,7 +1029,7 @@ async function startPlaylistMode(session) {
       const baseUrl = buildClipUrl(nextUrl, nextClipData.startTime);
       if (!baseUrl) return;
       const url = addPlaybackOwnerToUrl(baseUrl, activePlaybackOwnerNonce);
-      console.log('[Playlist] 異なるURL → ページ遷移:', url);
+      console.log('[Playlist] 異なるURLへページ遷移します');
 
       setTimeout(async () => {
         const prepared = await beginAutoNavigation({
@@ -1065,7 +1053,6 @@ async function startPlaylistMode(session) {
       const ownerNonce = getTabPlaybackOwnerNonce();
       const session = await claimPlaybackSession(ownerNonce);
       if (!session) return;
-      autoNavCache = session.autoNavigation ? { ts: Date.now() } : null;
       currentSession = session;
       if (session.context.mode === 'playlist') {
         await startPlaylistMode(session);
@@ -1128,13 +1115,15 @@ async function startPlaylistMode(session) {
   window.addEventListener('historyChange', (event) => {
     UI.scheduleInjection();
     const nextLocation = routeIdentity(event.detail?.url || location.href);
-    if (
-      activePlaybackOwnerNonce &&
-      nextLocation !== playbackLocation &&
-      !isAutoNavActive()
-    ) {
-      deactivatePlaybackContext();
-    }
+    handleOwnedPlaybackRouteChange({
+      ownerNonce: activePlaybackOwnerNonce,
+      currentRoute: playbackLocation,
+      nextRoute: nextLocation,
+      onAutoNavigation: (route) => {
+        playbackLocation = route;
+      },
+      onManualNavigation: deactivatePlaybackContext,
+    });
   });
   window.addEventListener('load', () => UI.scheduleInjection(), { once: true });
 

--- a/src/content/content_netflix.js
+++ b/src/content/content_netflix.js
@@ -8,9 +8,10 @@ import { getApiEndpoint } from './../api.js';
 import {
   clearAutoNavigation,
   closeMemoSidebar,
+  createElementWait,
   detectService,
   handleClipTransition,
-  isAutoNavigation,
+  handleOwnedPlaybackRouteChange,
   markAutoNavigation,
   markExtUi,
   MEMO_SIDEBAR_ID,
@@ -98,7 +99,9 @@ function initializeNetflixPlayback() {
   let activePlaylistQueue = null;
   let activePlaylistOrder = null;
   let playbackGeneration = 0;
+  let cancelPendingVideoWait = null;
   let removePendingMetadataListener = null;
+  let removeVideoErrorListener = null;
 
   function applyPlaybackContext(context, ownerNonce) {
     setPlaybackContext(context);
@@ -146,29 +149,44 @@ function initializeNetflixPlayback() {
     activePlaybackOwnerNonce = null;
     playbackLocation = null;
     playbackGeneration += 1;
+    clearAutoNavigation();
     clearPlaybackContext();
     closeCommentPanel();
     releasePlaybackOwnership(ownerNonce);
 
-    stopClipEndMonitor?.();
-    stopClipEndMonitor = null;
-    removePendingMetadataListener?.();
-    removePendingMetadataListener = null;
-    if (countdownIntervalId !== null) {
-      clearInterval(countdownIntervalId);
-      countdownIntervalId = null;
-    }
-    stopUIWarmer();
+    stopPlaybackRuntime();
     clipData = null;
     activePlaylistQueue = null;
     activePlaylistOrder = null;
   }
 
+  function stopPlaybackRuntime() {
+    cancelPendingVideoWait?.();
+    cancelPendingVideoWait = null;
+    stopClipEndMonitor?.();
+    stopClipEndMonitor = null;
+    removePendingMetadataListener?.();
+    removePendingMetadataListener = null;
+    removeVideoErrorListener?.();
+    removeVideoErrorListener = null;
+    if (countdownIntervalId !== null) {
+      clearInterval(countdownIntervalId);
+      countdownIntervalId = null;
+    }
+    stopUIWarmer();
+  }
+
   function handlePlaybackRouteChange(nextUrl) {
     const resolvedUrl = routeIdentity(nextUrl || location.href);
-    if (!activePlaybackOwnerNonce || resolvedUrl === playbackLocation) return;
-    if (isAutoNavigation()) return;
-    deactivatePlaybackContext();
+    handleOwnedPlaybackRouteChange({
+      ownerNonce: activePlaybackOwnerNonce,
+      currentRoute: playbackLocation,
+      nextRoute: resolvedUrl,
+      onAutoNavigation: (route) => {
+        playbackLocation = route;
+      },
+      onManualNavigation: deactivatePlaybackContext,
+    });
   }
 
   clearAutoNavigation();
@@ -263,7 +281,7 @@ function initializeNetflixPlayback() {
             startTime = videoPlayer.currentTime;
           }
         } catch (error) {
-          console.error(error);
+          console.error('[Clip] recording action failed');
           alert(error.message);
           resetRecordState();
         }
@@ -300,7 +318,6 @@ function initializeNetflixPlayback() {
       window.addEventListener("historyChange", (e) => {
         resetRecordState();
         handlePlaybackRouteChange(e.detail?.url);
-        chrome.runtime.sendMessage({ type: "HISTORY_CHANGE", data: e.detail });
       });
 
       function resetRecordState() {
@@ -559,9 +576,9 @@ function initializeNetflixPlayback() {
         return;
       }
       renderClipList(container, { items, onSelect: (clipId) => selectClip(clipId) });
-    } catch (err) {
+    } catch {
       container.textContent = "データの取得に失敗しました。";
-      console.error("API取得失敗:", err);
+      console.error("API取得に失敗しました");
     }
   }
 
@@ -601,7 +618,7 @@ function initializeNetflixPlayback() {
         openClip: (selectedClip) => redirectToClip(selectedClip, ownerNonce)
       });
     } catch (err) {
-      console.error("クリップ選択処理でエラー:", err);
+      console.error("クリップ選択処理でエラーが発生しました");
       const unsupported = err?.message?.includes('invalid_service');
       window.alert(
         unsupported
@@ -658,30 +675,35 @@ function initializeNetflixPlayback() {
       title: snapshot.clip.title,
       clipId: snapshot.clip.clipId ?? snapshot.clip.id
     };
-    console.info('[Clip] loaded:', clipData);
+    console.info('[Clip] loaded');
     return true;
   }
 
-  function waitForVideoElement() {
-    return new Promise(resolve => {
-      const existing = document.querySelector('video');
-      if (existing) return resolve(existing);
-      const observer = new MutationObserver(() => {
-        const v = document.querySelector('video');
-        if (v) { observer.disconnect(); resolve(v); }
-      });
-      observer.observe(document.body, { childList: true, subtree: true });
-    });
+  async function waitForVideoElement(generation) {
+    cancelPendingVideoWait?.();
+    const wait = createElementWait('video');
+    cancelPendingVideoWait = wait.cancel;
+    try {
+      const player = await wait.promise;
+      return generation === playbackGeneration ? player : null;
+    } finally {
+      if (cancelPendingVideoWait === wait.cancel) {
+        cancelPendingVideoWait = null;
+      }
+    }
   }
 
   async function init(session) {
     try {
       const loaded = loadClipFromSession(session);
       if (!loaded) return;
-      videoPlayer = await waitForVideoElement();
+      const generation = playbackGeneration;
+      const player = await waitForVideoElement(generation);
+      if (!player || generation !== playbackGeneration || !clipData) return;
+      videoPlayer = player;
       setupPlayer("clip");
-    } catch (err) {
-      console.error('[Clip] Initialization failed:', err);
+    } catch {
+      console.error('[Clip] Initialization failed');
     }
   }
 
@@ -711,7 +733,10 @@ function initializeNetflixPlayback() {
         endTime:   Number(currentClip.endTime   ?? currentClip.endtime),
         title:     currentClip.clipname
       };
-      videoPlayer = await waitForVideoElement();
+      const generation = playbackGeneration;
+      const player = await waitForVideoElement(generation);
+      if (!player || generation !== playbackGeneration || !clipData) return;
+      videoPlayer = player;
       setupPlayer("playlist");
   }
 
@@ -779,7 +804,6 @@ function initializeNetflixPlayback() {
       },
 
       onDifferentUrl: async () => {
-        markAutoNavigation("playlist");
         const targetUrl = buildServiceUrl(
           next.service,
           next.url,
@@ -799,6 +823,15 @@ function initializeNetflixPlayback() {
           deactivatePlaybackContext();
           return;
         }
+        const marked = markAutoNavigation({
+          ownerNonce: activePlaybackOwnerNonce,
+          expectedRoute: routeIdentity(url),
+          reason: 'playlist',
+        });
+        if (!marked) {
+          deactivatePlaybackContext();
+          return;
+        }
         setTimeout(() => { window.location.href = url; }, 150);
       }
     });
@@ -812,9 +845,15 @@ function initializeNetflixPlayback() {
     const start = Number(clipData?.startTime);
 
     if (!Number.isFinite(end) || !Number.isFinite(start)) {
-      console.warn("[Clip] clipDataの時間が不正です:", clipData);
+      console.warn("[Clip] clipDataの時間が不正です");
       return;
     }
+
+    // A replacement player can already have metadata while the previous
+    // element is still waiting for it. Remove that stale listener before the
+    // ready-state branch so it cannot start an obsolete monitor later.
+    removePendingMetadataListener?.();
+    removePendingMetadataListener = null;
 
     const setupGeneration = playbackGeneration;
     const onReady = () => {
@@ -827,7 +866,6 @@ function initializeNetflixPlayback() {
     if (videoPlayer.readyState >= 1) {
       onReady();
     } else {
-      removePendingMetadataListener?.();
       const metadataPlayer = videoPlayer;
       const removeMetadataListener = () =>
         metadataPlayer.removeEventListener('loadedmetadata', onReady);
@@ -835,7 +873,17 @@ function initializeNetflixPlayback() {
       metadataPlayer.addEventListener('loadedmetadata', onReady, { once: true });
     }
 
-    videoPlayer.addEventListener('error', e => console.error('[Video] error:', e));
+    removeVideoErrorListener?.();
+    const errorPlayer = videoPlayer;
+    const onVideoError = () => console.error('[Video] playback error');
+    const removeErrorListener = () => {
+      errorPlayer.removeEventListener('error', onVideoError);
+      if (removeVideoErrorListener === removeErrorListener) {
+        removeVideoErrorListener = null;
+      }
+    };
+    errorPlayer.addEventListener('error', onVideoError);
+    removeVideoErrorListener = removeErrorListener;
   }
 
   function monitorClipEnd(end, start, mode /* "clip" | "playlist" */) {
@@ -852,7 +900,7 @@ function initializeNetflixPlayback() {
 
     function onTimeUpdate() {
       if (monitoredPlayer.currentTime + EPSILON >= end) {
-        console.info("[Clip] Reached end:", clipData?.title || "unknown");
+        console.info("[Clip] Reached end");
         stopMonitor();
         clearInterval(countdownIntervalId);
 
@@ -941,6 +989,7 @@ function initializeNetflixPlayback() {
   // ---------------------------------------------------------------------------
   window.addEventListener("beforeunload", () => {
     playbackGeneration += 1;
+    stopPlaybackRuntime();
     clearPlaybackContext();
     closeCommentPanel();
   });

--- a/src/content/extensionSync.js
+++ b/src/content/extensionSync.js
@@ -1,9 +1,12 @@
 import {
   STORAGE_KEYS,
   storageGet,
-  storageSet,
   normalizePendingClips,
 } from './../shared/storage.js';
+import {
+  isValidExtensionAuthToken,
+  isValidExtensionInstanceId,
+} from './../shared/authValidation.js';
 
 // このモジュールは content script 専用。サイト API への fetch(同期・トークンリフレッシュ)は
 // background(src/background/sync.js, tokenRefresh.js)が担う。content の fetch はページ
@@ -56,7 +59,7 @@ function sendRuntimeMessage(message) {
 export async function getOrCreateExtensionInstanceId() {
   const stored = await storageGet([STORAGE_KEYS.extensionInstanceId]);
   const existingId = stored[STORAGE_KEYS.extensionInstanceId];
-  if (existingId) {
+  if (isValidExtensionInstanceId(existingId)) {
     return existingId;
   }
 
@@ -64,7 +67,7 @@ export async function getOrCreateExtensionInstanceId() {
   // 読んで別 UUID を作ると instanceId 不一致でトークンが拒否されるため、ここでは自前生成
   // せず background の直列化された生成器から取得する。
   const response = await sendRuntimeMessage({ type: 'GET_OR_CREATE_INSTANCE_ID' });
-  if (response?.ok && response.extensionInstanceId) {
+  if (response?.ok && isValidExtensionInstanceId(response.extensionInstanceId)) {
     return response.extensionInstanceId;
   }
   throw new Error(response?.message || 'Failed to obtain extensionInstanceId');
@@ -72,7 +75,10 @@ export async function getOrCreateExtensionInstanceId() {
 
 export async function getExtensionInstanceId() {
   const stored = await storageGet([STORAGE_KEYS.extensionInstanceId]);
-  return stored[STORAGE_KEYS.extensionInstanceId] ?? null;
+  const extensionInstanceId = stored[STORAGE_KEYS.extensionInstanceId];
+  return isValidExtensionInstanceId(extensionInstanceId)
+    ? extensionInstanceId
+    : null;
 }
 
 export async function getExtensionConnectionState() {
@@ -83,7 +89,10 @@ export async function getExtensionConnectionState() {
     STORAGE_KEYS.lastSyncAt,
     STORAGE_KEYS.pendingClips,
   ]);
-  const extensionAuthToken = stored[STORAGE_KEYS.extensionAuthToken] || null;
+  const storedAuthToken = stored[STORAGE_KEYS.extensionAuthToken];
+  const extensionAuthToken = isValidExtensionAuthToken(storedAuthToken)
+    ? storedAuthToken
+    : null;
 
   return {
     extensionInstanceId,
@@ -124,14 +133,13 @@ export function toExtensionClipPayload(clip) {
 
 export async function enqueueClip(clip) {
   const normalizedClip = toExtensionClipPayload(clip);
-  const stored = await storageGet([STORAGE_KEYS.pendingClips]);
-  const pendingClips = normalizePendingClips(stored[STORAGE_KEYS.pendingClips]);
-  const queueById = new Map(pendingClips.map((item) => [item.clientItemId, item]));
-  queueById.set(normalizedClip.clientItemId, normalizedClip);
-
-  await storageSet({
-    [STORAGE_KEYS.pendingClips]: Array.from(queueById.values()),
+  const result = await sendRuntimeMessage({
+    type: 'ENQUEUE_PENDING_CLIP',
+    clip: normalizedClip,
   });
+  if (!result?.ok) {
+    throw new Error(result?.message || result?.reason || 'Failed to enqueue clip');
+  }
 
   return normalizedClip;
 }

--- a/src/content/extension_link.js
+++ b/src/content/extension_link.js
@@ -16,8 +16,6 @@ function isTrustedOrigin(origin) {
   return TRUSTED_ORIGINS.has(origin);
 }
 
-console.log('[extension-link] content script loaded on', location.href);
-
 // トークンの期限チェック・自動リフレッシュは background(tokenRefresh.js)が
 // chrome.alarms と SW 起動時に行う。content 側では何もしない。
 
@@ -32,13 +30,8 @@ window.addEventListener('message', (event) => {
   if (!data || typeof data !== 'object') return;
   if (data.type !== 'GET_EXTENSION_INSTANCE_ID') return;
 
-  console.log('[extension-link] GET_EXTENSION_INSTANCE_ID received', {
-    requestId: data.requestId,
-  });
-
   const port = chrome.runtime.connect({ name: 'extensionInstanceId' });
   port.onMessage.addListener((response) => {
-    console.log('[extension-link] background response', response);
     window.postMessage(
       { type: 'EXTENSION_INSTANCE_ID_RESPONSE', requestId: data.requestId, ...response },
       window.location.origin

--- a/src/content/getClipData.js
+++ b/src/content/getClipData.js
@@ -65,7 +65,12 @@ function publishHandoffResult({ source, requestId, result }) {
 }
 
 async function registerClipHandoff(clip) {
-  const nonce = createPlaybackOwnerNonce();
+  let nonce;
+  try {
+    nonce = createPlaybackOwnerNonce();
+  } catch {
+    return { result: { ok: false, reason: 'handoff_failed' }, nonce: null };
+  }
   const result = await beginPlaybackHandoff({
     nonce,
     mode: 'clip',
@@ -126,7 +131,18 @@ window.addEventListener('message', async (event) => {
 
   const source = 'PLAY_PLAYLIST_START';
   const requestId = normalizeRequestId(message.requestId);
-  const normalized = normalizePlaylistJson(localStorage.getItem('playQueue'));
+  let rawQueue;
+  try {
+    rawQueue = localStorage.getItem('playQueue');
+  } catch {
+    publishHandoffResult({
+      source,
+      requestId,
+      result: { ok: false, reason: 'handoff_failed' },
+    });
+    return;
+  }
+  const normalized = normalizePlaylistJson(rawQueue);
   if (!normalized.ok) {
     publishHandoffResult({ source, requestId, result: normalized });
     return;
@@ -136,7 +152,17 @@ window.addEventListener('message', async (event) => {
   const firstClip = queue.reduce((first, item) =>
     item.order < first.order ? item : first
   );
-  const nonce = createPlaybackOwnerNonce();
+  let nonce;
+  try {
+    nonce = createPlaybackOwnerNonce();
+  } catch {
+    publishHandoffResult({
+      source,
+      requestId,
+      result: { ok: false, reason: 'handoff_failed' },
+    });
+    return;
+  }
   const handoff = await beginPlaybackHandoff({
     nonce,
     mode: 'playlist',

--- a/src/content/playbackContext.js
+++ b/src/content/playbackContext.js
@@ -5,6 +5,7 @@ const PLAYBACK_CONTEXT_STORAGE_KEY = 'dextPlaybackContextV1';
 const EMPTY_SNAPSHOT = Object.freeze({ initialized: false, context: null });
 let memorySnapshot = EMPTY_SNAPSHOT;
 let memoryFallbackActive = false;
+let memoryStorage = null;
 
 function normalizeClipId(value) {
   const numberValue =
@@ -53,12 +54,22 @@ function parseStoredSnapshot(rawValue) {
 export function readPlaybackContext() {
   const storage = getSessionStorage();
   if (!storage) return memorySnapshot;
-  if (memoryFallbackActive) return memorySnapshot;
+  if (
+    memoryStorage === storage ||
+    (memoryFallbackActive && memoryStorage === null)
+  ) {
+    return memorySnapshot;
+  }
 
   try {
     const rawValue = storage.getItem(PLAYBACK_CONTEXT_STORAGE_KEY);
-    return parseStoredSnapshot(rawValue);
+    memorySnapshot = parseStoredSnapshot(rawValue);
+    memoryStorage = storage;
+    memoryFallbackActive = false;
+    return memorySnapshot;
   } catch {
+    memoryStorage = storage;
+    memoryFallbackActive = true;
     return memorySnapshot;
   }
 }
@@ -98,12 +109,15 @@ function writePlaybackContext(context) {
         PLAYBACK_CONTEXT_STORAGE_KEY,
         JSON.stringify(nextSnapshot)
       );
+      memoryStorage = storage;
       memoryFallbackActive = false;
     } catch {
       // Keep the module-local value so this tab still remains isolated.
+      memoryStorage = storage;
       memoryFallbackActive = true;
     }
   } else {
+    memoryStorage = null;
     memoryFallbackActive = true;
   }
 

--- a/src/content/playbackOwnership.js
+++ b/src/content/playbackOwnership.js
@@ -5,6 +5,19 @@ import {
 
 export { PLAYBACK_OWNER_QUERY_PARAM, PLAYBACK_OWNER_STORAGE_KEY };
 export const PLAYBACK_OWNER_TAB_KEY = 'dextPlaybackOwnerTab';
+
+function readPlaybackOwnerQuery(url = globalThis.location?.href) {
+  try {
+    const searchParams = new URL(url).searchParams;
+    return {
+      present: searchParams.has(PLAYBACK_OWNER_QUERY_PARAM),
+      value: searchParams.get(PLAYBACK_OWNER_QUERY_PARAM),
+    };
+  } catch {
+    return { present: false, value: null };
+  }
+}
+
 function sendMessage(message) {
   return new Promise((resolve) => {
     const runtime = globalThis.chrome?.runtime;
@@ -27,21 +40,47 @@ function sendMessage(message) {
 }
 
 export function createPlaybackOwnerNonce() {
-  return globalThis.crypto?.randomUUID?.() ||
-    `playback-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const cryptoApi = globalThis.crypto;
+  if (typeof cryptoApi?.randomUUID === 'function') {
+    try {
+      const nonce = cryptoApi.randomUUID();
+      if (
+        typeof nonce === 'string' &&
+        nonce.length >= 8 &&
+        nonce.length <= 200
+      ) {
+        return nonce;
+      }
+    } catch {
+      // Fall through to getRandomValues when randomUUID is unavailable at runtime.
+    }
+  }
+
+  if (typeof cryptoApi?.getRandomValues === 'function') {
+    const bytes = new Uint8Array(16);
+    cryptoApi.getRandomValues(bytes);
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    const hex = [...bytes].map((byte) => byte.toString(16).padStart(2, '0'));
+    return [
+      hex.slice(0, 4).join(''),
+      hex.slice(4, 6).join(''),
+      hex.slice(6, 8).join(''),
+      hex.slice(8, 10).join(''),
+      hex.slice(10).join(''),
+    ].join('-');
+  }
+
+  throw new Error('Secure random number generator is unavailable');
 }
 
 export function getPlaybackOwnerNonceFromUrl(url = globalThis.location?.href) {
-  try {
-    return new URL(url).searchParams.get(PLAYBACK_OWNER_QUERY_PARAM);
-  } catch {
-    return null;
-  }
+  return readPlaybackOwnerQuery(url).value;
 }
 
 export function getTabPlaybackOwnerNonce() {
-  const fromUrl = getPlaybackOwnerNonceFromUrl();
-  if (fromUrl) return fromUrl;
+  const fromUrl = readPlaybackOwnerQuery();
+  if (fromUrl.present) return fromUrl.value;
   try {
     return globalThis.sessionStorage?.getItem(PLAYBACK_OWNER_TAB_KEY) || null;
   } catch {
@@ -86,7 +125,8 @@ export function beginPlaybackHandoff({ nonce, mode, clipId, snapshot }) {
 }
 
 export async function claimPlaybackOwnership({ nonce }) {
-  const mayNeedLegacyHandoff = !getPlaybackOwnerNonceFromUrl();
+  const ownerQuery = readPlaybackOwnerQuery();
+  const mayNeedLegacyHandoff = !ownerQuery.present;
   let requestedNonce = nonce;
   for (let attempt = 0; attempt < (mayNeedLegacyHandoff ? 20 : 1); attempt += 1) {
     const result = await sendMessage({
@@ -99,7 +139,7 @@ export async function claimPlaybackOwnership({ nonce }) {
       return result;
     }
     if (
-      !getPlaybackOwnerNonceFromUrl() &&
+      !ownerQuery.present &&
       requestedNonce &&
       (result?.reason === 'handoff_not_found' || result?.reason === 'route_mismatch')
     ) {

--- a/src/shared/authValidation.js
+++ b/src/shared/authValidation.js
@@ -1,0 +1,24 @@
+const EXTENSION_INSTANCE_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const MAX_EXTENSION_AUTH_TOKEN_LENGTH = 4096;
+
+export function isValidExtensionInstanceId(value) {
+  return typeof value === 'string'
+    && EXTENSION_INSTANCE_ID_PATTERN.test(value);
+}
+
+// Bearer credentials are sent as an HTTP header value. Keep the token opaque,
+// but reject values that cannot be represented safely as one header token.
+export function isValidExtensionAuthToken(value) {
+  return typeof value === 'string'
+    && value.length > 0
+    && value.length <= MAX_EXTENSION_AUTH_TOKEN_LENGTH
+    && /^[\x21-\x7e]+$/.test(value);
+}
+
+export function normalizeExtensionTokenExpiry(value) {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  const expiresAtMs = Date.parse(value);
+  return Number.isFinite(expiresAtMs)
+    ? new Date(expiresAtMs).toISOString()
+    : null;
+}

--- a/src/shared/playbackBridgeValidation.js
+++ b/src/shared/playbackBridgeValidation.js
@@ -122,11 +122,21 @@ function normalizeService(value, index) {
   return { ok: true, value: normalized };
 }
 
+function hasExplicitPort(value) {
+  const authority = value
+    .trim()
+    .match(/^(?:[a-z][a-z\d+.-]*:)?[\\/]{2}([^\\/?#]*)/i)?.[1];
+  if (!authority) return false;
+  const hostAndPort = authority.slice(authority.lastIndexOf('@') + 1);
+  return hostAndPort.includes(':');
+}
+
 function normalizeUrl(value, service, index) {
   if (
     typeof value !== 'string' ||
     value.length === 0 ||
-    value.length > MAX_PLAYBACK_URL_LENGTH
+    value.length > MAX_PLAYBACK_URL_LENGTH ||
+    hasExplicitPort(value)
   ) {
     return failure('invalid_url', 'url', index);
   }

--- a/src/util/history_change.js
+++ b/src/util/history_change.js
@@ -1,5 +1,5 @@
 (() => {
-    // manifest / inject_script.js / content_netflix.js の複数経路から注入されうるため、
+    // inject_script.js / content_netflix.js の複数経路から MAIN world へ注入されうるため、
     // 同一 world 内での二重フック（historyChange の重複発火）をガードする。
     if (window.__extHistoryChangeHooked__) return;
     window.__extHistoryChangeHooked__ = true;

--- a/src/util/services.js
+++ b/src/util/services.js
@@ -50,8 +50,8 @@ export function appendStartTimeParam(baseUrl, paramKey, startTime) {
     const urlObj = new URL(baseUrl);
     urlObj.searchParams.set(paramKey, String(startTime));
     return urlObj.toString();
-  } catch (error) {
-    console.warn("⚠️ URL 解析に失敗しました:", baseUrl, error);
+  } catch {
+    console.warn("⚠️ URL 解析に失敗しました");
     return baseUrl;
   }
 }

--- a/test/backgroundAuth.test.js
+++ b/test/backgroundAuth.test.js
@@ -5,18 +5,31 @@ import {
   saveExtensionAuthTokenInBackground,
   unlinkExtensionInBackground,
 } from '../src/background/authState.js';
-import { openLoginTab, syncPendingQueue } from '../src/background/sync.js';
+import {
+  enqueuePendingClipInBackground,
+  openLoginTab,
+  runExclusive,
+  syncPendingQueue,
+} from '../src/background/sync.js';
 import { checkAndRefreshToken } from '../src/background/tokenRefresh.js';
-import { saveExtensionAuthToken } from '../src/content/extensionSync.js';
+import { getOrCreateInstanceId } from '../src/background/instanceId.js';
+import {
+  enqueueClip,
+  getExtensionConnectionState,
+  saveExtensionAuthToken,
+} from '../src/content/extensionSync.js';
 
-async function withChromeState(state, { createTab } = {}, task) {
+const INSTANCE_ID = '11111111-1111-4111-8111-111111111111';
+const OTHER_INSTANCE_ID = '22222222-2222-4222-8222-222222222222';
+
+async function withChromeState(state, { createTab, getStorage } = {}, task) {
   const originalChrome = globalThis.chrome;
   const runtime = { lastError: null };
   globalThis.chrome = {
     runtime,
     storage: {
       local: {
-        get(keys, callback) {
+        get: getStorage || function get(keys, callback) {
           const keyList = Array.isArray(keys) ? keys : [keys];
           callback(Object.fromEntries(
             keyList
@@ -52,31 +65,139 @@ async function withChromeState(state, { createTab } = {}, task) {
 }
 
 test('background auth save validates instance and token before writing', async () => {
-  const state = { extensionInstanceId: 'instance-id' };
+  const state = { extensionInstanceId: INSTANCE_ID };
 
   await withChromeState(state, {}, async () => {
     assert.deepEqual(await saveExtensionAuthTokenInBackground({
-      extensionInstanceId: 'another-instance',
+      extensionInstanceId: OTHER_INSTANCE_ID,
       extensionAuthToken: 'token',
     }), { ok: false, reason: 'instance_mismatch' });
     assert.deepEqual(await saveExtensionAuthTokenInBackground({
-      extensionInstanceId: 'instance-id',
+      extensionInstanceId: INSTANCE_ID,
       extensionAuthToken: '   ',
     }), { ok: false, reason: 'invalid_token' });
+    assert.deepEqual(await saveExtensionAuthTokenInBackground({
+      extensionInstanceId: INSTANCE_ID,
+      extensionAuthToken: 'token\nwith-newline',
+    }), { ok: false, reason: 'invalid_token' });
+    assert.deepEqual(await saveExtensionAuthTokenInBackground({
+      extensionInstanceId: 'not-a-uuid',
+      extensionAuthToken: 'token',
+    }), { ok: false, reason: 'instance_mismatch' });
+    assert.deepEqual(await saveExtensionAuthTokenInBackground({
+      extensionInstanceId: '00000000-0000-0000-0000-000000000000',
+      extensionAuthToken: 'token',
+    }), { ok: false, reason: 'instance_mismatch' });
   });
 
   assert.equal(Object.hasOwn(state, 'extensionAuthToken'), false);
 });
 
+test('instance ID generation coalesces concurrent calls and heals invalid storage', async () => {
+  const state = {
+    extensionInstanceId: 'corrupted-id',
+    extensionAuthToken: 'stale-token',
+    extensionTokenExpiresAt: '2099-01-01T00:00:00.000Z',
+    extensionTokenRefreshBackoff: { failureCount: 2 },
+    extensionLinked: true,
+  };
+  let getCalls = 0;
+  let releaseGet;
+  let markGetStarted;
+  const getStarted = new Promise((resolve) => {
+    markGetStarted = resolve;
+  });
+
+  await withChromeState(state, {
+    getStorage(keys, callback) {
+      getCalls += 1;
+      const keyList = Array.isArray(keys) ? keys : [keys];
+      const respond = () => callback(Object.fromEntries(
+        keyList
+          .filter((key) => Object.hasOwn(state, key))
+          .map((key) => [key, state[key]])
+      ));
+      if (getCalls > 1) {
+        respond();
+        return;
+      }
+      releaseGet = respond;
+      markGetStarted();
+    },
+  }, async () => {
+    const first = getOrCreateInstanceId();
+    const second = getOrCreateInstanceId();
+    assert.equal(first, second);
+    await getStarted;
+    assert.equal(getCalls, 1);
+    releaseGet();
+
+    const [firstId, secondId] = await Promise.all([first, second]);
+    assert.equal(firstId, secondId);
+    assert.match(firstId, /^[0-9a-f-]{36}$/i);
+  });
+
+  assert.notEqual(state.extensionInstanceId, 'corrupted-id');
+  assert.equal(Object.hasOwn(state, 'extensionAuthToken'), false);
+  assert.equal(Object.hasOwn(state, 'extensionTokenExpiresAt'), false);
+  assert.equal(Object.hasOwn(state, 'extensionTokenRefreshBackoff'), false);
+  assert.equal(state.extensionLinked, false);
+});
+
+test('instance ID generation re-reads storage after the in-flight operation settles', async () => {
+  const state = { extensionInstanceId: INSTANCE_ID };
+
+  await withChromeState(state, {}, async () => {
+    assert.equal(await getOrCreateInstanceId(), INSTANCE_ID);
+
+    delete state.extensionInstanceId;
+    state.extensionAuthToken = 'stale-token';
+    state.extensionLinked = true;
+
+    const regenerated = await getOrCreateInstanceId();
+    assert.notEqual(regenerated, INSTANCE_ID);
+    assert.equal(state.extensionInstanceId, regenerated);
+    assert.equal(Object.hasOwn(state, 'extensionAuthToken'), false);
+    assert.equal(state.extensionLinked, false);
+  });
+});
+
+test('a valid instance ID lookup is not blocked by an auth request in flight', async () => {
+  const state = { extensionInstanceId: INSTANCE_ID };
+  let releaseBlocker;
+  let markBlockerStarted;
+  const blockerStarted = new Promise((resolve) => {
+    markBlockerStarted = resolve;
+  });
+  const blocker = runExclusive(() => new Promise((resolve) => {
+    releaseBlocker = resolve;
+    markBlockerStarted();
+  }));
+  await blockerStarted;
+
+  try {
+    await withChromeState(state, {}, async () => {
+      const outcome = await Promise.race([
+        getOrCreateInstanceId(),
+        new Promise((resolve) => setImmediate(() => resolve('blocked'))),
+      ]);
+      assert.equal(outcome, INSTANCE_ID);
+    });
+  } finally {
+    releaseBlocker();
+    await blocker;
+  }
+});
+
 test('background auth save normalizes expiry and clears old refresh backoff', async () => {
   const state = {
-    extensionInstanceId: 'instance-id',
+    extensionInstanceId: INSTANCE_ID,
     extensionTokenRefreshBackoff: { failureCount: 2 },
   };
 
   await withChromeState(state, {}, async () => {
     assert.deepEqual(await saveExtensionAuthTokenInBackground({
-      extensionInstanceId: 'instance-id',
+      extensionInstanceId: INSTANCE_ID,
       extensionAuthToken: 'new-token',
       expiresAt: '2099-01-01T00:00:00Z',
     }), { ok: true });
@@ -90,17 +211,17 @@ test('background auth save normalizes expiry and clears old refresh backoff', as
 
 test('unlink and re-link operations are applied in mutex call order', async () => {
   const state = {
-    extensionInstanceId: 'instance-id',
+    extensionInstanceId: INSTANCE_ID,
     extensionAuthToken: 'old-token',
     extensionLinked: true,
   };
 
   await withChromeState(state, {}, async () => {
     const unlinkFirst = unlinkExtensionInBackground({
-      extensionInstanceId: 'instance-id',
+      extensionInstanceId: INSTANCE_ID,
     });
     const saveSecond = saveExtensionAuthTokenInBackground({
-      extensionInstanceId: 'instance-id',
+      extensionInstanceId: INSTANCE_ID,
       extensionAuthToken: 'new-token',
     });
     assert.deepEqual(await unlinkFirst, { ok: true });
@@ -109,11 +230,11 @@ test('unlink and re-link operations are applied in mutex call order', async () =
     assert.equal(state.extensionLinked, true);
 
     const saveFirst = saveExtensionAuthTokenInBackground({
-      extensionInstanceId: 'instance-id',
+      extensionInstanceId: INSTANCE_ID,
       extensionAuthToken: 'newer-token',
     });
     const unlinkSecond = unlinkExtensionInBackground({
-      extensionInstanceId: 'instance-id',
+      extensionInstanceId: INSTANCE_ID,
     });
     assert.deepEqual(await saveFirst, { ok: true });
     assert.deepEqual(await unlinkSecond, { ok: true });
@@ -203,13 +324,13 @@ test('content auth bridge forwards writes and surfaces runtime errors', async ()
 
   try {
     assert.equal(await saveExtensionAuthToken(
-      'instance-id',
+      INSTANCE_ID,
       'token',
       '2099-01-01T00:00:00.000Z'
     ), true);
     assert.deepEqual(sentMessage, {
       type: 'SAVE_EXTENSION_AUTH_TOKEN',
-      extensionInstanceId: 'instance-id',
+      extensionInstanceId: INSTANCE_ID,
       extensionAuthToken: 'token',
       expiresAt: '2099-01-01T00:00:00.000Z',
     });
@@ -220,7 +341,7 @@ test('content auth bridge forwards writes and surfaces runtime errors', async ()
       chrome.runtime.lastError = null;
     };
     await assert.rejects(
-      saveExtensionAuthToken('instance-id', 'token'),
+      saveExtensionAuthToken(INSTANCE_ID, 'token'),
       /service worker unavailable/
     );
   } finally {
@@ -230,6 +351,21 @@ test('content auth bridge forwards writes and surfaces runtime errors', async ()
       globalThis.chrome = originalChrome;
     }
   }
+});
+
+test('content auth status fails closed for an invalid stored token', async () => {
+  const state = {
+    extensionInstanceId: INSTANCE_ID,
+    extensionAuthToken: 'invalid\ntoken',
+    extensionLinked: true,
+  };
+
+  await withChromeState(state, {}, async () => {
+    const connection = await getExtensionConnectionState();
+    assert.equal(connection.extensionInstanceId, INSTANCE_ID);
+    assert.equal(connection.extensionAuthToken, null);
+    assert.equal(connection.extensionLinked, false);
+  });
 });
 
 async function withStalledFetch(task) {
@@ -269,7 +405,7 @@ async function withStalledFetch(task) {
 
 test('a stalled clip sync times out and releases the auth mutex', async () => {
   const state = {
-    extensionInstanceId: 'instance-id',
+    extensionInstanceId: INSTANCE_ID,
     extensionAuthToken: 'token',
     extensionLinked: true,
     pendingClips: [{
@@ -293,7 +429,7 @@ test('a stalled clip sync times out and releases the auth mutex', async () => {
     });
 
     assert.deepEqual(await saveExtensionAuthTokenInBackground({
-      extensionInstanceId: 'instance-id',
+      extensionInstanceId: INSTANCE_ID,
       extensionAuthToken: 'new-token',
     }), { ok: true });
   });
@@ -302,9 +438,473 @@ test('a stalled clip sync times out and releases the auth mutex', async () => {
   assert.equal(state.pendingClips.length, 1);
 });
 
+test('a stale sync 401 keeps a replaced token and the pending queue', async () => {
+  const state = {
+    extensionInstanceId: INSTANCE_ID,
+    extensionAuthToken: 'old-token',
+    extensionLinked: true,
+    pendingClips: [{
+      clientItemId: 'client-item',
+      url: 'https://www.netflix.com/watch/1',
+      startTime: 1,
+      endTime: 2,
+    }],
+  };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    state.extensionAuthToken = 'new-token';
+    return { status: 401, json: async () => null };
+  };
+
+  try {
+    await withChromeState(state, {}, async () => {
+      assert.deepEqual(await syncPendingQueue({ openLoginIfMissingToken: true }), {
+        ok: false,
+        queued: true,
+        reason: 'stale_unauthorized',
+      });
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(state.extensionAuthToken, 'new-token');
+  assert.equal(state.extensionLinked, true);
+  assert.equal(state.pendingClips.length, 1);
+  assert.equal(Object.hasOwn(state, 'extensionLoginPromptLastOpenedAt'), false);
+});
+
+test('clip sync removes only IDs confirmed by a valid success response', async () => {
+  const state = {
+    extensionInstanceId: INSTANCE_ID,
+    extensionAuthToken: 'token',
+    extensionLinked: true,
+    pendingClips: [
+      {
+        clientItemId: 'accepted-item',
+        url: 'https://www.netflix.com/watch/1',
+        startTime: 1,
+        endTime: 2,
+      },
+      {
+        clientItemId: 'queued-item',
+        url: 'https://www.netflix.com/watch/2',
+        startTime: 3,
+        endTime: 4,
+      },
+    ],
+  };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => ({
+    status: 200,
+    json: async () => ({
+      ok: true,
+      acceptedItemIds: ['accepted-item'],
+    }),
+  });
+
+  try {
+    await withChromeState(state, {}, async () => {
+      assert.deepEqual(await syncPendingQueue(), {
+        ok: true,
+        acceptedCount: 1,
+      });
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.deepEqual(
+    state.pendingClips.map((clip) => clip.clientItemId),
+    ['queued-item']
+  );
+  assert.match(state.lastSyncAt, /^\d{4}-\d{2}-\d{2}T/);
+});
+
+test('a clip enqueued while sync removes accepted IDs is not lost', async () => {
+  const state = {
+    extensionInstanceId: INSTANCE_ID,
+    extensionAuthToken: 'token',
+    extensionLinked: true,
+    pendingClips: [{
+      clientItemId: 'accepted-item',
+      url: 'https://www.netflix.com/watch/1',
+      startTime: 1,
+      endTime: 2,
+    }],
+  };
+  const originalFetch = globalThis.fetch;
+  const originalLocation = globalThis.location;
+  let releaseFetch;
+  let markFetchStarted;
+  const fetchStarted = new Promise((resolve) => {
+    markFetchStarted = resolve;
+  });
+  let releaseRemovalRead;
+  let markRemovalReadStarted;
+  const removalReadStarted = new Promise((resolve) => {
+    markRemovalReadStarted = resolve;
+  });
+  let pendingOnlyReads = 0;
+
+  globalThis.location = {
+    href: 'https://www.netflix.com/watch/2',
+    origin: 'https://www.netflix.com',
+  };
+  globalThis.fetch = async () => {
+    markFetchStarted();
+    return new Promise((resolve) => {
+      releaseFetch = () => resolve({
+        status: 200,
+        json: async () => ({
+          ok: true,
+          acceptedItemIds: ['accepted-item'],
+        }),
+      });
+    });
+  };
+
+  try {
+    await withChromeState(state, {
+      getStorage(keys, callback) {
+        const keyList = Array.isArray(keys) ? keys : [keys];
+        const snapshot = Object.fromEntries(
+          keyList
+            .filter((key) => Object.hasOwn(state, key))
+            .map((key) => [key, structuredClone(state[key])])
+        );
+        if (keyList.length === 1 && keyList[0] === 'pendingClips') {
+          pendingOnlyReads += 1;
+          if (pendingOnlyReads === 1) {
+            releaseRemovalRead = () => callback(snapshot);
+            markRemovalReadStarted();
+            return;
+          }
+        }
+        callback(snapshot);
+      },
+    }, async () => {
+      chrome.runtime.sendMessage = (message, callback) => {
+        assert.equal(message?.type, 'ENQUEUE_PENDING_CLIP');
+        enqueuePendingClipInBackground(message.clip).then(callback);
+      };
+
+      const syncPromise = syncPendingQueue();
+      await fetchStarted;
+      releaseFetch();
+      await removalReadStarted;
+
+      const enqueuePromise = enqueueClip({
+        clientItemId: 'new-item',
+        url: 'https://www.netflix.com/watch/2',
+        startTime: 3,
+        endTime: 4,
+      });
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.equal(
+        pendingOnlyReads,
+        1,
+        'enqueue must wait for the in-progress queue mutation before reading'
+      );
+      releaseRemovalRead();
+
+      const [syncResult, queuedClip] = await Promise.all([
+        syncPromise,
+        enqueuePromise,
+      ]);
+      assert.deepEqual(syncResult, {
+        ok: true,
+        acceptedCount: 1,
+      });
+      assert.equal(queuedClip.clientItemId, 'new-item');
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalLocation === undefined) {
+      delete globalThis.location;
+    } else {
+      globalThis.location = originalLocation;
+    }
+  }
+
+  assert.deepEqual(
+    state.pendingClips.map((clip) => clip.clientItemId),
+    ['new-item']
+  );
+});
+
+test('enqueue stays responsive during sync fetch and coalesces a follow-up sync', async () => {
+  const state = {
+    extensionInstanceId: INSTANCE_ID,
+    extensionAuthToken: 'token',
+    extensionLinked: true,
+    pendingClips: [{
+      clientItemId: 'first-item',
+      url: 'https://www.netflix.com/watch/1',
+      startTime: 1,
+      endTime: 2,
+    }],
+  };
+  const originalFetch = globalThis.fetch;
+  const originalLocation = globalThis.location;
+  const requestItemIds = [];
+  let releaseFirstFetch;
+  let markFirstFetchStarted;
+  const firstFetchStarted = new Promise((resolve) => {
+    markFirstFetchStarted = resolve;
+  });
+
+  globalThis.location = {
+    href: 'https://www.netflix.com/watch/2',
+    origin: 'https://www.netflix.com',
+  };
+  globalThis.fetch = async (_url, options) => {
+    const itemIds = JSON.parse(options.body).items.map((item) => item.clientItemId);
+    requestItemIds.push(itemIds);
+    if (requestItemIds.length === 1) {
+      markFirstFetchStarted();
+      return new Promise((resolve) => {
+        releaseFirstFetch = () => resolve({
+          status: 200,
+          json: async () => ({
+            ok: true,
+            acceptedItemIds: ['first-item'],
+          }),
+        });
+      });
+    }
+    return {
+      status: 200,
+      json: async () => ({
+        ok: true,
+        acceptedItemIds: ['second-item'],
+      }),
+    };
+  };
+
+  try {
+    await withChromeState(state, {}, async () => {
+      chrome.runtime.sendMessage = (message, callback) => {
+        assert.equal(message?.type, 'ENQUEUE_PENDING_CLIP');
+        enqueuePendingClipInBackground(message.clip).then(callback);
+      };
+
+      const firstSync = syncPendingQueue();
+      await firstFetchStarted;
+
+      const enqueueOutcome = await Promise.race([
+        enqueueClip({
+          clientItemId: 'second-item',
+          url: 'https://www.netflix.com/watch/2',
+          startTime: 3,
+          endTime: 4,
+        }).then((clip) => ({ type: 'queued', clip })),
+        new Promise((resolve) => setImmediate(() => resolve({ type: 'blocked' }))),
+      ]);
+      assert.equal(enqueueOutcome.type, 'queued');
+      assert.equal(enqueueOutcome.clip.clientItemId, 'second-item');
+
+      const coalescedSync = syncPendingQueue();
+      assert.equal(coalescedSync, firstSync);
+      releaseFirstFetch();
+
+      assert.deepEqual(await coalescedSync, {
+        ok: true,
+        acceptedCount: 1,
+      });
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalLocation === undefined) {
+      delete globalThis.location;
+    } else {
+      globalThis.location = originalLocation;
+    }
+  }
+
+  assert.deepEqual(requestItemIds, [['first-item'], ['second-item']]);
+  assert.deepEqual(state.pendingClips, []);
+});
+
+test('malformed clip sync success keeps every pending clip queued', async () => {
+  const invalidPayloads = [
+    null,
+    {},
+    { ok: false, acceptedItemIds: ['client-item'] },
+    { ok: true },
+    { ok: true, acceptedItemIds: ['unknown-item'] },
+    { ok: true, acceptedItemIds: ['client-item', 'client-item'] },
+  ];
+
+  for (const payload of invalidPayloads) {
+    const state = {
+      extensionInstanceId: INSTANCE_ID,
+      extensionAuthToken: 'token',
+      extensionLinked: true,
+      pendingClips: [{
+        clientItemId: 'client-item',
+        url: 'https://www.netflix.com/watch/1',
+        startTime: 1,
+        endTime: 2,
+      }],
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => ({
+      status: 200,
+      json: async () => payload,
+    });
+
+    try {
+      await withChromeState(state, {}, async () => {
+        assert.deepEqual(await syncPendingQueue(), {
+          ok: false,
+          queued: true,
+          reason: 'invalid_response',
+        });
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    assert.equal(state.pendingClips.length, 1);
+    assert.equal(Object.hasOwn(state, 'lastSyncAt'), false);
+  }
+});
+
+test('a generic sync 400 keeps the attempted queue when no item is identified', async () => {
+  const state = {
+    extensionInstanceId: INSTANCE_ID,
+    extensionAuthToken: 'token',
+    extensionLinked: true,
+    pendingClips: [
+      {
+        clientItemId: 'first-item',
+        url: 'https://www.netflix.com/watch/1',
+        startTime: 1,
+        endTime: 2,
+      },
+      {
+        clientItemId: 'second-item',
+        url: 'https://www.netflix.com/watch/2',
+        startTime: 3,
+        endTime: 4,
+      },
+    ],
+  };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => ({
+    status: 400,
+    json: async () => ({
+      message: 'Invalid request body',
+      code: 'INVALID_BODY',
+    }),
+  });
+
+  try {
+    await withChromeState(state, {}, async () => {
+      assert.deepEqual(await syncPendingQueue(), {
+        ok: false,
+        queued: true,
+        reason: 'validation_error',
+      });
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.deepEqual(
+    state.pendingClips.map((clip) => clip.clientItemId),
+    ['first-item', 'second-item']
+  );
+});
+
+test('a sync 400 drops only client item IDs explicitly identified by the server', async () => {
+  const state = {
+    extensionInstanceId: INSTANCE_ID,
+    extensionAuthToken: 'token',
+    extensionLinked: true,
+    pendingClips: [
+      {
+        clientItemId: 'bad-item',
+        url: 'https://www.netflix.com/watch/1',
+        startTime: 1,
+        endTime: 2,
+      },
+      {
+        clientItemId: 'good-item',
+        url: 'https://www.netflix.com/watch/2',
+        startTime: 3,
+        endTime: 4,
+      },
+    ],
+  };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => ({
+    status: 400,
+    json: async () => ({
+      issues: [{ clientItemId: 'bad-item' }],
+    }),
+  });
+
+  try {
+    await withChromeState(state, {}, async () => {
+      assert.deepEqual(await syncPendingQueue(), {
+        ok: false,
+        queued: false,
+        reason: 'validation_error',
+      });
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.deepEqual(
+    state.pendingClips.map((clip) => clip.clientItemId),
+    ['good-item']
+  );
+});
+
+test('clip sync heals an invalid stored instance ID before any fetch', async () => {
+  const state = {
+    extensionInstanceId: 'corrupted-id',
+    extensionAuthToken: 'token',
+    extensionLinked: true,
+    pendingClips: [{
+      clientItemId: 'client-item',
+      url: 'https://www.netflix.com/watch/1',
+      startTime: 1,
+      endTime: 2,
+    }],
+  };
+  const originalFetch = globalThis.fetch;
+  let fetchCalls = 0;
+  globalThis.fetch = async () => {
+    fetchCalls += 1;
+    throw new Error('fetch must not run');
+  };
+
+  try {
+    await withChromeState(state, {}, async () => {
+      assert.deepEqual(await syncPendingQueue(), {
+        ok: false,
+        queued: true,
+        reason: 'missing_token',
+      });
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(fetchCalls, 0);
+  assert.notEqual(state.extensionInstanceId, 'corrupted-id');
+  assert.equal(Object.hasOwn(state, 'extensionAuthToken'), false);
+  assert.equal(state.extensionLinked, false);
+  assert.equal(state.pendingClips.length, 1);
+});
+
 test('a stalled token refresh times out and releases the auth mutex', async () => {
   const state = {
-    extensionInstanceId: 'instance-id',
+    extensionInstanceId: INSTANCE_ID,
     extensionAuthToken: 'token',
     extensionLinked: true,
     extensionTokenExpiresAt: '2020-01-01T00:00:00.000Z',
@@ -321,11 +921,214 @@ test('a stalled token refresh times out and releases the auth mutex', async () =
     });
 
     assert.deepEqual(await saveExtensionAuthTokenInBackground({
-      extensionInstanceId: 'instance-id',
+      extensionInstanceId: INSTANCE_ID,
       extensionAuthToken: 'new-token',
     }), { ok: true });
   });
 
   assert.equal(state.extensionAuthToken, 'new-token');
   assert.equal(state.extensionLinked, true);
+});
+
+test('token refresh accepts only a complete success payload and clears backoff', async () => {
+  const state = {
+    extensionInstanceId: INSTANCE_ID,
+    extensionAuthToken: 'old-token',
+    extensionLinked: true,
+    extensionTokenExpiresAt: '2020-01-01T00:00:00.000Z',
+    extensionTokenRefreshBackoff: {
+      tokenFingerprint: 'superseded',
+      failureCount: 3,
+      nextAttemptAt: '2020-01-01T00:00:00.000Z',
+    },
+  };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => ({
+    status: 200,
+    json: async () => ({
+      ok: true,
+      extensionAuthToken: 'rotated-token',
+      expiresAt: '2099-01-01T00:00:00Z',
+    }),
+  });
+
+  try {
+    await withChromeState(state, {}, async () => {
+      assert.deepEqual(await checkAndRefreshToken(), {
+        ok: true,
+        refreshed: true,
+      });
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(state.extensionAuthToken, 'rotated-token');
+  assert.equal(state.extensionTokenExpiresAt, '2099-01-01T00:00:00.000Z');
+  assert.equal(state.extensionLinked, true);
+  assert.equal(Object.hasOwn(state, 'extensionTokenRefreshBackoff'), false);
+});
+
+test('refresh discards backoff from a superseded token before the due check', async () => {
+  const state = {
+    extensionInstanceId: INSTANCE_ID,
+    extensionAuthToken: 'current-token',
+    extensionLinked: true,
+    extensionTokenExpiresAt: '2099-01-01T00:00:00.000Z',
+    extensionTokenRefreshBackoff: {
+      tokenFingerprint: 'fingerprint-for-an-old-token',
+      failureCount: 4,
+      nextAttemptAt: '2099-01-01T00:00:00.000Z',
+    },
+  };
+  const originalFetch = globalThis.fetch;
+  let fetchCalls = 0;
+  globalThis.fetch = async () => {
+    fetchCalls += 1;
+    throw new Error('fetch must not run');
+  };
+
+  try {
+    await withChromeState(state, {}, async () => {
+      assert.deepEqual(await checkAndRefreshToken(), {
+        ok: true,
+        skipped: true,
+        reason: 'not_due',
+      });
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(fetchCalls, 0);
+  assert.equal(state.extensionAuthToken, 'current-token');
+  assert.equal(Object.hasOwn(state, 'extensionTokenRefreshBackoff'), false);
+});
+
+test('token refresh heals an invalid stored instance ID before any fetch', async () => {
+  const state = {
+    extensionInstanceId: 'corrupted-id',
+    extensionAuthToken: 'token',
+    extensionLinked: true,
+    extensionTokenExpiresAt: '2099-01-01T00:00:00.000Z',
+  };
+  const originalFetch = globalThis.fetch;
+  let fetchCalls = 0;
+  globalThis.fetch = async () => {
+    fetchCalls += 1;
+    throw new Error('fetch must not run');
+  };
+
+  try {
+    await withChromeState(state, {}, async () => {
+      assert.deepEqual(await checkAndRefreshToken(), {
+        ok: true,
+        skipped: true,
+        reason: 'not_linked',
+      });
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(fetchCalls, 0);
+  assert.notEqual(state.extensionInstanceId, 'corrupted-id');
+  assert.equal(Object.hasOwn(state, 'extensionAuthToken'), false);
+  assert.equal(Object.hasOwn(state, 'extensionTokenExpiresAt'), false);
+  assert.equal(state.extensionLinked, false);
+});
+
+test('malformed token refresh success keeps the current token and schedules backoff', async () => {
+  const invalidPayloads = [
+    null,
+    { ok: false, extensionAuthToken: 'rotated-token', expiresAt: '2099-01-01T00:00:00Z' },
+    { ok: true, extensionAuthToken: '', expiresAt: '2099-01-01T00:00:00Z' },
+    { ok: true, extensionAuthToken: 'rotated-token', expiresAt: 'not-a-date' },
+    { ok: true, extensionAuthToken: 'rotated-token', expiresAt: '2020-01-01T00:00:00Z' },
+  ];
+
+  for (const payload of invalidPayloads) {
+    const state = {
+      extensionInstanceId: INSTANCE_ID,
+      extensionAuthToken: 'current-token',
+      extensionLinked: true,
+      extensionTokenExpiresAt: '2020-01-01T00:00:00.000Z',
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => ({
+      status: 200,
+      json: async () => payload,
+    });
+
+    try {
+      await withChromeState(state, {}, async () => {
+        assert.deepEqual(await checkAndRefreshToken(), {
+          ok: false,
+          reason: 'invalid_response',
+        });
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    assert.equal(state.extensionAuthToken, 'current-token');
+    assert.equal(state.extensionLinked, true);
+    assert.equal(state.extensionTokenRefreshBackoff.failureCount, 1);
+    assert.equal(state.extensionTokenRefreshBackoff.lastStatus, 200);
+  }
+});
+
+test('token refresh 401 clears only the token used by that request', async () => {
+  const currentState = {
+    extensionInstanceId: INSTANCE_ID,
+    extensionAuthToken: 'current-token',
+    extensionLinked: true,
+    extensionTokenExpiresAt: '2020-01-01T00:00:00.000Z',
+    extensionTokenRefreshBackoff: { failureCount: 1 },
+  };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => ({ status: 401, json: async () => null });
+
+  try {
+    await withChromeState(currentState, {}, async () => {
+      assert.deepEqual(await checkAndRefreshToken(), {
+        ok: false,
+        reason: 'unauthorized',
+      });
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(Object.hasOwn(currentState, 'extensionAuthToken'), false);
+  assert.equal(Object.hasOwn(currentState, 'extensionTokenExpiresAt'), false);
+  assert.equal(Object.hasOwn(currentState, 'extensionTokenRefreshBackoff'), false);
+  assert.equal(currentState.extensionLinked, false);
+
+  const staleState = {
+    extensionInstanceId: INSTANCE_ID,
+    extensionAuthToken: 'old-token',
+    extensionLinked: true,
+    extensionTokenExpiresAt: '2020-01-01T00:00:00.000Z',
+  };
+  globalThis.fetch = async () => {
+    staleState.extensionAuthToken = 'new-token';
+    staleState.extensionTokenExpiresAt = '2099-01-01T00:00:00.000Z';
+    return { status: 401, json: async () => null };
+  };
+
+  try {
+    await withChromeState(staleState, {}, async () => {
+      assert.deepEqual(await checkAndRefreshToken(), {
+        ok: false,
+        reason: 'stale_unauthorized',
+      });
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.equal(staleState.extensionAuthToken, 'new-token');
+  assert.equal(staleState.extensionLinked, true);
+  assert.equal(staleState.extensionTokenExpiresAt, '2099-01-01T00:00:00.000Z');
 });

--- a/test/backgroundDetachedTasks.test.js
+++ b/test/backgroundDetachedTasks.test.js
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  PLAYBACK_CLEANUP_RETRY_DELAY_MINUTES,
+  runDetachedTask,
+  runPlaybackCleanupTask,
+} from '../src/background/detachedTasks.js';
+
+test('a rejected detached task is reported and resolves as a fixed failure', async () => {
+  const logs = [];
+  const result = await runDetachedTask(
+    () => Promise.reject(new Error('private failure detail')),
+    {
+      label: 'test task',
+      logger: (...args) => logs.push(args),
+    }
+  );
+
+  assert.deepEqual(result, { ok: false, reason: 'task_failed' });
+  assert.equal(logs.length, 1);
+  assert.equal(logs[0][0], '[background] test task failed');
+  assert.deepEqual(logs[0][1], { message: 'private failure detail' });
+});
+
+test('playback cleanup failure schedules the same alarm for a delayed retry', async () => {
+  const scheduled = [];
+  const result = await runPlaybackCleanupTask({
+    cleanup: () => Promise.reject(new Error('storage unavailable')),
+    alarmName: 'playback-handoff-cleanup:nonce-example',
+    scheduleAlarm: async (name, options) => {
+      scheduled.push({ name, options });
+    },
+    logger: () => {},
+  });
+
+  assert.deepEqual(result, { ok: false, reason: 'task_failed' });
+  assert.deepEqual(scheduled, [{
+    name: 'playback-handoff-cleanup:nonce-example',
+    options: {
+      delayInMinutes: PLAYBACK_CLEANUP_RETRY_DELAY_MINUTES,
+    },
+  }]);
+});
+
+test('recovery failure is also contained instead of rejecting', async () => {
+  const logs = [];
+  const result = await runDetachedTask(
+    () => {
+      throw new Error('task failed');
+    },
+    {
+      label: 'recoverable task',
+      onError: () => Promise.reject(new Error('retry scheduling failed')),
+      logger: (...args) => logs.push(args),
+    }
+  );
+
+  assert.deepEqual(result, { ok: false, reason: 'task_failed' });
+  assert.deepEqual(logs.map(([message]) => message), [
+    '[background] recoverable task failed',
+    '[background] recoverable task recovery failed',
+  ]);
+});

--- a/test/commentPanel.test.js
+++ b/test/commentPanel.test.js
@@ -2,10 +2,205 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import {
+  COMMENT_PANEL_ID,
+  closeCommentPanel,
   isAmbiguousPostFailure,
   resolveCurrentClipIdFromState,
   shouldClearSubmittedDraft,
+  shouldClosePanelForKeyEvent,
+  toggleCommentPanel,
 } from '../src/content/commentPanel.js';
+
+class FakeEventTarget {
+  constructor() {
+    this.listeners = new Map();
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) || new Set();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type, listener) {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  dispatchEvent(event) {
+    for (const listener of this.listeners.get(event.type) || []) {
+      listener(event);
+    }
+    return true;
+  }
+}
+
+class FakeElement extends FakeEventTarget {
+  constructor(tagName, ownerDocument, { shadowHost = null } = {}) {
+    super();
+    this.tagName = tagName.toUpperCase();
+    this.ownerDocument = ownerDocument;
+    this.shadowHost = shadowHost;
+    this.children = [];
+    this.parentElement = null;
+    this.attributes = new Map();
+    this.dataset = {};
+    this.style = { cssText: '' };
+    this.className = '';
+    this.id = '';
+    this.textContent = '';
+    this.value = '';
+    this.disabled = false;
+    this.hidden = false;
+  }
+
+  get isConnected() {
+    if (this === this.ownerDocument.documentElement) return true;
+    if (this.shadowHost) return this.shadowHost.isConnected;
+    return this.parentElement?.isConnected === true;
+  }
+
+  append(...children) {
+    for (const child of children) this.appendChild(child);
+  }
+
+  appendChild(child) {
+    if (!(child instanceof FakeElement)) return child;
+    child.parentElement = this;
+    this.children.push(child);
+    return child;
+  }
+
+  replaceChildren(...children) {
+    for (const child of this.children) child.parentElement = null;
+    this.children = [];
+    this.append(...children);
+  }
+
+  contains(target) {
+    return target === this || this.children.some((child) => child.contains(target));
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, String(value));
+  }
+
+  getAttribute(name) {
+    return this.attributes.get(name) ?? null;
+  }
+
+  querySelectorAll(selector) {
+    const matches = [];
+    const visit = (element) => {
+      if (selector === 'button' && element.tagName === 'BUTTON') {
+        matches.push(element);
+      }
+      for (const child of element.children) visit(child);
+    };
+    visit(this);
+    return matches;
+  }
+
+  attachShadow() {
+    const root = new FakeElement('#shadow-root', this.ownerDocument, {
+      shadowHost: this,
+    });
+    this.attachedShadow = root;
+    return root;
+  }
+
+  focus() {
+    this.ownerDocument.activeElement = this;
+  }
+
+  remove() {
+    if (!this.parentElement) return;
+    const index = this.parentElement.children.indexOf(this);
+    if (index >= 0) this.parentElement.children.splice(index, 1);
+    this.parentElement = null;
+  }
+}
+
+class FakeDocument extends FakeEventTarget {
+  constructor() {
+    super();
+    this.documentElement = new FakeElement('html', this);
+    this.body = new FakeElement('body', this);
+    this.documentElement.appendChild(this.body);
+    this.activeElement = this.body;
+    this.visibilityState = 'visible';
+  }
+
+  createElement(tagName) {
+    return new FakeElement(tagName, this);
+  }
+
+  querySelectorAll(selector) {
+    const ariaControls = selector.match(/^\[aria-controls="([^"]+)"\]$/)?.[1];
+    const matches = [];
+    const visit = (element) => {
+      if (
+        (ariaControls && element.getAttribute('aria-controls') === ariaControls) ||
+        (selector.startsWith('#') && element.id === selector.slice(1)) ||
+        element.tagName.toLowerCase() === selector
+      ) {
+        matches.push(element);
+      }
+      for (const child of element.children) visit(child);
+    };
+    visit(this.documentElement);
+    return matches;
+  }
+
+  querySelector(selector) {
+    return this.querySelectorAll(selector)[0] || null;
+  }
+
+  getElementById(id) {
+    return this.querySelector(`#${id}`);
+  }
+}
+
+class FakeMutationObserver {
+  static instances = [];
+
+  constructor(callback) {
+    this.callback = callback;
+    this.connected = false;
+    FakeMutationObserver.instances.push(this);
+  }
+
+  observe() {
+    this.connected = true;
+  }
+
+  disconnect() {
+    this.connected = false;
+  }
+}
+
+class FakeChromeStorageEvent {
+  constructor() {
+    this.listeners = new Set();
+  }
+
+  addListener(listener) {
+    this.listeners.add(listener);
+  }
+
+  removeListener(listener) {
+    this.listeners.delete(listener);
+  }
+
+  emit(changes, areaName) {
+    for (const listener of this.listeners) listener(changes, areaName);
+  }
+}
+
+async function flushAsyncWork() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise((resolve) => setImmediate(resolve));
+}
 
 test('単体再生は clipId を id より優先する', () => {
   assert.equal(
@@ -148,4 +343,166 @@ test('投稿済みか不明な失敗は一覧で確認する', () => {
   }
   assert.equal(isAmbiguousPostFailure('validation_error'), false);
   assert.equal(isAmbiguousPostFailure('unauthorized'), false);
+  assert.equal(isAmbiguousPostFailure('rate_limited'), false);
+});
+
+test('EscapeはIME変換中にパネルを閉じない', () => {
+  assert.equal(
+    shouldClosePanelForKeyEvent({
+      type: 'keydown',
+      key: 'Escape',
+      isComposing: true,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldClosePanelForKeyEvent({
+      type: 'keydown',
+      key: 'Escape',
+      isComposing: false,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldClosePanelForKeyEvent({ type: 'keyup', key: 'Escape' }),
+    false,
+  );
+});
+
+test('投稿中のauth変更は成功応答をstale化させず、後から一覧を更新する', async () => {
+  const previousGlobals = new Map();
+  for (const name of [
+    'chrome',
+    'CustomEvent',
+    'document',
+    'MutationObserver',
+    'sessionStorage',
+    'window',
+  ]) {
+    previousGlobals.set(name, {
+      present: Object.hasOwn(globalThis, name),
+      value: globalThis[name],
+    });
+  }
+
+  const document = new FakeDocument();
+  const window = new FakeEventTarget();
+  const storageChanged = new FakeChromeStorageEvent();
+  const sessionValues = new Map([
+    [
+      'dextPlaybackContextV1',
+      JSON.stringify({
+        initialized: true,
+        context: { mode: 'clip', clipId: 42 },
+      }),
+    ],
+  ]);
+  const runtimeMessages = [];
+  let postCallback = null;
+
+  FakeMutationObserver.instances = [];
+  globalThis.document = document;
+  globalThis.window = window;
+  globalThis.MutationObserver = FakeMutationObserver;
+  globalThis.CustomEvent = class {
+    constructor(type, { detail } = {}) {
+      this.type = type;
+      this.detail = detail;
+    }
+  };
+  globalThis.sessionStorage = {
+    getItem: (key) => sessionValues.get(key) ?? null,
+    setItem: (key, value) => sessionValues.set(key, value),
+    removeItem: (key) => sessionValues.delete(key),
+  };
+  globalThis.chrome = {
+    runtime: {
+      lastError: null,
+      sendMessage(message, callback) {
+        runtimeMessages.push(message);
+        if (message.type === 'POST_CLIP_COMMENT') {
+          postCallback = callback;
+          return;
+        }
+        callback({
+          ok: true,
+          comments: [],
+          hasNext: false,
+          nextCursor: null,
+        });
+      },
+    },
+    storage: { onChanged: storageChanged },
+  };
+
+  const trigger = document.createElement('button');
+  trigger.setAttribute('aria-controls', COMMENT_PANEL_ID);
+  document.body.appendChild(trigger);
+  trigger.focus();
+
+  try {
+    assert.equal(
+      toggleCommentPanel({ mountEl: document.body, triggerEl: trigger }),
+      true,
+    );
+    await flushAsyncWork();
+
+    const host = document.getElementById(COMMENT_PANEL_ID);
+    const textarea = host.children[0];
+    const panel = host.attachedShadow.children[1];
+    const form = panel.children[3];
+    textarea.value = '送信本文';
+    textarea.dispatchEvent({ type: 'input', target: textarea });
+    form.dispatchEvent({
+      type: 'submit',
+      target: form,
+      preventDefault() {},
+    });
+    await flushAsyncWork();
+
+    assert.equal(typeof postCallback, 'function');
+    storageChanged.emit({ extensionAuthToken: { newValue: 'new-token' } }, 'local');
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(
+      runtimeMessages.filter((message) => message.type === 'FETCH_CLIP_COMMENTS')
+        .length,
+      1,
+      '投稿中のauth変更はGETを先行させない',
+    );
+
+    postCallback({
+      ok: true,
+      comment: {
+        id: 7,
+        username: 'ユーザー',
+        body: '送信本文',
+        createdAt: '2026-08-23T00:00:00.000Z',
+      },
+    });
+    await flushAsyncWork();
+
+    assert.equal(textarea.value, '');
+    assert.equal(
+      runtimeMessages.filter((message) => message.type === 'FETCH_CLIP_COMMENTS')
+        .length,
+      2,
+      '投稿完了後にqueued refreshを1回実行する',
+    );
+
+    const mountObserver = FakeMutationObserver.instances.at(-1);
+    closeCommentPanel();
+    assert.equal(trigger.getAttribute('aria-expanded'), 'false');
+    assert.equal(document.activeElement, trigger);
+    assert.equal(storageChanged.listeners.size, 0);
+    assert.equal(document.listeners.get('visibilitychange')?.size, 0);
+    assert.equal(window.listeners.get('keydown')?.size, 0);
+    assert.equal(mountObserver.connected, false);
+  } finally {
+    closeCommentPanel();
+    for (const [name, previous] of previousGlobals) {
+      if (previous.present) globalThis[name] = previous.value;
+      else delete globalThis[name];
+    }
+  }
 });

--- a/test/comments.test.js
+++ b/test/comments.test.js
@@ -3,6 +3,7 @@ import { test } from 'node:test';
 
 import {
   buildCommentsApiUrl,
+  COMMENTS_REQUEST_TIMEOUT_MS,
   fetchClipComments,
   getCommentsResponseReason,
   isValidCommentsSuccessResponse,
@@ -13,6 +14,8 @@ import {
 import { saveExtensionAuthTokenInBackground } from '../src/background/authState.js';
 import { runExclusive } from '../src/background/sync.js';
 
+const INSTANCE_ID = '11111111-1111-4111-8111-111111111111';
+
 function commentFixture(clipId = 1, overrides = {}) {
   return {
     id: 10,
@@ -20,6 +23,7 @@ function commentFixture(clipId = 1, overrides = {}) {
     userId: 7,
     username: 'alice',
     body: 'hello',
+    atMs: null,
     createdAt: '2026-07-18T09:30:00.000Z',
     ...overrides,
   };
@@ -197,6 +201,7 @@ test('HTTP statusをコメントUI向けreasonへ変換する', () => {
   assert.equal(getCommentsResponseReason(401), 'unauthorized');
   assert.equal(getCommentsResponseReason(403), 'forbidden');
   assert.equal(getCommentsResponseReason(404), 'not_found');
+  assert.equal(getCommentsResponseReason(429), 'rate_limited');
   assert.equal(getCommentsResponseReason(500), 'request_failed');
 });
 
@@ -219,6 +224,12 @@ test('successful GET and POST responses require their expected JSON shape', () =
     postResponseFixture(1),
     1
   ), true);
+  assert.equal(isValidCommentsSuccessResponse('POST', postResponseFixture(1, {
+    comment: commentFixture(1, {
+      atMs: 12_345,
+      futureField: { safely: 'ignored' },
+    }),
+  }), 1), true);
   assert.equal(isValidCommentsSuccessResponse('GET', getResponseFixture(1, {
     comments: [commentFixture(1, {
       userId: null,
@@ -269,7 +280,7 @@ test('comment responses require every field in the API contract', () => {
 
 test('malformed success JSON is returned as invalid_response', async () => {
   const state = {
-    extensionInstanceId: 'instance-id',
+    extensionInstanceId: INSTANCE_ID,
     extensionAuthToken: 'token',
   };
 
@@ -298,7 +309,7 @@ test('malformed success JSON is returned as invalid_response', async () => {
 
 test('GET accepts only 200 and POST accepts only 201', async () => {
   const state = {
-    extensionInstanceId: 'instance-id',
+    extensionInstanceId: INSTANCE_ID,
     extensionAuthToken: 'token',
   };
 
@@ -325,9 +336,63 @@ test('GET accepts only 200 and POST accepts only 201', async () => {
   });
 });
 
+test('429 is returned as a deterministic rate limit rejection', async () => {
+  const state = {
+    extensionInstanceId: INSTANCE_ID,
+    extensionAuthToken: 'token',
+    extensionLinked: true,
+  };
+
+  await withCommentRequestMocks({
+    state,
+    fetchImpl: async () => jsonResponse(429, {
+      message: 'Comment rate limit exceeded',
+      code: 'COMMENT_RATE_LIMITED',
+    }),
+  }, async () => {
+    assert.deepEqual(await postClipComment({ clipId: 1, body: 'hello' }), {
+      ok: false,
+      reason: 'rate_limited',
+      status: 429,
+      message: 'Comment rate limit exceeded',
+      code: 'COMMENT_RATE_LIMITED',
+    });
+  });
+
+  assert.equal(state.extensionAuthToken, 'token');
+  assert.equal(state.extensionLinked, true);
+});
+
+test('comments heal an invalid stored instance ID before any fetch', async () => {
+  const state = {
+    extensionInstanceId: 'corrupted-id',
+    extensionAuthToken: 'token',
+    extensionLinked: true,
+  };
+  let fetchCalls = 0;
+
+  await withCommentRequestMocks({
+    state,
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      throw new Error('fetch must not run');
+    },
+  }, async () => {
+    assert.deepEqual(await fetchClipComments({ clipId: 1 }), {
+      ok: false,
+      reason: 'missing_token',
+    });
+  });
+
+  assert.equal(fetchCalls, 0);
+  assert.notEqual(state.extensionInstanceId, 'corrupted-id');
+  assert.equal(Object.hasOwn(state, 'extensionAuthToken'), false);
+  assert.equal(state.extensionLinked, false);
+});
+
 test('a stale 401 does not clear a newly stored auth token', async () => {
   const state = {
-    extensionInstanceId: 'instance-id',
+    extensionInstanceId: INSTANCE_ID,
     extensionAuthToken: 'old-token',
     extensionTokenExpiresAt: '2099-01-01T00:00:00.000Z',
     extensionLinked: true,
@@ -353,7 +418,7 @@ test('a stale 401 does not clear a newly stored auth token', async () => {
 
 test('a 401 for the current token clears auth state', async () => {
   const state = {
-    extensionInstanceId: 'instance-id',
+    extensionInstanceId: INSTANCE_ID,
     extensionAuthToken: 'current-token',
     extensionTokenExpiresAt: '2099-01-01T00:00:00.000Z',
     extensionTokenRefreshBackoff: { failureCount: 1 },
@@ -376,7 +441,7 @@ test('a 401 for the current token clears auth state', async () => {
 
 test('a re-link queued during an old-token 401 is saved after the clear', async () => {
   const state = {
-    extensionInstanceId: 'instance-id',
+    extensionInstanceId: INSTANCE_ID,
     extensionAuthToken: 'old-token',
     extensionLinked: true,
   };
@@ -399,7 +464,7 @@ test('a re-link queued during an old-token 401 is saved after the clear', async 
     await fetchStarted;
 
     const savePromise = saveExtensionAuthTokenInBackground({
-      extensionInstanceId: 'instance-id',
+      extensionInstanceId: INSTANCE_ID,
       extensionAuthToken: 'new-token',
       expiresAt: '2099-01-01T00:00:00.000Z',
     });
@@ -422,7 +487,7 @@ test('a re-link queued during an old-token 401 is saved after the clear', async 
 
 test('a re-link queued first is visible to the following comments request', async () => {
   const state = {
-    extensionInstanceId: 'instance-id',
+    extensionInstanceId: INSTANCE_ID,
     extensionAuthToken: 'old-token',
     extensionLinked: true,
   };
@@ -436,7 +501,7 @@ test('a re-link queued first is visible to the following comments request', asyn
     },
   }, async () => {
     const savePromise = saveExtensionAuthTokenInBackground({
-      extensionInstanceId: 'instance-id',
+      extensionInstanceId: INSTANCE_ID,
       extensionAuthToken: 'new-token',
     });
     const commentsPromise = fetchClipComments({ clipId: 1 });
@@ -455,7 +520,7 @@ test('a re-link queued first is visible to the following comments request', asyn
 
 test('a stalled comments request is aborted and returned as timeout', async () => {
   const state = {
-    extensionInstanceId: 'instance-id',
+    extensionInstanceId: INSTANCE_ID,
     extensionAuthToken: 'token',
   };
   const originalSetTimeout = globalThis.setTimeout;
@@ -497,9 +562,52 @@ test('a stalled comments request is aborted and returned as timeout', async () =
   }
 });
 
+test('a completed comments response is not timed out only because the wall clock crossed the deadline', async () => {
+  const state = {
+    extensionInstanceId: INSTANCE_ID,
+    extensionAuthToken: 'token',
+  };
+  const originalDateNow = Date.now;
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  let now = 1_000;
+  let timeoutCallback;
+
+  Date.now = () => now;
+  globalThis.setTimeout = (callback) => {
+    timeoutCallback = callback;
+    return 1;
+  };
+  globalThis.clearTimeout = () => {};
+
+  try {
+    await withCommentRequestMocks({
+      state,
+      fetchImpl: async (_url, options) => ({
+        status: 200,
+        json: async () => {
+          assert.equal(options.signal.aborted, false);
+          now += COMMENTS_REQUEST_TIMEOUT_MS + 1;
+          return getResponseFixture(1);
+        },
+      }),
+    }, async () => {
+      assert.deepEqual(
+        await fetchClipComments({ clipId: 1 }),
+        getResponseFixture(1)
+      );
+      assert.equal(typeof timeoutCallback, 'function');
+    });
+  } finally {
+    Date.now = originalDateNow;
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+  }
+});
+
 test('the comments deadline includes time waiting for the exclusive queue', async () => {
   const state = {
-    extensionInstanceId: 'instance-id',
+    extensionInstanceId: INSTANCE_ID,
     extensionAuthToken: 'token',
   };
   const originalSetTimeout = globalThis.setTimeout;

--- a/test/content/common.test.mjs
+++ b/test/content/common.test.mjs
@@ -32,6 +32,28 @@ class FakeEventTarget {
   }
 }
 
+class FakeMutationObserver {
+  static instances = [];
+
+  constructor(callback) {
+    this.callback = callback;
+    this.connected = false;
+    FakeMutationObserver.instances.push(this);
+  }
+
+  observe() {
+    this.connected = true;
+  }
+
+  disconnect() {
+    this.connected = false;
+  }
+
+  trigger() {
+    if (this.connected) this.callback([]);
+  }
+}
+
 class FakeElement extends FakeEventTarget {
   constructor(tagName, ownerDocument) {
     super();
@@ -45,11 +67,19 @@ class FakeElement extends FakeEventTarget {
       width: '',
     };
     this.dataset = {};
+    this.attributes = new Map();
     this.className = '';
     this.id = '';
     this.textContent = '';
     this.value = '';
     this.onclick = null;
+  }
+
+  get isConnected() {
+    return (
+      this === this.ownerDocument.body ||
+      this.parentElement?.isConnected === true
+    );
   }
 
   append(...children) {
@@ -66,6 +96,14 @@ class FakeElement extends FakeEventTarget {
 
   contains(target) {
     return target === this || this.children.some((child) => child.contains(target));
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, String(value));
+  }
+
+  getAttribute(name) {
+    return this.attributes.get(name) ?? null;
   }
 
   focus() {
@@ -125,13 +163,16 @@ class FakeDocument extends FakeEventTarget {
   }
 }
 
-function createKeyboardEvent(target) {
+function createKeyboardEvent(
+  target,
+  { key = 'Enter', isComposing = false, repeat = false } = {},
+) {
   return {
     type: 'keydown',
     target,
-    key: 'Enter',
-    isComposing: false,
-    repeat: false,
+    key,
+    isComposing,
+    repeat,
     defaultPrevented: false,
     propagationStopped: false,
     immediatePropagationStopped: false,
@@ -181,6 +222,8 @@ function installDom() {
   globalThis.document = document;
   globalThis.window = window;
   globalThis.location = { href: 'https://www.netflix.com/watch/1' };
+  FakeMutationObserver.instances = [];
+  globalThis.MutationObserver = FakeMutationObserver;
   return { document, window };
 }
 
@@ -371,4 +414,76 @@ test('opening a memo after the Netflix clip list preserves the true player width
 
   closeMemoSidebar();
   assert.equal(player.style.width, '65%');
+});
+
+test('site-side removal tears down memo listeners and restores the exact width', async () => {
+  const { document, window } = installDom();
+  const { closeMemoSidebar, openMemoSidebar } = await loadCommonModule();
+  const player = document.createElement('video');
+  player.style.width = '';
+  const save = createDeferred();
+  let playCount = 0;
+  player.play = () => {
+    playCount += 1;
+  };
+  let closeCount = 0;
+
+  const sidebar = openMemoSidebar({
+    videoPlayer: player,
+    onSave: () => save.promise,
+    onClose: () => {
+      closeCount += 1;
+    },
+  });
+  const mountObserver = FakeMutationObserver.instances.at(-1);
+
+  assert.equal(mountObserver?.connected, true);
+  sidebarControls(sidebar).saveButton.onclick();
+  sidebar.remove();
+  mountObserver.trigger();
+
+  assert.equal(player.style.width, '');
+  assert.equal(window.listeners.get('keydown')?.size, 0);
+  assert.equal(document.listeners.get('focusin')?.size, 0);
+  assert.equal(mountObserver.connected, false);
+  assert.equal(closeCount, 1);
+  assert.equal(closeMemoSidebar(), false);
+
+  save.resolve();
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(playCount, 0);
+});
+
+test('memo Escape respects IME composition and restores focus on close', async () => {
+  const { document, window } = installDom();
+  const { MEMO_SIDEBAR_ID, openMemoSidebar } = await loadCommonModule();
+  const player = document.createElement('video');
+  const trigger = document.createElement('button');
+  document.body.appendChild(trigger);
+  trigger.focus();
+
+  const sidebar = openMemoSidebar({ videoPlayer: player });
+  const controls = sidebarControls(sidebar);
+
+  assert.equal(sidebar.getAttribute('role'), 'dialog');
+  assert.equal(
+    sidebar.getAttribute('aria-labelledby'),
+    `${MEMO_SIDEBAR_ID}-title`,
+  );
+  assert.equal(controls.closeButton.getAttribute('aria-label'), '録画メモを閉じる');
+
+  const composingEscape = createKeyboardEvent(controls.nameInput, {
+    key: 'Escape',
+    isComposing: true,
+  });
+  window.dispatch(composingEscape);
+  assert.equal(document.getElementById(MEMO_SIDEBAR_ID), sidebar);
+  assert.equal(composingEscape.defaultPrevented, false);
+  assert.equal(composingEscape.immediatePropagationStopped, true);
+
+  const escape = createKeyboardEvent(controls.nameInput, { key: 'Escape' });
+  window.dispatch(escape);
+  assert.equal(document.getElementById(MEMO_SIDEBAR_ID), null);
+  assert.equal(escape.defaultPrevented, true);
+  assert.equal(document.activeElement, trigger);
 });

--- a/test/content/integrationHelpers.test.mjs
+++ b/test/content/integrationHelpers.test.mjs
@@ -1,8 +1,223 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import {
+  AUTO_NAVIGATION_KEY,
+  clearAutoNavigation,
+  createElementWait,
+  handleOwnedPlaybackRouteChange,
+  markAutoNavigation,
+} from '../../src/content/common.js';
 import { setTextContentIfChanged } from '../../src/content/domUpdates.js';
 import { commitSelectedClip } from '../../src/content/netflixClipSelection.js';
+
+class MemoryStorage {
+  constructor() {
+    this.values = new Map();
+  }
+
+  getItem(key) {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key, value) {
+    this.values.set(key, String(value));
+  }
+
+  removeItem(key) {
+    this.values.delete(key);
+  }
+}
+
+function installWebStorage(t, { sessionStorage, localStorage }) {
+  const sessionDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    'sessionStorage',
+  );
+  const localDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    'localStorage',
+  );
+  Object.defineProperty(globalThis, 'sessionStorage', {
+    configurable: true,
+    value: sessionStorage,
+    writable: true,
+  });
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: localStorage,
+    writable: true,
+  });
+  t.after(() => {
+    if (sessionDescriptor) {
+      Object.defineProperty(globalThis, 'sessionStorage', sessionDescriptor);
+    } else {
+      delete globalThis.sessionStorage;
+    }
+    if (localDescriptor) {
+      Object.defineProperty(globalThis, 'localStorage', localDescriptor);
+    } else {
+      delete globalThis.localStorage;
+    }
+  });
+}
+
+test('Netflix auto-navigation markers cannot suppress another tab teardown', (t) => {
+  const tabAStorage = new MemoryStorage();
+  const tabBStorage = new MemoryStorage();
+  const sharedLocalStorage = new MemoryStorage();
+  installWebStorage(t, {
+    sessionStorage: tabAStorage,
+    localStorage: sharedLocalStorage,
+  });
+
+  assert.equal(
+    markAutoNavigation({
+      ownerNonce: 'owner-nonce-tab-a',
+      expectedRoute: 'https://www.netflix.com/watch/2',
+      reason: 'playlist',
+    }),
+    true,
+  );
+  assert.equal(sharedLocalStorage.getItem(AUTO_NAVIGATION_KEY), null);
+
+  tabBStorage.setItem(
+    AUTO_NAVIGATION_KEY,
+    tabAStorage.getItem(AUTO_NAVIGATION_KEY),
+  );
+  sharedLocalStorage.setItem(AUTO_NAVIGATION_KEY, 'legacy-shared-marker');
+  globalThis.sessionStorage = tabBStorage;
+  let tabBTeardownCount = 0;
+  assert.equal(
+    handleOwnedPlaybackRouteChange({
+      ownerNonce: 'owner-nonce-tab-b',
+      currentRoute: 'https://www.netflix.com/watch/10',
+      nextRoute: 'https://www.netflix.com/watch/2',
+      onManualNavigation: () => {
+        tabBTeardownCount += 1;
+      },
+    }),
+    'manual',
+  );
+  assert.equal(tabBTeardownCount, 1);
+  assert.equal(sharedLocalStorage.getItem(AUTO_NAVIGATION_KEY), 'legacy-shared-marker');
+
+  globalThis.sessionStorage = tabAStorage;
+  assert.equal(
+    handleOwnedPlaybackRouteChange({
+      ownerNonce: 'owner-nonce-tab-a',
+      currentRoute: 'https://www.netflix.com/watch/1',
+      nextRoute: 'https://www.netflix.com/watch/2',
+    }),
+    'auto',
+  );
+});
+
+test('Disney+ auto-navigation is consumed before a second SPA route teardown', (t) => {
+  installWebStorage(t, {
+    sessionStorage: new MemoryStorage(),
+    localStorage: new MemoryStorage(),
+  });
+
+  let ownerNonce = 'owner-nonce-disney';
+  let playbackRoute = 'https://www.disneyplus.com/play/one';
+  let contextActive = true;
+  let panelOpen = true;
+  let releaseCount = 0;
+  const handleRoute = (nextRoute) =>
+    handleOwnedPlaybackRouteChange({
+      ownerNonce,
+      currentRoute: playbackRoute,
+      nextRoute,
+      onAutoNavigation: (route) => {
+        playbackRoute = route;
+      },
+      onManualNavigation: () => {
+        ownerNonce = null;
+        contextActive = false;
+        panelOpen = false;
+        releaseCount += 1;
+        clearAutoNavigation();
+      },
+    });
+
+  assert.equal(
+    markAutoNavigation({
+      ownerNonce,
+      expectedRoute: 'https://www.disneyplus.com/play/two',
+      reason: 'playlist:2:22',
+    }),
+    true,
+  );
+  assert.equal(handleRoute('https://www.disneyplus.com/play/two'), 'auto');
+  assert.equal(contextActive, true);
+  assert.equal(panelOpen, true);
+  assert.equal(releaseCount, 0);
+
+  assert.equal(handleRoute('https://www.disneyplus.com/browse'), 'manual');
+  assert.equal(ownerNonce, null);
+  assert.equal(contextActive, false);
+  assert.equal(panelOpen, false);
+  assert.equal(releaseCount, 1);
+
+  ownerNonce = 'owner-nonce-disney-reload';
+  playbackRoute = 'https://www.disneyplus.com/play/three';
+  contextActive = true;
+  panelOpen = true;
+  assert.equal(
+    markAutoNavigation({
+      ownerNonce,
+      expectedRoute: playbackRoute,
+      reason: 'playlist:3:33',
+    }),
+    true,
+  );
+  clearAutoNavigation();
+
+  assert.equal(handleRoute('https://www.disneyplus.com/search'), 'manual');
+  assert.equal(ownerNonce, null);
+  assert.equal(contextActive, false);
+  assert.equal(panelOpen, false);
+  assert.equal(releaseCount, 2);
+});
+
+test('a cancelled Netflix video wait disconnects and settles without a video', async () => {
+  let video = null;
+  let observer;
+  class FakeMutationObserver {
+    constructor(callback) {
+      this.callback = callback;
+      this.disconnectCount = 0;
+      observer = this;
+    }
+
+    observe() {}
+
+    disconnect() {
+      this.disconnectCount += 1;
+    }
+
+    trigger() {
+      this.callback();
+    }
+  }
+  const documentRef = {
+    body: {},
+    querySelector: () => video,
+  };
+  const wait = createElementWait('video', {
+    documentRef,
+    MutationObserverConstructor: FakeMutationObserver,
+  });
+
+  wait.cancel();
+  assert.equal(await wait.promise, null);
+  assert.equal(observer.disconnectCount, 1);
+
+  video = { tagName: 'VIDEO' };
+  observer.trigger();
+  assert.equal(observer.disconnectCount, 1);
+});
 
 test('unchanged Disney+ button labels do not rewrite their text node', () => {
   let textContent = 'コメント';

--- a/test/getClipData.test.js
+++ b/test/getClipData.test.js
@@ -7,6 +7,7 @@ const runtimeMessages = [];
 const scheduledTasks = [];
 let storedQueue = null;
 let runtimeResponse = { ok: true };
+let storageReadError = null;
 
 globalThis.window = {
   location: {
@@ -23,6 +24,7 @@ globalThis.window = {
 globalThis.document = { cookie: '' };
 globalThis.localStorage = {
   getItem(key) {
+    if (storageReadError) throw storageReadError;
     return key === 'playQueue' ? storedQueue : null;
   },
 };
@@ -48,6 +50,7 @@ function resetObservations() {
   scheduledTasks.length = 0;
   storedQueue = null;
   runtimeResponse = { ok: true };
+  storageReadError = null;
   window.location.href = 'http://localhost:3000/clips';
 }
 
@@ -80,6 +83,37 @@ test('SET_CLIP_DATA rejects a missing payload without contacting background', as
       requestId: 'missing-payload',
     },
   });
+});
+
+test('window messages from another source or origin are ignored', async () => {
+  resetObservations();
+  const payload = {
+    type: 'SET_CLIP_DATA',
+    payload: {
+      clip: {
+        clipId: 1,
+        service: 'netflix',
+        url: 'https://www.netflix.com/watch/1',
+        startTime: 1,
+        endTime: 2,
+      },
+    },
+  };
+
+  await listeners.message({
+    source: {},
+    origin: window.location.origin,
+    data: payload,
+  });
+  await listeners.message({
+    source: window,
+    origin: 'http://attacker.invalid',
+    data: payload,
+  });
+
+  assert.equal(runtimeMessages.length, 0);
+  assert.equal(postedMessages.length, 0);
+  assert.equal(scheduledTasks.length, 0);
 });
 
 test('invalid playlist data never reaches background or navigation', async () => {
@@ -122,5 +156,26 @@ test('failed BEGIN_PLAYBACK_HANDOFF reports failure and does not navigate', asyn
     ok: false,
     reason: 'handoff_failed',
     requestId: 'handoff-failure',
+  });
+});
+
+test('blocked playlist storage reports a fixed failure without navigation', async () => {
+  resetObservations();
+  storageReadError = new Error('private storage detail');
+
+  await listeners.message(messageEvent({
+    type: 'PLAY_PLAYLIST_START',
+    requestId: 'blocked-storage',
+  }));
+
+  assert.equal(runtimeMessages.length, 0);
+  assert.equal(scheduledTasks.length, 0);
+  assert.equal(window.location.href, 'http://localhost:3000/clips');
+  assert.deepEqual(postedMessages.at(-1).message, {
+    type: 'EXTENSION_PLAYBACK_HANDOFF_RESULT',
+    source: 'PLAY_PLAYLIST_START',
+    ok: false,
+    reason: 'handoff_failed',
+    requestId: 'blocked-storage',
   });
 });

--- a/test/historyChange.test.mjs
+++ b/test/historyChange.test.mjs
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+function restoreGlobal(name, descriptor) {
+  if (descriptor) {
+    Object.defineProperty(globalThis, name, descriptor);
+  } else {
+    delete globalThis[name];
+  }
+}
+
+test('history hook patches once and reports push, replace, and popstate URLs', async () => {
+  const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+  const originalHistory = Object.getOwnPropertyDescriptor(globalThis, 'history');
+  const originalCustomEvent = Object.getOwnPropertyDescriptor(
+    globalThis,
+    'CustomEvent'
+  );
+  const listeners = new Map();
+  const events = [];
+  const location = { href: 'https://www.disneyplus.com/video/one' };
+
+  Object.defineProperty(globalThis, 'CustomEvent', {
+    configurable: true,
+    value: class CustomEvent {
+      constructor(type, options = {}) {
+        this.type = type;
+        this.detail = options.detail;
+      }
+    },
+  });
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      location,
+      addEventListener(type, listener) {
+        listeners.set(type, listener);
+      },
+      dispatchEvent(event) {
+        events.push(event);
+      },
+    },
+  });
+  Object.defineProperty(globalThis, 'history', {
+    configurable: true,
+    value: {
+      pushState(_state, _unused, url) {
+        location.href = new URL(url, location.href).href;
+        return 'push-result';
+      },
+      replaceState(_state, _unused, url) {
+        location.href = new URL(url, location.href).href;
+        return 'replace-result';
+      },
+    },
+  });
+
+  try {
+    await import(`../src/util/history_change.js?first=${Date.now()}`);
+    const patchedPushState = history.pushState;
+    const patchedReplaceState = history.replaceState;
+
+    assert.equal(history.pushState({}, '', '/video/two'), 'push-result');
+    assert.equal(history.replaceState({}, '', '/video/three'), 'replace-result');
+    listeners.get('popstate')();
+
+    assert.deepEqual(
+      events.map((event) => ({ type: event.type, detail: event.detail })),
+      [
+        {
+          type: 'historyChange',
+          detail: {
+            method: 'pushState',
+            url: '/video/two',
+          },
+        },
+        {
+          type: 'historyChange',
+          detail: {
+            method: 'replaceState',
+            url: '/video/three',
+          },
+        },
+        {
+          type: 'historyChange',
+          detail: {
+            method: 'popstate',
+            url: 'https://www.disneyplus.com/video/three',
+          },
+        },
+      ]
+    );
+
+    await import(`../src/util/history_change.js?second=${Date.now()}`);
+    assert.equal(history.pushState, patchedPushState);
+    assert.equal(history.replaceState, patchedReplaceState);
+  } finally {
+    restoreGlobal('window', originalWindow);
+    restoreGlobal('history', originalHistory);
+    restoreGlobal('CustomEvent', originalCustomEvent);
+  }
+});

--- a/test/manifest.test.mjs
+++ b/test/manifest.test.mjs
@@ -1,10 +1,13 @@
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import test from 'node:test';
 
+const require = createRequire(import.meta.url);
 const manifest = JSON.parse(
   await readFile(new URL('../manifest.json', import.meta.url), 'utf8')
 );
+const webpackConfig = require('../webpack.config.js');
 
 test('Disney+ installs the history hook in the page MAIN world before the content bundle', () => {
   const historyHook = manifest.content_scripts.find(
@@ -22,4 +25,56 @@ test('Disney+ installs the history hook in the page MAIN world before the conten
   );
   assert.ok(disneyBundle);
   assert.equal(disneyBundle.run_at, 'document_idle');
+});
+
+test('Netflix does not install a duplicate isolated-world history hook', () => {
+  const netflixBootstrap = manifest.content_scripts.find(
+    (entry) =>
+      entry.matches?.includes('https://www.netflix.com/*') &&
+      entry.js?.includes('src/inject/inject_script.js')
+  );
+
+  assert.ok(netflixBootstrap);
+  assert.equal(netflixBootstrap.run_at, 'document_end');
+  assert.deepEqual(netflixBootstrap.js, ['src/inject/inject_script.js']);
+});
+
+test('manifest references every webpack bundle and no unbundled localhost bridge source', () => {
+  const manifestBundles = new Set([
+    manifest.background?.service_worker,
+    ...manifest.content_scripts.flatMap((entry) => entry.js || []),
+  ].filter((path) => typeof path === 'string' && path.startsWith('dist/')));
+  const webpackBundles = new Set(
+    Object.keys(webpackConfig.entry).map((name) => `dist/${name}.js`)
+  );
+
+  assert.deepEqual(manifestBundles, webpackBundles);
+  assert.equal(
+    manifest.content_scripts.some((entry) =>
+      entry.js?.includes('src/content/getClipData.js')
+    ),
+    false
+  );
+});
+
+test('manifest permissions and exposed resources stay within the reviewed boundary', () => {
+  assert.deepEqual(
+    [...manifest.permissions].sort(),
+    ['activeTab', 'alarms', 'scripting', 'storage', 'tabs']
+  );
+  assert.deepEqual(
+    [...manifest.host_permissions].sort(),
+    [
+      'http://127.0.0.1:3000/*',
+      'http://localhost:3000/*',
+      'https://www.disneyplus.com/*',
+      'https://www.netflix.com/*',
+    ]
+  );
+  assert.deepEqual(manifest.web_accessible_resources, [
+    {
+      matches: ['https://www.netflix.com/*'],
+      resources: ['src/util/history_change.js'],
+    },
+  ]);
 });

--- a/test/playbackBridgeValidation.test.js
+++ b/test/playbackBridgeValidation.test.js
@@ -116,6 +116,7 @@ test('single clip input rejects unsupported services and cross-service URLs', ()
     'http://www.netflix.com/watch/1',
     'https://evil.example/watch/1',
     'https://user:pass@www.netflix.com/watch/1',
+    'https://www.netflix.com:443/watch/1',
   ]) {
     assert.equal(normalizeClipInput(clipInput({ url })).reason, 'invalid_url');
   }

--- a/test/playbackContext.test.js
+++ b/test/playbackContext.test.js
@@ -178,3 +178,19 @@ test('memory fallback wins over an older value left in sessionStorage', () => {
   storage.setItem = MemorySessionStorage.prototype.setItem;
   clearPlaybackContext();
 });
+
+test('the initialized module snapshot ignores later host-page storage tampering', () => {
+  const storage = globalThis.sessionStorage;
+  setPlaybackContext({ mode: 'clip', clipId: 20 });
+
+  storage.setItem('dextPlaybackContextV1', JSON.stringify({
+    initialized: true,
+    context: { mode: 'clip', clipId: 999 },
+  }));
+
+  assert.deepEqual(readPlaybackContext(), {
+    initialized: true,
+    context: { mode: 'clip', clipId: 20 },
+  });
+  clearPlaybackContext();
+});

--- a/test/playbackOwnership.test.js
+++ b/test/playbackOwnership.test.js
@@ -11,6 +11,7 @@ import {
 class MemoryStorageArea {
   constructor(initial = {}) {
     this.data = { ...initial };
+    this.nextSetFailure = null;
   }
 
   async get(keys) {
@@ -21,7 +22,22 @@ class MemoryStorageArea {
   }
 
   async set(items) {
+    const failure = this.nextSetFailure;
+    this.nextSetFailure = null;
+    if (failure && !failure.afterWrite) throw failure.error;
     Object.assign(this.data, items);
+    if (failure?.afterWrite) throw failure.error;
+  }
+
+  async remove(keys) {
+    for (const key of Array.isArray(keys) ? keys : [keys]) delete this.data[key];
+  }
+
+  failNextSet({ afterWrite = false } = {}) {
+    this.nextSetFailure = {
+      afterWrite,
+      error: new Error('injected storage failure'),
+    };
   }
 }
 
@@ -175,6 +191,58 @@ test('a nonce-less legacy claim rejects ambiguous opener handoffs', async () => 
     await harness.manager.claim({ tabId: 71, openerTabId: 70 }),
     { ok: false, reason: 'ambiguous_handoff' }
   );
+});
+
+test('an explicitly supplied malformed nonce never falls back to a legacy handoff', async () => {
+  const harness = createHarness();
+  await harness.manager.beginHandoff({
+    nonce: 'nonce-explicit-target',
+    sourceTabId: 75,
+    context: { mode: 'clip', clipId: 76 },
+    snapshot: clipSnapshot('nonce-explicit-target', 76),
+  });
+
+  assert.deepEqual(
+    await harness.manager.claim({
+      tabId: 76,
+      openerTabId: 75,
+      nonce: 'bad',
+    }),
+    { ok: false, reason: 'invalid_claim' }
+  );
+  const registry = harness.sessionStorage.data[PLAYBACK_REGISTRY_STORAGE_KEY];
+  assert.equal(registry.pending['nonce-explicit-target'].sourceTabId, 75);
+  assert.deepEqual(registry.active, {});
+});
+
+test('URL nonce lookup never reads or writes inherited registry properties', async () => {
+  const harness = createHarness();
+  const inheritedEntries = [
+    ['__proto__', Object.prototype],
+    ['constructor', Object],
+    ['toString', Object.prototype.toString],
+  ];
+  const previousTargets = inheritedEntries.map(([name, target]) => ({
+    name,
+    target,
+    value: target.targetTabId,
+  }));
+
+  for (const [nonce] of inheritedEntries) {
+    assert.deepEqual(
+      await harness.manager.handleTabNavigation({
+        tabId: 77,
+        url: `https://www.netflix.com/watch/77?dextPlaybackOwner=${nonce}`,
+      }),
+      { ok: true, released: false }
+    );
+  }
+
+  for (const { name, target, value } of previousTargets) {
+    assert.equal(target.targetTabId, value, `${name} was mutated`);
+  }
+  const registry = harness.sessionStorage.data[PLAYBACK_REGISTRY_STORAGE_KEY];
+  assert.deepEqual(registry.pending, {});
 });
 
 test('releasing one active tab restores the latest remaining snapshot', async () => {
@@ -332,6 +400,32 @@ test('claim rejects a stale owner when the document route no longer matches its 
     { ok: false, reason: 'route_mismatch', retryable: false }
   );
   assert.equal(harness.localStorage.data.playbackOwnerNonce, null);
+});
+
+test('prepare rejects a route that does not match the owned snapshot', async () => {
+  const harness = createHarness();
+  const nonce = 'nonce-prepare-route';
+  await beginAndClaim(harness, {
+    nonce,
+    sourceTabId: 93,
+    clipId: 931,
+  });
+
+  assert.deepEqual(
+    await harness.manager.prepareNavigation({
+      tabId: 93,
+      nonce,
+      nextUrl: 'https://www.netflix.com/watch/999',
+    }),
+    { ok: false, reason: 'route_mismatch' }
+  );
+  assert.deepEqual(
+    await harness.manager.handleTabNavigation({
+      tabId: 93,
+      url: 'https://www.netflix.com/watch/999',
+    }),
+    { ok: true, released: true, cleared: true }
+  );
 });
 
 test('rapid handoffs retain nonce-bound snapshots and can be claimed independently', async () => {
@@ -517,6 +611,77 @@ test('invalid ownership update leaves the active snapshot unchanged', async () =
   assert.deepEqual(result, { ok: false, reason: 'snapshot_mismatch' });
   assert.deepEqual(harness.localStorage.data, beforeLocal);
   assert.deepEqual(harness.sessionStorage.data, beforeRegistry);
+});
+
+test('storage failures roll back both sides of a handoff transaction', async () => {
+  for (const storageName of ['sessionStorage', 'localStorage']) {
+    for (const afterWrite of [false, true]) {
+      const harness = createHarness();
+      await beginAndClaim(harness, {
+        nonce: 'nonce-storage-existing',
+        sourceTabId: 72,
+        clipId: 721,
+      });
+      const beforeLocal = structuredClone(harness.localStorage.data);
+      const beforeSession = structuredClone(harness.sessionStorage.data);
+      harness[storageName].failNextSet({ afterWrite });
+
+      await assert.rejects(
+        harness.manager.beginHandoff({
+          nonce: 'nonce-storage-failing',
+          sourceTabId: 73,
+          context: { mode: 'clip', clipId: 731 },
+          snapshot: clipSnapshot('nonce-storage-failing', 731),
+        }),
+        /injected storage failure/
+      );
+
+      assert.deepEqual(
+        harness.localStorage.data,
+        beforeLocal,
+        `${storageName} afterWrite=${afterWrite} changed local storage`
+      );
+      assert.deepEqual(
+        harness.sessionStorage.data,
+        beforeSession,
+        `${storageName} afterWrite=${afterWrite} changed session storage`
+      );
+    }
+  }
+});
+
+test('storage failures roll back registry-only and release transitions', async () => {
+  const harness = createHarness();
+  await beginAndClaim(harness, {
+    nonce: 'nonce-storage-transition',
+    sourceTabId: 74,
+    clipId: 741,
+  });
+  const beforeLocal = structuredClone(harness.localStorage.data);
+  const beforeSession = structuredClone(harness.sessionStorage.data);
+
+  harness.sessionStorage.failNextSet({ afterWrite: true });
+  await assert.rejects(
+    harness.manager.prepareNavigation({
+      tabId: 74,
+      nonce: 'nonce-storage-transition',
+      nextUrl: 'https://www.netflix.com/watch/741?t=2',
+    }),
+    /injected storage failure/
+  );
+  assert.deepEqual(harness.localStorage.data, beforeLocal);
+  assert.deepEqual(harness.sessionStorage.data, beforeSession);
+
+  harness.localStorage.failNextSet({ afterWrite: true });
+  await assert.rejects(
+    harness.manager.release({
+      tabId: 74,
+      nonce: 'nonce-storage-transition',
+    }),
+    /injected storage failure/
+  );
+  assert.deepEqual(harness.localStorage.data, beforeLocal);
+  assert.deepEqual(harness.sessionStorage.data, beforeSession);
 });
 
 test('reset erases retained clip and playlist payloads', async () => {

--- a/test/playbackOwnershipClient.test.js
+++ b/test/playbackOwnershipClient.test.js
@@ -4,6 +4,8 @@ import test from 'node:test';
 import {
   PLAYBACK_OWNER_TAB_KEY,
   claimPlaybackOwnership,
+  createPlaybackOwnerNonce,
+  getTabPlaybackOwnerNonce,
 } from '../src/content/playbackOwnership.js';
 
 class MemorySessionStorage {
@@ -53,6 +55,68 @@ test('an explicit URL nonce never falls back to an opener handoff', async () => 
   assert.deepEqual(result, { ok: false, reason: 'handoff_not_found' });
   assert.equal(messages.length, 1);
   assert.equal(messages[0].nonce, 'url-nonce-1');
+});
+
+test('an empty URL nonce marker does not reuse tab-local or legacy ownership', async () => {
+  const { messages } = installGlobals({
+    href: 'https://www.netflix.com/watch/1?dextPlaybackOwner=',
+    storedNonce: 'stored-owner-nonce',
+    respond: (message) => message.nonce === null
+      ? {
+          ok: true,
+          nonce: 'unexpected-legacy-nonce',
+          context: { mode: 'clip', clipId: 1 },
+          snapshot: {},
+        }
+      : { ok: false, reason: 'invalid_claim' },
+  });
+
+  const nonce = getTabPlaybackOwnerNonce();
+  assert.equal(nonce, '');
+  assert.deepEqual(await claimPlaybackOwnership({ nonce }), {
+    ok: false,
+    reason: 'invalid_claim',
+  });
+  assert.deepEqual(messages.map((message) => message.nonce), ['']);
+});
+
+test('nonce generation uses secure random bytes when randomUUID is unavailable', () => {
+  const previousCrypto = Object.getOwnPropertyDescriptor(globalThis, 'crypto');
+  Object.defineProperty(globalThis, 'crypto', {
+    configurable: true,
+    value: {
+      getRandomValues(bytes) {
+        bytes.fill(0xab);
+        return bytes;
+      },
+    },
+  });
+
+  try {
+    assert.equal(
+      createPlaybackOwnerNonce(),
+      'abababab-abab-4bab-abab-abababababab'
+    );
+  } finally {
+    Object.defineProperty(globalThis, 'crypto', previousCrypto);
+  }
+});
+
+test('nonce generation fails closed without a secure random source', () => {
+  const previousCrypto = Object.getOwnPropertyDescriptor(globalThis, 'crypto');
+  Object.defineProperty(globalThis, 'crypto', {
+    configurable: true,
+    value: undefined,
+  });
+
+  try {
+    assert.throws(
+      () => createPlaybackOwnerNonce(),
+      /Secure random number generator/
+    );
+  } finally {
+    Object.defineProperty(globalThis, 'crypto', previousCrypto);
+  }
 });
 
 test('a stale tab-local nonce falls back to a late legacy handoff', async () => {


### PR DESCRIPTION
## 概要

PR #129 の詳細レビューで確認した、認証・同期・再生handoff・UIライフサイクルの問題をまとめて修正します。

## 主な変更

- 認証状態、instance ID、token refresh、コメントAPIの検証と競合処理を強化
- pending clip queueをbackgroundの単一writerへ集約し、同期中enqueueの消失を防止
- Netflix / Disney+ のownership、nonce、route、自動遷移をタブ単位で安全化
- 自動遷移マーカーをsessionStorageのone-shot構造へ変更し、別タブ混線を防止
- コメント・メモsidebarとNetflix player監視のteardownを補完
- backgroundの非同期イベント拒否を回収し、cleanup失敗を再試行
- malformed response、storage failure、複数タブ競合などの回帰テストを追加
- 契約資料とレビュー記録を更新

## 背景・原因

共有storageのread-modify-write、origin-wide marker、未検証のstorage/API payload、fire-and-forget Promiseが、複数タブ・再連携・SPA遷移・一時的なstorage障害で競合する状態でした。書き込み責務と検証境界をbackgroundへ寄せ、tab / owner nonce / routeを一緒に検証するよう整理しています。

## 検証

- `npm test`: 143 / 143 pass
- `npm run lint`: 37 files pass
- `npm run build`: 5 bundles build成功
- `git diff --check codex/fix-comment-feature-review...HEAD`: pass
- 自動遷移マーカーの対象テスト再実行: 5 / 5 pass

## 補足

- `react--site` 側の修正はこのPRに含めず、別PRへ分離します。
- Chrome実機smokeはsite側差分を統合した後、最終工程で実施します。
- ローカルの詳細計画書とsite用patchは未追跡のままで、このPRには含めていません。